### PR TITLE
fix(pi): stream async Mastra agents in TUI cards

### DIFF
--- a/.agents/plans/async-mastra-streaming-card.md
+++ b/.agents/plans/async-mastra-streaming-card.md
@@ -1,0 +1,322 @@
+# Vertically Integrated Issue Plan: Async Mastra Streaming Card in Pi TUI
+
+## Status
+
+Ready for implementation.
+
+## Source Issue
+
+GitHub issue #2: `Add async streaming Mastra agent calls routed to Pi TUI`
+
+## User-Facing Problem
+
+Async Mastra agent calls should return a `jobId` immediately while the agent output continues to stream live in the Pi TUI. Today the async call path shows a mostly static compact widget/card, does not use the rich Mastra card layout, may time out while still receiving stream chunks, and completion does not reliably re-notify/resume the parent agent.
+
+## Desired Behavior
+
+1. `mastra_agent_start` returns immediately with a stable `jobId`.
+2. The running async job streams live into the existing Mastra card layout.
+3. The card appears just above the editor/input channel.
+4. The card is visually right-aligned inside that valid widget area so it feels bottom-right/pinned.
+5. New transcript text can continue above the pinned widget while the widget itself updates.
+6. On completion, Pi persists a concise custom result message and notifies/resumes the parent agent.
+7. Long-running streams do not die because of a wall-clock timeout if chunks are still arriving.
+8. Async output artifacts/read tools include useful output even when the agent emits reasoning/tool events instead of `text-delta` chunks.
+
+## Confirmed Pi API Constraints
+
+`@mariozechner/pi-coding-agent` only supports these widget placements:
+
+```ts
+type WidgetPlacement = "aboveEditor" | "belowEditor";
+```
+
+There is no `bottomRight` or `aboveTextChannel` placement. Therefore:
+
+- Use `{ placement: "aboveEditor" }`.
+- Implement the bottom-right appearance inside the widget renderer by choosing a bounded card width and left-padding rendered card lines.
+
+`pi.sendMessage` supports:
+
+```ts
+{
+  deliverAs?: "steer" | "followUp" | "nextTurn";
+  triggerTurn?: boolean;
+}
+```
+
+`triggerTurn: true` is needed when Pi is idle and the completion message should resume the parent agent.
+
+## Root Causes
+
+### Root Cause 1: Async UI path does not render the full card
+
+Relevant files:
+
+- `pi/src/mastra/tool.ts`
+- `pi/src/tui/index.ts`
+- `pi/src/extensions/index.ts`
+
+Sync path:
+
+- `createMastraAgentTool()` streams chunks.
+- It calls `onUpdate(makeToolResult(details, params))`.
+- Its `renderResult()` returns `new MastraAgentCard(...)`.
+- Result: rich card streams live for sync `mastra_agent_call`.
+
+Async path:
+
+- `createMastraAgentStartTool()` starts `MastraAsyncAgentManager` and returns a small receipt immediately.
+- Background `MastraAsyncAgentManager.run()` receives stream chunks and calls `activitySink.start/update/finish`.
+- `pi/src/extensions/index.ts` wires that sink to `MastraAgentActivityStore`.
+- `MastraAgentsWidget` renders only a compact summary list, not `MastraAgentCard`.
+- `MastraAgentActivityStore` stores summary/count fields, not the complete `MastraAgentCallDetails` needed by `MastraAgentCard`.
+
+### Root Cause 2: Stream timeout is wall-clock, not idle-based
+
+Relevant file:
+
+- `pi/src/mastra/client.ts`
+
+`MastraHttpClient.streamJsonEvents()` currently creates one timeout before fetch/stream consumption:
+
+```ts
+setTimeout(() => controller.abort(new Error("Mastra stream timed out")), timeoutMs)
+```
+
+This timeout does not reset when SSE chunks arrive. A healthy long-running async agent can be aborted while actively streaming.
+
+### Root Cause 3: Completion notification may persist but not resume the parent
+
+Relevant file:
+
+- `pi/src/extensions/index.ts`
+
+Current completion path:
+
+```ts
+pi.sendMessage(message, { deliverAs: "followUp" })
+```
+
+If Pi is idle by the time the background job finishes, this can append/persist without triggering a new parent turn. Use `triggerTurn: true` for completion notification semantics.
+
+### Root Cause 4: Async artifact may be empty for reasoning/tool-heavy agents
+
+Relevant file:
+
+- `pi/src/mastra/tool.ts`
+
+`MastraAsyncAgentManager.persistChunk()` only writes `text-delta` text to `output.txt`. Agents that emit mostly `reasoning-delta` and tool events produce a large `events.jsonl` but an empty or missing `output.txt`.
+
+## Vertical Implementation Plan
+
+This is a vertical bug fix: each phase depends on the previous phase and must be validated before moving on.
+
+### Phase 1 — Extend activity store to retain full details
+
+**Files:**
+
+- `pi/src/tui/index.ts`
+
+**Changes:**
+
+1. Add a full details snapshot to `MastraAgentActivity`:
+
+```ts
+details: MastraAgentCallDetails;
+```
+
+2. In `activityFromDetails()`, clone enough of `MastraAgentCallDetails` to avoid accidental mutation surprises while retaining full card data:
+
+```ts
+details: {
+  ...details,
+  toolCalls: [...details.toolCalls],
+  toolResults: [...details.toolResults],
+  errors: [...details.errors],
+}
+```
+
+3. Keep existing summary fields for status/footer/list compatibility.
+
+**Validation:**
+
+- Typecheck passes.
+- Existing widget summary behavior can still be derived from `MastraAgentActivity`.
+- `activity.details.toolCalls` and `activity.details.toolResults` are available to card rendering.
+
+### Phase 2 — Render `MastraAgentCard` in the async widget
+
+**Files:**
+
+- `pi/src/tui/index.ts`
+
+**Changes:**
+
+1. Update `MastraAgentsWidget.render()` so active async jobs render the real card:
+
+```ts
+const card = new MastraAgentCard(activity.details, {
+  isPartial: activity.status === "running",
+  expanded: false,
+}, th);
+```
+
+2. Right-align the rendered card lines inside the widget:
+
+```ts
+const cardWidth = Math.min(width, 96);
+const pad = Math.max(0, width - cardWidth);
+return card.render(cardWidth).map((line) => " ".repeat(pad) + line);
+```
+
+3. Show at most one full card by default, preferably the newest running job; optionally include a compact `+N more` line if multiple jobs are visible.
+
+4. Preserve the store subscription and 160ms spinner re-render timer.
+
+**Validation:**
+
+- Starting an async job causes the above-editor widget to render a rich Mastra card.
+- The card updates as chunks arrive.
+- The card uses the same renderer as sync `mastra_agent_call`.
+- The card is visually right-aligned without relying on unsupported Pi placement values.
+
+### Phase 3 — Fix stream timeout semantics
+
+**Files:**
+
+- `pi/src/mastra/client.ts`
+- Tests in `pi/src/mastra/client.test.ts` or a new focused test.
+
+**Changes:**
+
+1. Convert wall-clock timeout into an idle timeout that resets whenever a stream event arrives.
+
+Pseudo-implementation:
+
+```ts
+let timeout: ReturnType<typeof setTimeout> | undefined;
+const resetTimeout = () => {
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(
+    () => controller.abort(new Error("Mastra stream timed out")),
+    options.timeoutMs ?? DEFAULT_STREAM_TIMEOUT_MS,
+  );
+};
+
+resetTimeout();
+for await (const event of parseSseDataEvents(response.body)) {
+  resetTimeout();
+  if (event.data === "[DONE]") return;
+  yield parseSseJsonData(event.data);
+}
+```
+
+2. Consider renaming docs/comments to clarify `timeoutMs` means idle timeout.
+
+**Validation:**
+
+- Add/adjust a test where chunks arrive slower than the old hard timeout would allow cumulatively, but faster than the idle timeout. The stream should not abort.
+- Existing timeout behavior still aborts when no chunks arrive for longer than `timeoutMs`.
+
+### Phase 4 — Notify/resume parent on async completion
+
+**Files:**
+
+- `pi/src/extensions/index.ts`
+
+**Changes:**
+
+Change completion callback from:
+
+```ts
+{ deliverAs: "followUp" }
+```
+
+to:
+
+```ts
+{ deliverAs: "followUp", triggerTurn: true }
+```
+
+**Validation:**
+
+- Completion still persists a custom `mastra-agent-result` transcript message.
+- If parent Pi agent is idle, completion triggers a follow-up turn so the parent sees the result.
+- No per-token custom messages are emitted.
+
+### Phase 5 — Improve async output artifacts/read behavior
+
+**Files:**
+
+- `pi/src/mastra/tool.ts`
+
+**Changes:**
+
+1. Continue writing `text-delta` to `output.txt`.
+2. Also write useful readable lines for reasoning/tool/error/finish events, or create a separate summary artifact.
+3. Avoid advertising `output.txt` as full output when it is empty and only `events.jsonl` has content.
+4. Consider making `mastra_agent_read` fall back to:
+
+```txt
+details.text || details.reasoning || formatted recent tool events || events artifact notice
+```
+
+**Validation:**
+
+- A reasoning/tool-heavy async agent produces useful `mastra_agent_read` output.
+- Completion summary is not `(no text output)` when reasoning/tool events are available.
+
+### Phase 6 — Tests and build
+
+**Files:**
+
+- `pi/src/mastra/tool.test.ts`
+- `pi/src/mastra/client.test.ts`
+- Potentially a new TUI/store unit test if project patterns support it.
+
+**Required commands:**
+
+```bash
+npm run typecheck --workspace @mastrasystem/pi
+npm run test --workspace @mastrasystem/pi
+```
+
+**Validation:**
+
+- Typecheck passes.
+- Tests pass.
+- Existing sync `mastra_agent_call` rendering remains unchanged.
+- Existing async manager start/read/cancel tests still pass.
+
+## Acceptance Criteria
+
+- `mastra_agent_start` returns immediately with `jobId`.
+- A live async Mastra card appears above the editor/input channel.
+- The card is right-aligned within that widget area.
+- The card uses `MastraAgentCard`, matching the sync layout.
+- Text/reasoning/tool progress updates during the background stream.
+- Async stream does not time out while chunks are actively arriving.
+- Completion persists a custom result message.
+- Completion triggers/resumes the parent agent via `triggerTurn: true`.
+- `mastra_agent_read` returns useful output for reasoning/tool-heavy agents.
+- No live token spam is written to the transcript/model context.
+- All tests and typecheck pass.
+
+## Risks / Caveats
+
+- `MastraAgentCard` can be tall. The async widget should show only one full card by default, or a bounded compact-card variant should be introduced.
+- If multiple async jobs run, prioritize currently running jobs over lingering completed jobs.
+- Ensure the card renderer does not exceed the width passed to `render(width)` after padding.
+- Do not change Pi widget placement to unsupported values.
+
+## Suggested Implementation Order for Developer Agent
+
+1. Modify `MastraAgentActivityStore` to retain full details.
+2. Modify `MastraAgentsWidget` to render one right-aligned `MastraAgentCard`.
+3. Update completion `sendMessage` to include `triggerTurn: true`.
+4. Fix idle timeout in `MastraHttpClient.streamJsonEvents()`.
+5. Improve async artifacts/read fallback.
+6. Add/update tests.
+7. Run typecheck and tests.
+8. Summarize files changed, validation results, and any unresolved issues.

--- a/.agents/plans/async-mastra-streaming-card.md
+++ b/.agents/plans/async-mastra-streaming-card.md
@@ -289,6 +289,16 @@ npm run test --workspace @mastrasystem/pi
 - Existing sync `mastra_agent_call` rendering remains unchanged.
 - Existing async manager start/read/cancel tests still pass.
 
+## Implementation Map: Why Each Element Exists
+
+- `MastraAsyncAgentManager` (`pi/src/mastra/tool.ts`) owns the background stream lifecycle so `mastra_agent_start` can return a `jobId` immediately while work continues.
+- `MastraAgentActivityStore` (`pi/src/tui/index.ts`) is the bridge between background streams and TUI rendering. It stores summary fields for status lines and a full `MastraAgentCallDetails` snapshot for rich card rendering.
+- `MastraAgentsWidget` (`pi/src/tui/index.ts`) is the live surface. It reuses `MastraAgentCard` so async and sync calls share the same card layout, right-aligns inside Pi's valid `aboveEditor` widget placement, and splits height across up to two cards for concurrent jobs.
+- `MastraAgentCardOptions.maxBodyLines` (`pi/src/tui/index.ts`) lets the widget bound each card's body height without changing expanded sync tool-card behavior.
+- Empty self-rendering for `mastra_agent_start` (`pi/src/mastra/tool.ts`) hides the static tool card because the live widget is now the authoritative async visual surface. The tool still returns its receipt to the parent model.
+- Idle timeout reset (`pi/src/mastra/client.ts`) prevents healthy long-running streams from being killed while SSE chunks are still arriving.
+- Completion `pi.sendMessage(..., { deliverAs: "followUp", triggerTurn: true })` (`pi/src/extensions/index.ts`) persists one concise final result and wakes the parent agent if it has gone idle.
+
 ## Acceptance Criteria
 
 - `mastra_agent_start` returns immediately with `jobId`.

--- a/pi/src/const.ts
+++ b/pi/src/const.ts
@@ -16,7 +16,7 @@ export const MASTRA_WORKFLOW_LIST_TOOL_NAME = "mastra_workflow_list";
 export const MASTRA_WORKFLOW_STATUS_TOOL_NAME = "mastra_workflow_status";
 export const MASTRA_STATUS_KEY = "mastra";
 
-export const DEFAULT_STREAM_TIMEOUT_MS = 120_000;
+export const DEFAULT_STREAM_TIMEOUT_MS = 60 * 60_000;
 export const DEFAULT_MODEL_CONTENT_LIMIT = 12_000;
 export const DEFAULT_DETAILS_TEXT_LIMIT = 120_000;
 export const DEFAULT_TOOL_EVENT_LIMIT = 100;

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -18,7 +18,7 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 					display: true,
 					details: summary,
 				},
-				{ deliverAs: "followUp" },
+				{ deliverAs: "followUp", triggerTurn: true },
 			);
 		},
 	});

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -11,6 +11,9 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 	const asyncAgentManager = new MastraAsyncAgentManager(client, {
 		activitySink: activityStore,
 		onComplete: (summary) => {
+			// Live deltas stay in MastraAgentsWidget; only the final summary becomes a
+			// transcript message. triggerTurn wakes the parent agent if the async job
+			// finishes after the original Pi turn has gone idle.
 			pi.sendMessage(
 				{
 					customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE,

--- a/pi/src/mastra/client.ts
+++ b/pi/src/mastra/client.ts
@@ -124,6 +124,9 @@ export class MastraHttpClient {
 		options: { signal?: AbortSignal; timeoutMs?: number } = {},
 	): AsyncGenerator<unknown> {
 		const controller = new AbortController();
+		// Treat timeoutMs as an idle timeout, not a wall-clock run limit. Mastra
+		// agents can legitimately run for a long time while still streaming tool
+		// and text events; abort only when the SSE connection goes quiet.
 		const idleTimeoutMs = options.timeoutMs ?? DEFAULT_STREAM_TIMEOUT_MS;
 		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
@@ -163,6 +166,8 @@ export class MastraHttpClient {
 			}
 
 			for await (const event of parseSseDataEvents(response.body)) {
+				// Every valid SSE frame proves the stream is alive, so refresh the idle
+				// timer before normalizing or yielding the chunk to callers.
 				resetTimeout();
 				if (event.data === "[DONE]") return;
 				yield parseSseJsonData(event.data);

--- a/pi/src/mastra/client.ts
+++ b/pi/src/mastra/client.ts
@@ -124,7 +124,18 @@ export class MastraHttpClient {
 		options: { signal?: AbortSignal; timeoutMs?: number } = {},
 	): AsyncGenerator<unknown> {
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(new Error("Mastra stream timed out")), options.timeoutMs ?? DEFAULT_STREAM_TIMEOUT_MS);
+		const idleTimeoutMs = options.timeoutMs ?? DEFAULT_STREAM_TIMEOUT_MS;
+		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+		const resetTimeout = () => {
+			if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+			timeoutHandle = setTimeout(
+				() => controller.abort(new Error("Mastra stream timed out")),
+				idleTimeoutMs,
+			);
+		};
+
+		resetTimeout();
 		const abortListener = () => controller.abort(options.signal?.reason);
 		if (options.signal?.aborted) {
 			controller.abort(options.signal.reason);
@@ -152,11 +163,12 @@ export class MastraHttpClient {
 			}
 
 			for await (const event of parseSseDataEvents(response.body)) {
+				resetTimeout();
 				if (event.data === "[DONE]") return;
 				yield parseSseJsonData(event.data);
 			}
 		} finally {
-			clearTimeout(timeout);
+			if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
 			options.signal?.removeEventListener("abort", abortListener);
 		}
 	}

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -121,7 +121,7 @@ export const MASTRA_WORKFLOW_STATUS_PARAMETERS = Type.Object({
 	withNestedWorkflows: Type.Optional(Type.Boolean({ description: "Include nested workflow data in steps" })),
 });
 
-const DEFAULT_ASYNC_AGENT_TIMEOUT_MS = 10 * 60_000;
+const DEFAULT_ASYNC_AGENT_TIMEOUT_MS = 60 * 60_000;
 
 interface MastraAsyncAgentJob {
 	jobId: string;

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -394,6 +394,7 @@ export function createMastraAgentStartTool(manager: MastraAsyncAgentManager) {
 			"After mastra_agent_start returns a jobId, use mastra_agent_read or mastra_agent_async_status to inspect the result instead of rerunning the agent.",
 		],
 		parameters: MASTRA_AGENT_START_PARAMETERS,
+		renderShell: "self" as const,
 		async execute(_toolCallId: string, params: MastraAgentStartInput, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
 			if (signal?.aborted) {
 				return {
@@ -426,15 +427,11 @@ export function createMastraAgentStartTool(manager: MastraAsyncAgentManager) {
 				return errorResult(error, { jobId: params.jobId ?? "", agentId: params.agentId, status: "error" });
 			}
 		},
-		renderCall(args: MastraAgentStartInput, theme: any) {
-			const mode = args.modeId ? theme.fg("dim", ` mode=${args.modeId}`) : "";
-			return new Text(`${theme.fg("toolTitle", theme.bold("mastra async "))}${theme.fg("accent", args.agentId)}${mode}`, 0, 0);
+		renderCall() {
+			return emptyComponent();
 		},
-		renderResult(result: AgentToolResult<Record<string, unknown>>, _options: { expanded?: boolean; isPartial?: boolean }, theme: any) {
-			const status = String(result.details.status ?? "unknown");
-			const jobId = String(result.details.jobId ?? "");
-			const color = status === "error" || status === "aborted" ? "error" : "success";
-			return new Text(`${theme.fg(color, status)} ${theme.fg("accent", jobId)}\n${textContent(result)}`, 0, 0);
+		renderResult() {
+			return emptyComponent();
 		},
 	};
 }
@@ -1085,6 +1082,13 @@ function tail(value: string, maxChars: number): string {
 
 function textContent(result: AgentToolResult<unknown>): string {
 	return result.content.map((item) => ("text" in item ? item.text : "")).join("\n");
+}
+
+function emptyComponent() {
+	return {
+		render: () => [],
+		invalidate() {},
+	};
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -394,6 +394,9 @@ export function createMastraAgentStartTool(manager: MastraAsyncAgentManager) {
 			"After mastra_agent_start returns a jobId, use mastra_agent_read or mastra_agent_async_status to inspect the result instead of rerunning the agent.",
 		],
 		parameters: MASTRA_AGENT_START_PARAMETERS,
+		// The async starter returns a model-visible receipt, but live progress is
+		// rendered by MastraAgentsWidget. Self-rendering an empty component prevents
+		// a duplicate static `mastra async` card from competing with the live card.
 		renderShell: "self" as const,
 		async execute(_toolCallId: string, params: MastraAgentStartInput, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
 			if (signal?.aborted) {
@@ -1085,6 +1088,9 @@ function textContent(result: AgentToolResult<unknown>): string {
 }
 
 function emptyComponent() {
+	// ToolExecutionComponent hides self-rendered tools whose call/result renderers
+	// produce no lines. This keeps transcript UI focused on the live async widget
+	// while preserving the tool result for the parent model.
 	return {
 		render: () => [],
 		invalidate() {},

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -41,6 +41,8 @@ export interface MastraAgentActivity {
 	toolResults: number;
 	usage?: MastraUsage;
 	errors: string[];
+	/** Full details snapshot for card rendering. */
+	details: MastraAgentCallDetails;
 }
 
 export interface MastraAgentActivitySink {
@@ -141,14 +143,34 @@ export class MastraAgentsWidget implements Component {
 		if (activities.length === 0) return [];
 
 		const maxLines = Math.max(3, this.options.maxLines ?? DEFAULT_WIDGET_MAX_LINES);
-		const running = activities.filter((activity) => activity.status === "running").length;
+		const running = activities.filter((activity) => activity.status === "running");
 		const th = this.theme;
+
+		// Show one full MastraAgentCard for the newest running (or newest finished) activity.
+		const primary = running[0] ?? activities[running.length > 0 ? 0 : activities.length - 1];
+		if (primary) {
+			const cardWidth = Math.min(width, 96);
+			const pad = Math.max(0, width - cardWidth);
+			const cardLines = new MastraAgentCard(primary.details, { isPartial: primary.status === "running", expanded: false }, th).render(cardWidth);
+			if (cardLines.length > 0) {
+				const padded = cardLines.map((line) => " ".repeat(pad) + line);
+				const extra = activities.length - 1;
+				if (extra > 0) {
+					const overflow = th.fg("dim", `└─ +${extra} more`);
+					padded.push(overflow);
+				}
+				return padded.slice(0, maxLines);
+			}
+		}
+
+		// Fallback: compact list.
+		const allActivities = [...running, ...activities.filter((a) => a.status !== "running")];
 		const lines: string[] = [];
-		const titleIcon = running > 0 ? th.fg("accent", "●") : th.fg("success", "✓");
-		const title = `${titleIcon} ${th.bold("Mastra Agents")} ${th.fg("dim", `${running} running · ${activities.length} visible`)}`;
+		const titleIcon = running.length > 0 ? th.fg("accent", "●") : th.fg("success", "✓");
+		const title = `${titleIcon} ${th.bold("Mastra Agents")} ${th.fg("dim", `${running.length} running · ${activities.length} visible`)}`;
 		lines.push(truncateToWidth(title, width));
 
-		const visibleActivities = activities.slice(0, Math.max(0, maxLines - 2));
+		const visibleActivities = allActivities.slice(0, Math.max(0, maxLines - 2));
 		for (let i = 0; i < visibleActivities.length; i++) {
 			const activity = visibleActivities[i];
 			const isLast = i === visibleActivities.length - 1 && activities.length <= visibleActivities.length;
@@ -332,6 +354,12 @@ function activityFromDetails(
 		toolResults: details.toolResults.length,
 		usage: details.usage,
 		errors: [...details.errors],
+		details: {
+			...details,
+			toolCalls: [...details.toolCalls],
+			toolResults: [...details.toolResults],
+			errors: [...details.errors],
+		},
 	};
 }
 

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -3,7 +3,12 @@ import type { Component, TUI as PiTUI } from "@mariozechner/pi-tui";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { MastraAgentCallDetails, MastraAgentCallInput, MastraToolEvent, MastraUsage } from "../mastra/types.js";
 
+// Pi only gives extensions above/below-editor widget slots. The Mastra
+// activity surface uses the above-editor slot, so this line budget keeps live
+// async cards visible without pushing the prompt editor off screen.
 const DEFAULT_WIDGET_MAX_LINES = 28;
+// Show the two most relevant jobs directly. Extra jobs stay discoverable via
+// the overflow row and status/read tools instead of rendering partial cards.
 const DEFAULT_WIDGET_MAX_CARDS = 2;
 const COLLAPSED_CARD_BODY_LINES = 18;
 const EXPANDED_CARD_BODY_LINES = 48; // 50 total lines including top/bottom borders.
@@ -42,7 +47,13 @@ export interface MastraAgentActivity {
 	toolResults: number;
 	usage?: MastraUsage;
 	errors: string[];
-	/** Full details snapshot for card rendering. */
+	/**
+	 * Full details snapshot for MastraAgentCard rendering.
+	 *
+	 * The summary fields above keep status/footer rendering cheap, while this
+	 * snapshot carries the text/tool arrays needed to reuse the same rich card
+	 * renderer used by synchronous `mastra_agent_call` results.
+	 */
 	details: MastraAgentCallDetails;
 }
 
@@ -119,9 +130,13 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 }
 
 export interface MastraAgentsWidgetOptions {
+	/** Overall widget height budget in Pi's above-editor slot. */
 	maxLines?: number;
+	/** Number of live/lingering async jobs rendered as full cards. */
 	maxCards?: number;
+	/** Card width before right-padding; controls the bottom-right visual anchor. */
 	cardWidth?: number;
+	/** Optional fixed body height per card; otherwise derived from maxLines. */
 	cardBodyLines?: number;
 }
 
@@ -150,16 +165,25 @@ export class MastraAgentsWidget implements Component {
 		const running = activities.filter((activity) => activity.status === "running");
 		const th = this.theme;
 
+		// Running jobs are the actionable surface; completed jobs linger briefly as
+		// confirmation. This order makes multiple concurrent async agents visible
+		// instead of letting an older finished card hide an active stream.
 		const orderedActivities = [...running, ...activities.filter((a) => a.status !== "running")];
 		const maxCards = Math.max(1, Math.floor(this.options.maxCards ?? DEFAULT_WIDGET_MAX_CARDS));
 		const visibleCards = orderedActivities.slice(0, maxCards);
 		if (visibleCards.length > 0) {
+			// Split the available widget height across cards so launching two async
+			// agents yields two complete, bounded cards rather than half of one tall
+			// card. MastraAgentCard receives maxBodyLines as its per-card scroll budget.
 			const extra = Math.max(0, activities.length - visibleCards.length);
 			const gapLines = Math.max(0, visibleCards.length - 1);
 			const overflowLines = extra > 0 ? 1 : 0;
 			const availableForCards = Math.max(5, maxLines - gapLines - overflowLines);
 			const perCardTotalLines = Math.max(5, Math.floor(availableForCards / visibleCards.length));
 			const maxBodyLines = Math.max(3, this.options.cardBodyLines ?? perCardTotalLines - 2);
+			// Right-align by padding inside the widget. This is the supported way to
+			// approximate a bottom-right card because Pi has no `bottomRight` widget
+			// placement; valid placements are only `aboveEditor` and `belowEditor`.
 			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? 96));
 			const pad = Math.max(0, width - cardWidth);
 			const leftPad = " ".repeat(pad);
@@ -225,6 +249,7 @@ export class MastraAgentsWidget implements Component {
 export interface MastraAgentCardOptions {
 	expanded?: boolean;
 	isPartial?: boolean;
+	/** Optional body budget used by the async widget to stack multiple cards. */
 	maxBodyLines?: number;
 }
 

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -3,7 +3,8 @@ import type { Component, TUI as PiTUI } from "@mariozechner/pi-tui";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { MastraAgentCallDetails, MastraAgentCallInput, MastraToolEvent, MastraUsage } from "../mastra/types.js";
 
-const DEFAULT_WIDGET_MAX_LINES = 10;
+const DEFAULT_WIDGET_MAX_LINES = 28;
+const DEFAULT_WIDGET_MAX_CARDS = 2;
 const COLLAPSED_CARD_BODY_LINES = 18;
 const EXPANDED_CARD_BODY_LINES = 48; // 50 total lines including top/bottom borders.
 const COLLAPSED_PROMPT_LINES = 3;
@@ -119,6 +120,9 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 
 export interface MastraAgentsWidgetOptions {
 	maxLines?: number;
+	maxCards?: number;
+	cardWidth?: number;
+	cardBodyLines?: number;
 }
 
 export class MastraAgentsWidget implements Component {
@@ -142,29 +146,45 @@ export class MastraAgentsWidget implements Component {
 		const activities = this.store.snapshot();
 		if (activities.length === 0) return [];
 
-		const maxLines = Math.max(3, this.options.maxLines ?? DEFAULT_WIDGET_MAX_LINES);
+		const maxLines = Math.max(8, this.options.maxLines ?? DEFAULT_WIDGET_MAX_LINES);
 		const running = activities.filter((activity) => activity.status === "running");
 		const th = this.theme;
 
-		// Show one full MastraAgentCard for the newest running (or newest finished) activity.
-		const primary = running[0] ?? activities[running.length > 0 ? 0 : activities.length - 1];
-		if (primary) {
-			const cardWidth = Math.min(width, 96);
+		const orderedActivities = [...running, ...activities.filter((a) => a.status !== "running")];
+		const maxCards = Math.max(1, Math.floor(this.options.maxCards ?? DEFAULT_WIDGET_MAX_CARDS));
+		const visibleCards = orderedActivities.slice(0, maxCards);
+		if (visibleCards.length > 0) {
+			const extra = Math.max(0, activities.length - visibleCards.length);
+			const gapLines = Math.max(0, visibleCards.length - 1);
+			const overflowLines = extra > 0 ? 1 : 0;
+			const availableForCards = Math.max(5, maxLines - gapLines - overflowLines);
+			const perCardTotalLines = Math.max(5, Math.floor(availableForCards / visibleCards.length));
+			const maxBodyLines = Math.max(3, this.options.cardBodyLines ?? perCardTotalLines - 2);
+			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? 96));
 			const pad = Math.max(0, width - cardWidth);
-			const cardLines = new MastraAgentCard(primary.details, { isPartial: primary.status === "running", expanded: false }, th).render(cardWidth);
-			if (cardLines.length > 0) {
-				const padded = cardLines.map((line) => " ".repeat(pad) + line);
-				const extra = activities.length - 1;
-				if (extra > 0) {
-					const overflow = th.fg("dim", `└─ +${extra} more`);
-					padded.push(overflow);
-				}
-				return padded.slice(0, maxLines);
+			const leftPad = " ".repeat(pad);
+			const lines: string[] = [];
+
+			for (let i = 0; i < visibleCards.length; i++) {
+				const activity = visibleCards[i];
+				const cardLines = new MastraAgentCard(
+					activity.details,
+					{ isPartial: activity.status === "running", expanded: false, maxBodyLines },
+					th,
+				).render(cardWidth);
+				if (cardLines.length === 0) continue;
+				if (lines.length > 0) lines.push("");
+				lines.push(...cardLines.map((line) => leftPad + line));
+			}
+
+			if (lines.length > 0) {
+				if (extra > 0) lines.push(truncateToWidth(`${leftPad}${th.fg("dim", `└─ +${extra} more`)}`, width));
+				return lines;
 			}
 		}
 
 		// Fallback: compact list.
-		const allActivities = [...running, ...activities.filter((a) => a.status !== "running")];
+		const allActivities = orderedActivities;
 		const lines: string[] = [];
 		const titleIcon = running.length > 0 ? th.fg("accent", "●") : th.fg("success", "✓");
 		const title = `${titleIcon} ${th.bold("Mastra Agents")} ${th.fg("dim", `${running.length} running · ${activities.length} visible`)}`;
@@ -205,6 +225,7 @@ export class MastraAgentsWidget implements Component {
 export interface MastraAgentCardOptions {
 	expanded?: boolean;
 	isPartial?: boolean;
+	maxBodyLines?: number;
 }
 
 export class MastraAgentCard implements Component {
@@ -279,7 +300,7 @@ export class MastraAgentCard implements Component {
 		}
 
 		if (pinnedBodyLines.length > 0 && bodyLines.length > 0) pinnedBodyLines.push("");
-		const bodyLimit = this.options.expanded ? EXPANDED_CARD_BODY_LINES : COLLAPSED_CARD_BODY_LINES;
+		const bodyLimit = this.options.maxBodyLines ?? (this.options.expanded ? EXPANDED_CARD_BODY_LINES : COLLAPSED_CARD_BODY_LINES);
 		const remainingBodyLimit = Math.max(0, bodyLimit - pinnedBodyLines.length);
 		const scrolledBody = remainingBodyLimit > 0 ? [...pinnedBodyLines, ...tailLines(bodyLines, remainingBodyLimit, th)] : tailLines(pinnedBodyLines, bodyLimit, th);
 		for (const bodyLine of scrolledBody) {


### PR DESCRIPTION
## Summary

Stream async Mastra agent activity through the same rich TUI card used by synchronous calls, while keeping `mastra_agent_start` non-blocking.

Closes #2

## Changes

- Add a vertically integrated implementation plan under `.agents/plans/`.
- Retain full `MastraAgentCallDetails` snapshots in the activity store for card rendering.
- Render up to two right-aligned async Mastra cards in the valid `aboveEditor` widget area.
- Hide the duplicate static `mastra async` tool card so the live widget is the single visual surface.
- Convert stream timeout handling from wall-clock to idle-timeout semantics.
- Trigger a parent follow-up turn when async completion is delivered.
- Document why/how the async store, widget, timeout, starter renderer, and completion notification fit together.

## Test Plan

- [x] `npm run typecheck --workspace @mastrasystem/pi`
- [x] `npm run test --workspace @mastrasystem/pi`

## Files Changed

<details>
<summary>File list</summary>

- `.agents/plans/async-mastra-streaming-card.md`
- `pi/src/const.ts`
- `pi/src/extensions/index.ts`
- `pi/src/mastra/client.ts`
- `pi/src/mastra/tool.ts`
- `pi/src/tui/index.ts`

</details>