### PR TITLE
fix(pi): isolate async Mastra job threads

### DIFF
--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -31,6 +31,41 @@ test("uses Mastra memory payload shape", () => {
 	assert.deepEqual(request.messages, [{ role: "user", content: "hello" }]);
 });
 
+test("async agent manager uses unique default threads for concurrent jobs", async () => {
+	const requests: any[] = [];
+	const manager = new MastraAsyncAgentManager({
+		async *streamAgent(_agentId: string, request: unknown) {
+			requests.push(request);
+			yield { type: "finish" };
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "first", jobId: "job-one", finalMessage: false });
+	await manager.start({ agentId: "agent", message: "second", jobId: "job-two", finalMessage: false });
+
+	await waitFor(() => requests.length === 2);
+	assert.notEqual(requests[0].memory.thread, requests[1].memory.thread);
+	assert.match(requests[0].memory.thread, /:job-one$/);
+	assert.match(requests[1].memory.thread, /:job-two$/);
+});
+
+test("async agent manager honors explicit thread ids", async () => {
+	const requests: any[] = [];
+	const manager = new MastraAsyncAgentManager({
+		async *streamAgent(_agentId: string, request: unknown) {
+			requests.push(request);
+			yield { type: "finish" };
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "first", jobId: "job-one", threadId: "shared-thread", finalMessage: false });
+	await manager.start({ agentId: "agent", message: "second", jobId: "job-two", threadId: "shared-thread", finalMessage: false });
+
+	await waitFor(() => requests.length === 2);
+	assert.equal(requests[0].memory.thread, "shared-thread");
+	assert.equal(requests[1].memory.thread, "shared-thread");
+});
+
 test("async agent manager starts immediately and captures streamed output", async () => {
 	let updates = 0;
 	let completed = false;

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -151,21 +151,31 @@ export class MastraAsyncAgentManager {
 		const jobId = normalizeJobId(params.jobId);
 		if (this.jobs.has(jobId)) throw new Error(`Async Mastra agent job already exists: ${jobId}`);
 
-		const details = createInitialDetails(params);
+		// Async jobs for the same agent can run concurrently. If they share the
+		// normal per-agent default thread, Mastra's thread-scoped memory and
+		// observability can serialize or merge their streams, making TUI cards look
+		// like only one job is live. Use the normalized job id to isolate default
+		// async runs while still honoring an explicit caller-provided threadId.
+		const effectiveParams: MastraAgentStartInput = {
+			...params,
+			jobId,
+			threadId: params.threadId ?? defaultAsyncThreadId(params.agentId, jobId),
+		};
+		const details = createInitialDetails(effectiveParams);
 		const artifactDir = await mkdtemp(join(tmpdir(), `${jobId}-`));
 		const job: MastraAsyncAgentJob = {
 			jobId,
-			params,
+			params: effectiveParams,
 			details,
 			controller: new AbortController(),
 			artifactPath: join(artifactDir, "output.txt"),
 			eventsPath: join(artifactDir, "events.jsonl"),
-			finalMessage: params.finalMessage !== false,
+			finalMessage: effectiveParams.finalMessage !== false,
 		};
 		this.jobs.set(jobId, job);
-		this.options.activitySink?.start(jobId, params, details);
+		this.options.activitySink?.start(jobId, effectiveParams, details);
 
-		const request = createStreamRequest(params, details.threadId, details.resourceId);
+		const request = createStreamRequest(effectiveParams, details.threadId, details.resourceId);
 		void this.run(job, request);
 		return this.summary(job);
 	}
@@ -1051,6 +1061,10 @@ function normalizeJobId(value?: string): string {
 	const trimmed = value?.trim();
 	if (trimmed) return trimmed.replace(/[^a-zA-Z0-9._-]/g, "-");
 	return `mastra-agent-${Date.now()}-${randomUUID().slice(0, 8)}`;
+}
+
+function defaultAsyncThreadId(agentId: string, jobId: string): string {
+	return `${defaultThreadId(agentId)}:${jobId}`;
 }
 
 function clampMaxChars(value?: number): number {


### PR DESCRIPTION
## Summary

Isolate default async Mastra agent runs onto per-job thread IDs so concurrent starts for the same agent do not share one Mastra memory/observability thread.

## Context

When two async agents are launched with the same `agentId` and no explicit `threadId`, both previously used `defaultThreadId(agentId)`. That can merge or serialize thread-scoped Mastra stream state and make two TUI cards appear to update one-at-a-time or pop in/out.

## Changes

- Derive a unique default async thread from the normalized `jobId`.
- Continue honoring caller-provided `threadId` exactly.
- Leave synchronous `mastra_agent_call` default thread behavior unchanged.
- Add tests for unique default async threads and explicit thread preservation.

## Test Plan

- [x] `npm run typecheck --workspace @mastrasystem/pi`
- [x] `npm run test --workspace @mastrasystem/pi`