### PR TITLE
feat(pi): add async-by-default agent_query

### DIFF
--- a/pi/src/const.ts
+++ b/pi/src/const.ts
@@ -11,6 +11,7 @@ export const MASTRA_AGENT_RESULT_MESSAGE_TYPE = "mastra-agent-result";
 export const MASTRA_AGENT_INSPECT_TOOL_NAME = "agent_inspect";
 export const MASTRA_AGENT_LIST_TOOL_NAME = "agent_list";
 export const MASTRA_AGENT_STATUS_TOOL_NAME = "agent_status";
+export const MASTRA_AGENT_QUERY_TOOL_NAME = "agent_query";
 export const MASTRA_WORKFLOW_CALL_TOOL_NAME = "workflow_call";
 export const MASTRA_WORKFLOW_LIST_TOOL_NAME = "workflow_list";
 export const MASTRA_WORKFLOW_STATUS_TOOL_NAME = "workflow_status";

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { MastraAsyncAgentManager, createMastraAgentInspectTool, createStreamRequest, createWorkflowStreamRequest, normalizeInspectAgentIds } from "./tool.js";
+import {
+	MastraAsyncAgentManager,
+	createMastraAgentInspectTool,
+	createMastraAgentQueryTool,
+	createMastraTools,
+	createStreamRequest,
+	createWorkflowStreamRequest,
+	normalizeInspectAgentIds,
+	MASTRA_AGENT_QUERY_PARAMETERS,
+} from "./tool.js";
 
 test("omitted modeId leaves requestContext unchanged", () => {
 	const request = createStreamRequest(
@@ -174,6 +183,131 @@ test("async agent manager uses unique default threads for concurrent jobs", asyn
 	assert.match(requests[1].memory.thread, /:job-two$/);
 });
 
+
+test("createMastraTools registers agent_query and preserves workflow tools", () => {
+	const manager = { start: async () => fakeAsyncSummary() } as any;
+	const tools = createMastraTools({} as any, { asyncAgentManager: manager });
+	const names = tools.map((tool) => tool.name);
+	assert.equal(names[0], "agent_query");
+	assert.equal((tools[0] as any).renderShell, "self");
+	assert.ok(names.includes("agent_call"));
+	assert.ok(names.includes("agent_start"));
+	assert.ok(names.includes("workflow_call"));
+	assert.ok(names.includes("workflow_list"));
+	assert.ok(names.includes("workflow_status"));
+});
+
+test("agent_query schema is narrower than lower-level agent tools", () => {
+	const properties = (MASTRA_AGENT_QUERY_PARAMETERS as any).properties;
+	for (const key of ["agentId", "message", "synchronous", "threadId", "resourceId", "requestContext", "includeToolResults", "includeReasoning", "timeoutMs", "input_args"]) {
+		assert.ok(key in properties, `${key} should be exposed`);
+	}
+	assert.equal("maxSteps" in properties, false);
+	assert.equal("activeTools" in properties, false);
+	assert.equal("modeId" in properties, false);
+	assert.equal("jobId" in properties, false);
+	assert.equal("finalMessage" in properties, false);
+});
+
+test("agent_query defaults to async and returns a job handle", async () => {
+	const starts: any[] = [];
+	const tool = createMastraAgentQueryTool({
+		start: async (params: any) => {
+			starts.push(params);
+			return fakeAsyncSummary({ jobId: "query-job", agentId: params.agentId, threadId: "thread", resourceId: "resource" });
+		},
+	} as any, {} as any);
+
+	const result = await tool.execute("call", { agentId: "agent", message: "hello" });
+	assert.equal(starts.length, 1);
+	assert.equal(starts[0].includeReasoning, false);
+	assert.equal("maxSteps" in starts[0], false);
+	assert.equal("activeTools" in starts[0], false);
+	assert.equal((result.details as any).jobId, "query-job");
+	assert.match("text" in result.content[0] ? result.content[0].text : "", /Started async Mastra agent job: query-job/);
+});
+
+test("agent_query async path passes supported options through", async () => {
+	const starts: any[] = [];
+	const tool = createMastraAgentQueryTool({
+		start: async (params: any) => {
+			starts.push(params);
+			return fakeAsyncSummary({ agentId: params.agentId, threadId: params.threadId, resourceId: params.resourceId });
+		},
+	} as any, {} as any);
+
+	await tool.execute("call", {
+		agentId: "agent",
+		message: "hello $1",
+		threadId: "thread-x",
+		resourceId: "resource-x",
+		requestContext: { tenant: "acme" },
+		includeReasoning: true,
+		includeToolResults: true,
+		timeoutMs: 123,
+		input_args: { $1: "world" },
+	});
+
+	assert.equal(starts[0].includeReasoning, true);
+	assert.equal(starts[0].includeToolResults, true);
+	assert.equal(starts[0].threadId, "thread-x");
+	assert.equal(starts[0].resourceId, "resource-x");
+	assert.equal(starts[0].timeoutMs, 123);
+	assert.deepEqual(starts[0].requestContext, { tenant: "acme" });
+	assert.deepEqual(starts[0].input_args, { $1: "world" });
+});
+
+test("agent_query supports synchronous execution and input_args formatting", async () => {
+	const requests: any[] = [];
+	const tool = createMastraAgentQueryTool({
+		start: async () => {
+			throw new Error("async start should not be used for synchronous query");
+		},
+	} as any, {
+		async *streamAgent(agentId: string, request: unknown) {
+			requests.push({ agentId, request });
+			yield { type: "text-delta", text: "answer" };
+			yield { type: "reasoning-delta", text: "hidden" };
+			yield { type: "finish" };
+		},
+	} as any);
+
+	const result = await tool.execute("call", {
+		agentId: "agent",
+		message: "Use $1",
+		synchronous: true,
+		requestContext: { tenant: "acme" },
+		input_args: { $1: "value" },
+	});
+
+	assert.equal((result.details as any).text, "answer");
+	assert.equal("text" in result.content[0] ? result.content[0].text.includes("Reasoning:" ) : true, false);
+	assert.equal(requests[0].agentId, "agent");
+	assert.match(requests[0].request.messages[0].content, /Use \$1\n\nInput arguments:\n- \$1: value/);
+	assert.deepEqual(requests[0].request.requestContext, { tenant: "acme", input_args: { $1: "value" } });
+});
+
+test("agent_query renderers distinguish async summaries and sync details", () => {
+	const tool = createMastraAgentQueryTool({ start: async () => fakeAsyncSummary() } as any, {} as any) as any;
+	const asyncCallLines = tool.renderCall({ agentId: "agent", message: "hello" }, stubTheme).render(80).join("\n");
+	const syncCallLines = tool.renderCall({ agentId: "agent", message: "hello", synchronous: true }, stubTheme).render(80).join("\n");
+	assert.match(asyncCallLines, /mastra query/);
+	assert.match(asyncCallLines, /agent/);
+	assert.match(asyncCallLines, /mode=async/);
+	assert.match(syncCallLines, /mode=sync/);
+
+	const asyncLines = tool
+		.renderResult({ content: [{ type: "text", text: "started" }], details: fakeAsyncSummary() }, {}, stubTheme)
+		.render(80);
+	assert.deepEqual(asyncLines, []);
+
+	const syncLines = tool
+		.renderResult({ content: [{ type: "text", text: "answer" }], details: fakeCallDetails({ text: "answer" }) }, {}, stubTheme)
+		.render(80);
+	assert.ok(syncLines.length > 0);
+	assert.ok(syncLines.join("\n").includes("answer"));
+});
+
 test("async agent manager honors explicit thread ids", async () => {
 	const requests: any[] = [];
 	const manager = new MastraAsyncAgentManager({
@@ -306,6 +440,46 @@ test("agent inspect can include instructions when requested", async () => {
 	assert.equal(result.content[0].type, "text");
 	assert.match("text" in result.content[0] ? result.content[0].text : "", /Use evidence/);
 });
+
+
+const stubTheme: Record<string, (...args: string[]) => string> = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+	dim: (text: string) => text,
+};
+
+function fakeAsyncSummary(overrides: Record<string, unknown> = {}): any {
+	return {
+		jobId: "job",
+		agentId: "agent",
+		threadId: "thread",
+		resourceId: "resource",
+		status: "running",
+		textPreview: "",
+		toolCalls: 0,
+		toolResults: 0,
+		rawChunkCount: 0,
+		chunksTruncated: false,
+		errors: [],
+		...overrides,
+	};
+}
+
+function fakeCallDetails(overrides: Record<string, unknown> = {}): any {
+	return {
+		agentId: "agent",
+		threadId: "thread",
+		resourceId: "resource",
+		status: "done",
+		text: "answer",
+		toolCalls: [],
+		toolResults: [],
+		chunksTruncated: false,
+		errors: [],
+		rawChunkCount: 1,
+		...overrides,
+	};
+}
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
 	const start = Date.now();

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -13,6 +13,7 @@ import {
 	MASTRA_AGENT_CANCEL_TOOL_NAME,
 	MASTRA_AGENT_INSPECT_TOOL_NAME,
 	MASTRA_AGENT_LIST_TOOL_NAME,
+	MASTRA_AGENT_QUERY_TOOL_NAME,
 	MASTRA_AGENT_READ_TOOL_NAME,
 	MASTRA_AGENT_START_TOOL_NAME,
 	MASTRA_AGENT_STATUS_TOOL_NAME,
@@ -35,6 +36,7 @@ import type {
 	MastraAgentInspectDetails,
 	MastraAgentInspectInput,
 	MastraAgentInspection,
+	MastraAgentQueryInput,
 	MastraAgentReadInput,
 	MastraAgentStartInput,
 	MastraAgentStatusInput,
@@ -75,6 +77,19 @@ export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
 	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
 	jobId: Type.Optional(Type.String({ description: "Optional caller-provided async job id" })),
 	finalMessage: Type.Optional(Type.Boolean({ description: "Post a custom final transcript message when the async run completes. Defaults to true." })),
+	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
+});
+
+export const MASTRA_AGENT_QUERY_PARAMETERS = Type.Object({
+	agentId: Type.String({ description: "Mastra agent id to query" }),
+	message: Type.String({ description: "User message to send to the Mastra agent" }),
+	synchronous: Type.Optional(Type.Boolean({ description: "Execute synchronously and return final result. Defaults to false (async-by-default). When false, returns a job id immediately and streams progress to the Pi TUI." })),
+	threadId: Type.Optional(Type.String({ description: "Mastra memory thread id" })),
+	resourceId: Type.Optional(Type.String({ description: "Mastra memory resource id" })),
+	requestContext: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Request-scoped context for Mastra" })),
+	includeToolResults: Type.Optional(Type.Boolean({ description: "Include tool result summaries in model-facing text" })),
+	includeReasoning: Type.Optional(Type.Boolean({ description: "Include reasoning deltas in model-facing text. Defaults to false." })),
+	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
 	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
 });
 
@@ -122,6 +137,7 @@ export const MASTRA_WORKFLOW_STATUS_PARAMETERS = Type.Object({
 	fields: Type.Optional(Type.Array(Type.String(), { description: "Optional workflow run fields to request" })),
 	withNestedWorkflows: Type.Optional(Type.Boolean({ description: "Include nested workflow data in steps" })),
 });
+
 
 const DEFAULT_ASYNC_AGENT_TIMEOUT_MS = 60 * 60_000;
 
@@ -323,6 +339,7 @@ export function createMastraTools(client = new MastraHttpClient(), options: Mast
 			onComplete: options.onAsyncAgentComplete,
 		});
 	return [
+		createMastraAgentQueryTool(asyncAgentManager, client, options.agentActivitySink),
 		createMastraAgentTool(client, options.agentActivitySink),
 		createMastraAgentStartTool(asyncAgentManager),
 		createMastraAgentAsyncStatusTool(asyncAgentManager),
@@ -447,6 +464,127 @@ export function createMastraAgentStartTool(manager: MastraAsyncAgentManager) {
 			return emptyComponent();
 		},
 		renderResult() {
+			return emptyComponent();
+		},
+	};
+}
+
+export function createMastraAgentQueryTool(
+	manager: MastraAsyncAgentManager,
+	client = new MastraHttpClient(),
+	activitySink?: MastraAgentActivitySink,
+) {
+	return {
+		name: MASTRA_AGENT_QUERY_TOOL_NAME,
+		label: "Mastra Agent Query",
+		description: "Call a Mastra agent with async-by-default execution. Returns a job id immediately unless synchronous=true. Supports input_args, includeToolResults, and includeReasoning (default: false). Does not expose maxSteps or activeTools.",
+		promptSnippet: "Query a Mastra agent with async-by-default execution, using a narrower schema than agent_call.",
+		promptGuidelines: [
+			"Use agent_query for Mastra agent delegation when async-by-default behavior is preferred and maxSteps/activeTools are not needed.",
+			"After agent_query returns a jobId (async mode), use agent_read to retrieve output unless the initial prompt explicitly opts out.",
+		],
+		parameters: MASTRA_AGENT_QUERY_PARAMETERS,
+		renderShell: "self" as const,
+		async execute(
+			_toolCallId: string,
+			params: MastraAgentQueryInput,
+			signal?: AbortSignal,
+			onUpdate?: AgentToolUpdateCallback<MastraAgentCallDetails>,
+		): Promise<AgentToolResult<MastraAgentCallDetails | Record<string, unknown>>> {
+			// Default to async unless synchronous is explicitly true
+			if (params.synchronous !== true) {
+				if (signal?.aborted) {
+					return {
+						content: [{ type: "text", text: "Async Mastra agent query was aborted before launch." }],
+						details: {
+							jobId: "",
+							agentId: params.agentId,
+							modeId: undefined,
+							threadId: params.threadId ?? defaultThreadId(params.agentId),
+							resourceId: params.resourceId ?? defaultResourceId(),
+							status: "aborted",
+							prompt: params.message,
+							textPreview: "",
+							toolCalls: 0,
+							toolResults: 0,
+							rawChunkCount: 0,
+							chunksTruncated: false,
+							errors: ["aborted before launch"],
+						} as unknown as Record<string, unknown>,
+					};
+				}
+				try {
+					const summary = await manager.start({
+						agentId: params.agentId,
+						message: params.message,
+						threadId: params.threadId,
+						resourceId: params.resourceId,
+						requestContext: params.requestContext,
+						includeToolResults: params.includeToolResults,
+						includeReasoning: params.includeReasoning ?? false,
+						timeoutMs: params.timeoutMs,
+						input_args: params.input_args,
+					});
+					return {
+						content: [{ type: "text", text: formatAsyncStartResult(summary) }],
+						details: summary as unknown as Record<string, unknown>,
+					};
+				} catch (error) {
+					return errorResult(error, { jobId: "", agentId: params.agentId, status: "error" });
+				}
+			}
+
+			// Synchronous path: stream via client.streamAgent (same pattern as agent_call)
+			const details = createInitialDetails({
+				agentId: params.agentId,
+				message: params.message,
+				threadId: params.threadId,
+				resourceId: params.resourceId,
+				requestContext: params.requestContext,
+				includeToolResults: params.includeToolResults,
+				includeReasoning: params.includeReasoning,
+				timeoutMs: params.timeoutMs,
+				input_args: params.input_args,
+			});
+			const request = createStreamRequest(params, details.threadId, details.resourceId);
+			const emitUpdate = () => {
+				details.updatedAt = Date.now();
+				activitySink?.update(_toolCallId, details);
+				onUpdate?.(makeToolResult(details, params));
+			};
+
+			activitySink?.start(_toolCallId, params, details);
+			emitUpdate();
+
+			try {
+				for await (const chunk of client.streamAgent(params.agentId, request, { signal, timeoutMs: params.timeoutMs })) {
+					applyNormalizedEvent(details, normalizeMastraChunk(chunk));
+					emitUpdate();
+				}
+
+				if (details.status === "running") details.status = "done";
+				details.updatedAt = Date.now();
+				details.completedAt = details.completedAt ?? details.updatedAt;
+				activitySink?.finish(_toolCallId, details);
+				return makeToolResult(details, params);
+			} catch (error) {
+				details.status = signal?.aborted ? "aborted" : "error";
+				details.updatedAt = Date.now();
+				details.completedAt = details.updatedAt;
+				details.errors.push(error instanceof Error ? error.message : String(error));
+				activitySink?.finish(_toolCallId, details);
+				return makeToolResult(details, params);
+			}
+		},
+		renderCall(args: MastraAgentQueryInput, theme: any) {
+			const mode = args.synchronous ? "sync" : "async";
+			return new Text(`${theme.fg("toolTitle", theme.bold("mastra query "))}${theme.fg("accent", args.agentId)}${theme.fg("dim", ` mode=${mode}`)}`, 0, 0);
+		},
+		renderResult(result: AgentToolResult<MastraAgentCallDetails | Record<string, unknown>>, options: { expanded?: boolean; isPartial?: boolean }, theme: any) {
+			// If result has text/toolCalls it's a sync call details; otherwise async summary
+			if (result.details && "text" in (result.details as any) && "toolCalls" in (result.details as any)) {
+				return new MastraAgentCard(result.details as MastraAgentCallDetails, options, theme);
+			}
 			return emptyComponent();
 		},
 	};

--- a/pi/src/mastra/types.ts
+++ b/pi/src/mastra/types.ts
@@ -221,6 +221,19 @@ export interface MastraAgentStartInput extends MastraAgentCallInput {
 	finalMessage?: boolean;
 }
 
+export interface MastraAgentQueryInput {
+	agentId: string;
+	message: string;
+	synchronous?: boolean;
+	threadId?: string;
+	resourceId?: string;
+	requestContext?: Record<string, unknown>;
+	includeToolResults?: boolean;
+	includeReasoning?: boolean;
+	timeoutMs?: number;
+	input_args?: MastraAgentInputArgs;
+}
+
 export interface MastraAgentAsyncStatusInput {
 	jobId?: string;
 }

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -212,9 +212,9 @@ export class MastraAgentsWidget implements Component {
 			const maxBodyLines = Math.max(3, this.options.cardBodyLines ?? perCardTotalLines - 2);
 			// Cards align to the left gutter. Pi widget slot placement (aboveEditor /
 			// belowEditor) anchors to the content edge, so no horizontal offset is
-			// applied. cardWidth limits the card content width; overflow is truncated
-			// at the right rather than right-aligned.
-			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? 96));
+			// applied. cardWidth can optionally limit the card content width; by
+			// default, async cards use the full available widget width.
+			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? width));
 			const lines: string[] = [];
 
 			for (let i = 0; i < visibleCards.length; i++) {


### PR DESCRIPTION
## Summary
- Add `agent_query` as the async-by-default Pi Mastra agent invocation surface.
- Support `synchronous: true` opt-in while preserving existing lower-level agent and workflow tools.
- Keep the `agent_query` schema narrow: no `maxSteps` or `activeTools`; supports `input_args`, `includeReasoning`, and `includeToolResults`.

## Validation
- `cd pi && npm run typecheck`
- `cd pi && npm test` — 83/83 passing
- `npm run typecheck`
- `git diff --check`
- Validator agent strict audit: PASS, including false-positive/weak-oracle review of the test suite.
- Headless Pi smoke: `pi --no-session --tools agent_query -p ...` returned `PASS` for an `input_args`-backed `agent_query` call.

Closes #8