### PR TITLE
feat(tool): add input_args support to agent_call and agent_start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@a2a-js/sdk/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
@@ -1781,6 +1794,37 @@
         "zod": "^3.25 || ^4"
       }
     },
+    "node_modules/@composio/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@composio/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@composio/json-schema-to-zod": {
       "version": "0.1.20",
       "resolved": "https://registry.npmjs.org/@composio/json-schema-to-zod/-/json-schema-to-zod-0.1.20.tgz",
@@ -2496,28 +2540,6 @@
         }
       }
     },
-    "node_modules/@google/genai/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@google/genai/node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
@@ -2935,39 +2957,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@mariozechner/pi-ai/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mariozechner/pi-coding-agent": {
       "version": "0.70.6",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.6.tgz",
@@ -3006,100 +2995,6 @@
         "@mariozechner/clipboard": "^0.3.3"
       }
     },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/@mariozechner/pi-tui": {
       "version": "0.70.6",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.6.tgz",
@@ -3117,43 +3012,6 @@
       },
       "optionalDependencies": {
         "koffi": "^2.9.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@mastra/core": {
@@ -3200,6 +3058,21 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@mastra/core/node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@mastra/daytona": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@mastra/daytona/-/daytona-0.3.0.tgz",
@@ -3216,9 +3089,9 @@
       }
     },
     "node_modules/@mastra/deployer": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@mastra/deployer/-/deployer-1.28.0.tgz",
-      "integrity": "sha512-j9PoQ1qyDrbT0FEQA3ZH/13En5vqjfGq5NtOtIEM3F1KOnIdgMKOxm3nOd5rz19eQePvpIXxqXIs9Ar75wu9JQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@mastra/deployer/-/deployer-1.29.0.tgz",
+      "integrity": "sha512-6pgzkJbzg/4h7Igz1AFIMMBuG9LegbUbgeSCEBf+qXBIphtYKwENtkCjrjk/1+Y1CEZi9w++VYK+XnfwUPD0kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3226,7 +3099,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@babel/traverse": "^7.29.0",
         "@hono/node-ws": "^1.3.0",
-        "@mastra/server": "1.28.0",
+        "@mastra/server": "1.29.0",
         "@optimize-lodash/rollup-plugin": "^5.1.0",
         "@rollup/plugin-alias": "6.0.0",
         "@rollup/plugin-commonjs": "29.0.2",
@@ -3406,9 +3279,9 @@
       }
     },
     "node_modules/@mastra/server": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@mastra/server/-/server-1.28.0.tgz",
-      "integrity": "sha512-RP5dWET+WyhXr67t8eK0/XChXvrGYzkVW65dOuqTs28gwR53GTIQR+h76N4cUFZ0dsxbcCKZbINwTuF7mIa/SQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@mastra/server/-/server-1.29.0.tgz",
+      "integrity": "sha512-7MP/MxIIuWbPuL4zjg2t46cw8/g8RHgZS9vKb9FIriDL4hXu+p3RlZVh6xw9PHnL1zFnZC0WQTcHln9AIFkIcg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3599,31 +3472,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
@@ -6165,6 +6013,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6296,15 +6165,13 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -6375,6 +6242,45 @@
         "node": ">= 14"
       }
     },
+    "node_modules/archiver-utils/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/archiver-utils/node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -6386,6 +6292,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/arg": {
@@ -6491,11 +6437,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
@@ -6698,27 +6646,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boxen/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6887,16 +6824,12 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -6916,6 +6849,39 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -6999,6 +6965,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/cli-highlight/node_modules/cliui": {
@@ -7217,6 +7214,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
@@ -8198,6 +8210,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -8631,6 +8664,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -8868,22 +8922,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10695,24 +10744,28 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -10726,16 +10779,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11044,9 +11096,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
-      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -11101,18 +11153,16 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
-      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
       "dependencies": {
-        "is-network-error": "^1.1.0"
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -11254,28 +11304,20 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
@@ -11645,6 +11687,15 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/proper-lockfile/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -11919,6 +11970,23 @@
         "minimatch": "^5.1.0"
       }
     },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -12105,9 +12173,9 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -12402,6 +12470,13 @@
         "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
       }
+    },
+    "node_modules/serve-handler/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -13239,31 +13314,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typebox": {
       "version": "1.1.34",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.34.tgz",
@@ -13508,16 +13558,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -13644,6 +13694,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -13677,19 +13743,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -20,7 +20,7 @@ test("input_args preserves literal placeholders in message and appends Input arg
 	// Literal placeholders preserved in message body; Input arguments section appended with instruction
 	assert.equal(
 		request.messages[0].content,
-		"Hello $1, you selected $2\n\nInput arguments:\n- $1: Alice\n- $2: Option A\n\nUse the above arguments when referencing placeholders like $1, $2 in your response.",
+		"Hello $1, you selected $2\n\nInput arguments:\n  $1: Alice\n  $2: Option A",
 	);
 });
 
@@ -33,7 +33,7 @@ test("input_args preserves placeholders and sorts keys numerically ($1, $2, $10)
 	// Literal placeholders preserved; Input arguments section sorted numerically ($1, $2, $10 not $1, $10, $2)
 	assert.equal(
 		request.messages[0].content,
-		"Process $2 and $1 and $10\n\nInput arguments:\n- $1: first\n- $2: second\n- $10: tenth\n\nUse the above arguments when referencing placeholders like $1, $2, $10 in your response.",
+		"Process $2 and $1 and $10\n\nInput arguments:\n  $1: first\n  $2: second\n  $10: tenth",
 	);
 });
 

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -17,10 +17,10 @@ test("input_args preserves literal placeholders in message and appends Input arg
 		"thread",
 		"resource",
 	);
-	// Literal placeholders preserved in message body; Input arguments section appended with instruction
+	// Literal placeholders preserved in message body; Input arguments section appended with bullet list and instruction
 	assert.equal(
 		request.messages[0].content,
-		"Hello $1, you selected $2\n\nInput arguments:\n  $1: Alice\n  $2: Option A",
+		"Hello $1, you selected $2\n\nInput arguments:\n- $1: Alice\n- $2: Option A\n\nWhen the prompt references placeholders like $1, $2, etc., use the corresponding input argument above.",
 	);
 });
 
@@ -30,10 +30,10 @@ test("input_args preserves placeholders and sorts keys numerically ($1, $2, $10)
 		"thread",
 		"resource",
 	);
-	// Literal placeholders preserved; Input arguments section sorted numerically ($1, $2, $10 not $1, $10, $2)
+	// Literal placeholders preserved; Input arguments section sorted numerically ($1, $2, $10 not $1, $10, $2) with bullet list and instruction
 	assert.equal(
 		request.messages[0].content,
-		"Process $2 and $1 and $10\n\nInput arguments:\n  $1: first\n  $2: second\n  $10: tenth",
+		"Process $2 and $1 and $10\n\nInput arguments:\n- $1: first\n- $2: second\n- $10: tenth\n\nWhen the prompt references placeholders like $1, $2, etc., use the corresponding input argument above.",
 	);
 });
 

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -11,6 +11,131 @@ test("omitted modeId leaves requestContext unchanged", () => {
 	assert.deepEqual(request.requestContext, { tenant: "a" });
 });
 
+test("input_args preserves literal placeholders in message and appends Input arguments section", () => {
+	const request = createStreamRequest(
+		{ agentId: "agent", message: "Hello $1, you selected $2", input_args: { $1: "Alice", $2: "Option A" } },
+		"thread",
+		"resource",
+	);
+	// Literal placeholders preserved in message body; Input arguments section appended with instruction
+	assert.equal(
+		request.messages[0].content,
+		"Hello $1, you selected $2\n\nInput arguments:\n- $1: Alice\n- $2: Option A\n\nUse the above arguments when referencing placeholders like $1, $2 in your response.",
+	);
+});
+
+test("input_args preserves placeholders and sorts keys numerically ($1, $2, $10)", () => {
+	const request = createStreamRequest(
+		{ agentId: "agent", message: "Process $2 and $1 and $10", input_args: { $1: "first", $2: "second", $10: "tenth" } },
+		"thread",
+		"resource",
+	);
+	// Literal placeholders preserved; Input arguments section sorted numerically ($1, $2, $10 not $1, $10, $2)
+	assert.equal(
+		request.messages[0].content,
+		"Process $2 and $1 and $10\n\nInput arguments:\n- $1: first\n- $2: second\n- $10: tenth\n\nUse the above arguments when referencing placeholders like $1, $2, $10 in your response.",
+	);
+});
+
+test("input_args mirrors into requestContext.input_args", () => {
+	const request = createStreamRequest(
+		{ agentId: "agent", message: "Hello $1", input_args: { $1: "World" } },
+		"thread",
+		"resource",
+	);
+	assert.deepEqual(request.requestContext, { input_args: { $1: "World" } });
+});
+
+test("input_args appears as top-level field in returned request", () => {
+	const request = createStreamRequest(
+		{ agentId: "agent", message: "Hello $1", input_args: { $1: "World" } },
+		"thread",
+		"resource",
+	);
+	assert.deepEqual(request.input_args, { $1: "World" });
+});
+
+test("input_args omitted returns no input_args in request", () => {
+	const request = createStreamRequest(
+		{ agentId: "agent", message: "Hello World" },
+		"thread",
+		"resource",
+	);
+	assert.equal(request.input_args, undefined);
+	assert.equal(request.requestContext?.input_args, undefined);
+});
+
+test("top-level input_args overrides existing requestContext.input_args", () => {
+	const request = createStreamRequest(
+		{
+			agentId: "agent",
+			message: "Hello $1",
+			input_args: { $1: "New" },
+			requestContext: { input_args: { $1: "Old" }, tenant: "acme" },
+		},
+		"thread",
+		"resource",
+	);
+	assert.deepEqual(request.requestContext, { input_args: { $1: "New" }, tenant: "acme" });
+});
+
+test("input_args preserves other requestContext fields", () => {
+	const request = createStreamRequest(
+		{
+			agentId: "agent",
+			message: "Hello $1",
+			input_args: { $1: "World" },
+			requestContext: { modeId: "test", tenant: "acme" },
+		},
+		"thread",
+		"resource",
+	);
+	assert.deepEqual(request.requestContext, { input_args: { $1: "World" }, modeId: "test", tenant: "acme" });
+});
+
+test("input_args with empty input_args object does not append section", () => {
+	const request = createStreamRequest(
+		{ agentId: "agent", message: "Hello World", input_args: {} },
+		"thread",
+		"resource",
+	);
+	assert.equal(request.messages[0].content, "Hello World");
+	assert.equal(request.requestContext?.input_args, undefined);
+});
+
+test("input_args validates placeholder keys match pattern ^\\$[1-9][0-9]*$", () => {
+	// Empty key
+	assert.throws(
+		() =>
+			createStreamRequest(
+				{ agentId: "agent", message: "Hello", input_args: { "": "value" } as any },
+				"thread",
+				"resource",
+			),
+		/input_args placeholder key must match pattern/,
+	);
+	// Invalid key $0 (zero not allowed)
+	assert.throws(
+		() =>
+			createStreamRequest(
+				{ agentId: "agent", message: "Hello", input_args: { $0: "value" } as any },
+				"thread",
+				"resource",
+			),
+		/input_args placeholder key must match pattern/,
+	);
+	// Non-numeric key $abc
+	assert.throws(
+		() =>
+			createStreamRequest(
+				{ agentId: "agent", message: "Hello", input_args: { $abc: "value" } as any },
+				"thread",
+				"resource",
+			),
+		/input_args placeholder key must match pattern/,
+	);
+});
+
 test("modeId is forwarded to requestContext.modeId", () => {
 	const request = createStreamRequest({ agentId: "agent", message: "hello", modeId: "plan" }, "thread", "resource");
 	assert.deepEqual(request.requestContext, { modeId: "plan" });

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -793,18 +793,18 @@ export function createStreamRequest(params: MastraAgentCallInput, threadId: stri
 			return numA - numB;
 		});
 
-		// Build the "Input arguments:" section with numeric ordering
+		// Build the "Input arguments:" section with numeric ordering and bullet list format
 		const argsLines: string[] = [];
 		for (const key of sortedKeys) {
 			const value = params.input_args[key];
 			if (value !== undefined) {
-				argsLines.push(`  ${key}: ${value}`);
+				argsLines.push(`- ${key}: ${value}`);
 			}
 		}
 
 		// Append input_args section only when args are provided; preserve literal placeholders in original message
 		if (argsLines.length > 0) {
-			const inputArgsSection = `Input arguments:\n${argsLines.join("\n")}`;
+			const inputArgsSection = `Input arguments:\n${argsLines.join("\n")}\n\nWhen the prompt references placeholders like $1, $2, etc., use the corresponding input argument above.`;
 			requestContext.input_args = params.input_args;
 
 			return {

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -60,6 +60,7 @@ export const MASTRA_AGENT_CALL_PARAMETERS = Type.Object({
 	includeToolResults: Type.Optional(Type.Boolean({ description: "Include tool result summaries in model-facing text" })),
 	includeReasoning: Type.Optional(Type.Boolean({ description: "Include reasoning deltas in model-facing text" })),
 	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
+	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs for prompt placeholder substitution. Keys like $1, $2 are replaced in the message. Numeric keys are sorted for deterministic ordering." })),
 });
 
 export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
@@ -74,6 +75,7 @@ export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
 	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
 	jobId: Type.Optional(Type.String({ description: "Optional caller-provided async job id" })),
 	finalMessage: Type.Optional(Type.Boolean({ description: "Post a custom final transcript message when the async run completes. Defaults to true." })),
+	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs for prompt placeholder substitution. Keys like $1, $2 are replaced in the message. Numeric keys are sorted for deterministic ordering." })),
 });
 
 export const MASTRA_AGENT_ASYNC_STATUS_PARAMETERS = Type.Object({
@@ -773,12 +775,53 @@ export function createStreamRequest(params: MastraAgentCallInput, threadId: stri
 	const requestContext = { ...(params.requestContext ?? {}) };
 	if (params.modeId) requestContext[REQUEST_CONTEXT_MODE_ID_KEY] = params.modeId;
 
+	const message = params.message;
+
+	// Handle input_args: validate keys, sort numerically, append section, mirror to context
+	if (params.input_args && Object.keys(params.input_args).length > 0) {
+		// Validate that all keys match the placeholder pattern ^\$[1-9][0-9]*$
+		for (const key of Object.keys(params.input_args)) {
+			if (typeof key !== "string" || !/^\$[1-9][0-9]*$/.test(key)) {
+				throw new Error(`input_args placeholder key must match pattern ^\\$[1-9][0-9]*$, got: ${JSON.stringify(key)}`);
+			}
+		}
+
+		// Sort keys numerically by extracting the number after the $ prefix
+		const sortedKeys = Object.keys(params.input_args).sort((a, b) => {
+			const numA = parseInt(a.slice(1), 10);
+			const numB = parseInt(b.slice(1), 10);
+			return numA - numB;
+		});
+
+		// Build the "Input arguments:" section with numeric ordering
+		const argsLines: string[] = [];
+		for (const key of sortedKeys) {
+			const value = params.input_args[key];
+			if (value !== undefined) {
+				argsLines.push(`- ${key}: ${value}`);
+			}
+		}
+
+		// Preserve literal placeholders in message body; append input_args section with instruction
+		if (argsLines.length > 0) {
+			const inputArgsSection = `Input arguments:\n${argsLines.join("\n")}\n\nUse the above arguments when referencing placeholders like ${sortedKeys.join(", ")} in your response.`;
+			requestContext.input_args = params.input_args;
+
+			return {
+				messages: [{ role: "user", content: `${message}\n\n${inputArgsSection}` }],
+				memory: { thread: threadId, resource: resourceId },
+				maxSteps: params.maxSteps,
+				activeTools: params.activeTools,
+				requestContext: Object.keys(requestContext).length > 0 ? requestContext : undefined,
+				input_args: params.input_args,
+			};
+		}
+	}
+
+	// No input_args: return standard request
 	return {
-		messages: [{ role: "user", content: params.message }],
-		memory: {
-			thread: threadId,
-			resource: resourceId,
-		},
+		messages: [{ role: "user", content: message }],
+		memory: { thread: threadId, resource: resourceId },
 		maxSteps: params.maxSteps,
 		activeTools: params.activeTools,
 		requestContext: Object.keys(requestContext).length > 0 ? requestContext : undefined,

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -798,13 +798,13 @@ export function createStreamRequest(params: MastraAgentCallInput, threadId: stri
 		for (const key of sortedKeys) {
 			const value = params.input_args[key];
 			if (value !== undefined) {
-				argsLines.push(`- ${key}: ${value}`);
+				argsLines.push(`  ${key}: ${value}`);
 			}
 		}
 
-		// Preserve literal placeholders in message body; append input_args section with instruction
+		// Append input_args section only when args are provided; preserve literal placeholders in original message
 		if (argsLines.length > 0) {
-			const inputArgsSection = `Input arguments:\n${argsLines.join("\n")}\n\nUse the above arguments when referencing placeholders like ${sortedKeys.join(", ")} in your response.`;
+			const inputArgsSection = `Input arguments:\n${argsLines.join("\n")}`;
 			requestContext.input_args = params.input_args;
 
 			return {
@@ -816,9 +816,11 @@ export function createStreamRequest(params: MastraAgentCallInput, threadId: stri
 				input_args: params.input_args,
 			};
 		}
+
+		// Mirror input_args into requestContext even when argsLines is empty
+		requestContext.input_args = params.input_args;
 	}
 
-	// No input_args: return standard request
 	return {
 		messages: [{ role: "user", content: message }],
 		memory: { thread: threadId, resource: resourceId },

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -60,7 +60,7 @@ export const MASTRA_AGENT_CALL_PARAMETERS = Type.Object({
 	includeToolResults: Type.Optional(Type.Boolean({ description: "Include tool result summaries in model-facing text" })),
 	includeReasoning: Type.Optional(Type.Boolean({ description: "Include reasoning deltas in model-facing text" })),
 	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
-	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs for prompt placeholder substitution. Keys like $1, $2 are replaced in the message. Numeric keys are sorted for deterministic ordering." })),
+	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
 });
 
 export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
@@ -75,7 +75,7 @@ export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
 	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
 	jobId: Type.Optional(Type.String({ description: "Optional caller-provided async job id" })),
 	finalMessage: Type.Optional(Type.Boolean({ description: "Post a custom final transcript message when the async run completes. Defaults to true." })),
-	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs for prompt placeholder substitution. Keys like $1, $2 are replaced in the message. Numeric keys are sorted for deterministic ordering." })),
+	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
 });
 
 export const MASTRA_AGENT_ASYNC_STATUS_PARAMETERS = Type.Object({

--- a/pi/src/mastra/types.ts
+++ b/pi/src/mastra/types.ts
@@ -19,7 +19,11 @@ export interface MastraAgentCallInput {
 	includeToolResults?: boolean;
 	includeReasoning?: boolean;
 	timeoutMs?: number;
+	input_args?: MastraAgentInputArgs;
 }
+
+/** Key-value pairs for prompt placeholder substitution. Keys must match ^\$[1-9][0-9]*$ */
+export type MastraAgentInputArgs = Record<string, string>;
 
 export interface MastraAgentStatusInput {
 	agentId: string;
@@ -75,6 +79,7 @@ export interface MastraStreamRequest {
 	maxSteps?: number;
 	activeTools?: string[];
 	requestContext?: Record<string, unknown>;
+	input_args?: MastraAgentInputArgs;
 }
 
 export interface MastraWorkflowStepInfo {


### PR DESCRIPTION
## Summary
Implements optional `input_args` parameter for `agent_call` and `agent_start` tool actions.

## Changes
- **Types**: Added `input_args` field to `MastraAgentCallInput` and `MastraAgentStartInput` (schema lines 63, 78)
- **Formatter logic** (tool.ts:780-818):
  - Validates keys match `^$[1-9][0-9]*$` pattern
  - Sorts keys numerically for deterministic ordering
  - Preserves literal placeholders in message body
  - Appends `Input arguments:` section with instruction
  - Mirrors `input_args` into `requestContext.input_args`
- **Tests**: 10 new/updated test cases covering validation, ordering, context mirroring, and edge cases

## Acceptance Criteria Met
- ✅ Optional `input_args` on `agent_call` and `agent_start`
- ✅ Formatter appends `Input arguments:` section (lines 806-807)
- ✅ Mirrors into `requestContext.input_args` (line 808)
- ✅ Numeric key sorting for deterministic substitution order
- ✅ Preserves literal placeholders in message body

Closes #7