### PR TITLE
Fix Mastra agent card lifecycle and render regions

### DIFF
--- a/.agents/skills/post-tdd-verification/SKILL.md
+++ b/.agents/skills/post-tdd-verification/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: post-tdd-verification
+description: Run a post-implementation verification pass after red-green-refactor appears complete. Use when Codex is given an implementation scope, transcript path, GitHub issue or PR, commit refs, branch, or test results and should audit whether tests are meaningful, implementation structure is sound, and the change respects SOLID design principles using three parallel verification subagents.
+---
+
+# Post-TDD Verification
+
+Use this skill after an implementation slice claims to be complete and tests pass. The goal is to challenge the quality of the test boundary and the implementation, not to reimplement the feature.
+
+## Inputs
+
+Collect or infer these inputs before dispatch:
+
+- Implementation scope: issue, feature, bug, or behavior the commit claims to handle.
+- Git refs: commit SHA, branch, PR URL, base branch, or comparison range.
+- Context sources: transcript path, issue URL/number, design notes, implementation plan, or prior audit notes.
+- Verification signals: test commands run, failing/passing history, CI status, or known gaps.
+
+If a value is unavailable, mark it explicitly as unknown in the subagent prompts. Do not block on missing metadata if the repo and commit range are enough to audit.
+
+## Dispatch Pattern
+
+Spawn three read-only verification subagents in parallel. Use explorer-style agents when available. Give each agent the same shared inputs and a narrow audit scope. Instruct every agent:
+
+- Do not edit files.
+- Inspect the commit diff, relevant tests, and implementation code.
+- Use transcript or issue context to compare intended behavior against actual coverage.
+- Return findings ordered by severity with file and line references when possible.
+- Separate confirmed findings from residual risk.
+
+While agents run, the coordinator may collect lightweight local context, but avoid duplicating the agents' full reviews.
+
+## Agent 1: Test Integrity Audit
+
+Audit red-green-refactor quality.
+
+Ask this agent to find:
+
+- False-positive tests: tests that could pass without exercising the intended behavior.
+- Tests that likely would not have failed before the implementation.
+- Assertions that only check shape, call count, snapshots, or happy paths while missing the real boundary.
+- Tests that assert implementation details instead of externally meaningful behavior.
+- Missing tests for lifecycle boundaries, error paths, race conditions, persistence, idempotency, fallback behavior, config limits, and user-visible outcomes.
+
+Require the output to include:
+
+- Test file, line, and test name when available.
+- Why the current assertion boundary is weak.
+- The concrete behavior a stronger test should prove.
+
+## Agent 2: Structural Implementation Audit
+
+Audit whether the implementation is wired correctly at the code structure level.
+
+Ask this agent to inspect:
+
+- Function definitions and call sites.
+- Class instantiation, dependency construction, and lifetime.
+- Imports, exports, package boundaries, and registration points.
+- Argument parsing, schema validation, defaulting, and config flow.
+- Async control flow, event registration, cleanup, cancellation, retry, and error propagation.
+- Data contracts between modules, tools, UI surfaces, persistence, and external APIs.
+- Dead code, duplicate paths, unreachable branches, stale compatibility shims, and naming drift.
+
+Require the output to explain how each issue can surface at runtime, not just that the code looks untidy.
+
+## Agent 3: SOLID Design Audit
+
+Audit design quality using SOLID as a practical checklist.
+
+Ask this agent to evaluate:
+
+- Single Responsibility: modules or classes doing too many unrelated jobs.
+- Open/Closed: places where new states, agents, events, or tools require invasive edits.
+- Liskov Substitution: implementations that violate expected interface behavior or state assumptions.
+- Interface Segregation: broad APIs, overloaded tools, or callers forced to know irrelevant fields.
+- Dependency Inversion: high-level logic depending directly on concrete transport, storage, UI, or runtime details.
+
+Also ask for overengineering risks. A SOLID audit should not push abstractions unless they reduce real coupling or make the current scope safer.
+
+## Coordinator Output
+
+Merge the three reports into a concise final audit:
+
+- Findings first, ordered by severity.
+- Label each finding source: `test-integrity`, `structural`, `solid`, or `cross-cutting`.
+- Include exact file links and line numbers when available.
+- Call out duplicate findings once, with combined evidence.
+- Include a short "Missing Tests" section if test gaps are the main result.
+- Include a short "Residual Risk" section for concerns that could not be confirmed.
+- Do not claim the implementation is verified unless all three audits found no material issues and the relevant tests or CI were actually checked.
+
+If the user asks for fixes after the audit, make a separate plan from the findings before editing.

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,5 +1,8 @@
 {
   "extensions": [
     "../pi/src/extensions/index.ts"
-  ]
+  ],
+  "terminal": {
+    "clearOnShrink": false
+  }
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Supervisor + 6 specialist agents in the Daytona agents pattern (Eugenechan00/day
 **Storage:** PostgresStore + DuckDBStore + FilesystemStore (composite)  
 **Sandbox:** Auto current-sandbox LocalSandbox when already inside Daytona; DaytonaAgentsDaytonaSandbox for forced/remote Daytona workspaces
 
-See [Mastra agent calling methods](docs/mastra-agent-calling-methods.md) for Pi call surfaces, default `resourceId`/`threadId` behavior, and how to start a new conversation thread intentionally.
+See [Mastra agent calling methods](docs/mastra-agent-calling-methods.md) for the Pi `agent_query` surface, default `resourceId`/`threadId` behavior, and how to start a new conversation thread intentionally.
 
 See [daytona-agents](https://github.com/Eugenechan00/daytona-agents) for the reference implementation.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,8 @@
 mastra-agent-extension:
   maxCards: 4
   maxLines: 60
-  listMaxLines: 12
+  listMaxLines: 18
+  listMaxAgents: 5
   reservedRows: 10
   defaultViewMode: list
   viewModeShortcut: ctrl+h

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,11 @@
+mastra-agent-extension:
+  maxCards: 4
+  maxLines: 60
+  listMaxLines: 12
+  reservedRows: 10
+  defaultViewMode: list
+  viewModeShortcut: ctrl+h
+  nextAgentShortcut: ctrl+down
+  previousAgentShortcut: ctrl+up
+  debug: true
+  debugPiRedraw: true

--- a/docs/mastra-agent-calling-methods.md
+++ b/docs/mastra-agent-calling-methods.md
@@ -2,14 +2,13 @@
 
 This note documents how Pi calls Mastra agents in this workspace and how conversation memory identifiers are chosen by default.
 
-## Call surfaces
+## Call Surface
 
-Pi exposes two primary Mastra agent call tools:
+Pi exposes one primary Mastra agent query tool:
 
 | Tool | Use | Continuity behavior |
 |---|---|---|
-| `agent_call` | Synchronous call when the caller needs final output before continuing. | Sends a resolved `memory.thread` and `memory.resource` with the request. |
-| `agent_start` | Asynchronous/background call with live progress in the Pi TUI. | Uses the same default memory identifier resolution as `agent_call`. |
+| `agent_query` | Async-by-default Mastra agent query. Pass `synchronous: true` only when the caller needs final output before continuing. | Sends a resolved `memory.thread` and `memory.resource` with the request. |
 
 Supporting tools:
 
@@ -22,7 +21,7 @@ Supporting tools:
 
 ## Async output handoff
 
-After an `agent_start` job completes, the parent agent should call `agent_read` for that job before finalizing so it can incorporate the async agent output. The only exception is when the user's initial prompt explicitly opted out with wording such as `pass the output` or `don't read the output`.
+After an async `agent_query` job completes, the parent agent should call `agent_read` for that job before finalizing so it can incorporate the async agent output. The only exception is when the user's initial prompt explicitly opted out with wording such as `pass the output` or `don't read the output`.
 
 ## Default memory identifiers
 
@@ -36,11 +35,11 @@ threadId   = `pi:${sha256(`${cwd}:${process.pid}`).slice(0, 12)}:${agentId}`
 Source:
 
 - `pi/src/mastra/memory.ts` defines `defaultResourceId()` and `defaultThreadId()`.
-- `pi/src/mastra/tool.ts` resolves `params.resourceId ?? defaultResourceId()` and `params.threadId ?? defaultThreadId(params.agentId)` before creating the stream request.
+- `pi/src/mastra/tool.ts` resolves `params.resourceId ?? defaultResourceId()` and `params.threadId ?? defaultThreadId(params.agentId)` before creating the stream request. Async `agent_query` jobs use the job id as a default thread suffix so concurrent jobs for the same agent do not share a live stream thread.
 
 ## Default reuse behavior
 
-For repeated calls with no explicit `threadId` or `resourceId`:
+For repeated synchronous calls with no explicit `threadId` or `resourceId`:
 
 | Scenario | Default `resourceId` | Default `threadId` |
 |---|---|---|
@@ -49,7 +48,7 @@ For repeated calls with no explicit `threadId` or `resourceId`:
 | Pi restart, same working directory, same agent | Reused | New, because `process.pid` changes |
 | Different working directory | New | New |
 
-This means Pi does **not** create a fresh default thread for every call within the same running Pi process. It reuses the same default thread for the same agent, working directory, and process.
+This means synchronous `agent_query` does **not** create a fresh default thread for every call within the same running Pi process. Async `agent_query` jobs use `defaultThreadId(agentId):jobId` by default so concurrent background jobs stay isolated; pass an explicit `threadId` to opt into shared continuity.
 
 ## Starting a new conversation intentionally
 

--- a/mastra-agents/package.json
+++ b/mastra-agents/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "mastra dev",
     "build": "mastra build",
+    "test": "node --test \"test/**/*.test.js\"",
     "start": "mastra start",
     "studio": "mastra studio"
   },

--- a/mastra-agents/src/mastra/index.ts
+++ b/mastra-agents/src/mastra/index.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { mastraAgents } from "../agents/agent";
 import { controlAgentScorers } from "../scorers/control-agent";
 import { daytonaWorkflows } from "../workflows/daytona";
+import { piAgentJobWorkflows } from "../workflows/pi-agent-job";
 import { workspaceWorkflows } from "../workflows/workspace";
 import { resolveWorkspacePath, workspace } from "../workspace";
 
@@ -61,6 +62,7 @@ export const mastra = new Mastra({
   agents: mastraAgents,
   workflows: {
     ...daytonaWorkflows,
+    ...piAgentJobWorkflows,
     ...workspaceWorkflows,
   },
   scorers: controlAgentScorers,

--- a/mastra-agents/src/workflows/index.ts
+++ b/mastra-agents/src/workflows/index.ts
@@ -1,2 +1,3 @@
 export { daytonaWorkflows } from "./daytona.js";
+export { piAgentJobWorkflows } from "./pi-agent-job.js";
 export { workspaceWorkflows } from "./workspace.js";

--- a/mastra-agents/src/workflows/pi-agent-job.ts
+++ b/mastra-agents/src/workflows/pi-agent-job.ts
@@ -11,6 +11,8 @@ const piAgentJobInputSchema = z.object({
   jobId: z.string(),
   jobName: z.string(),
   piSessionId: z.string().optional(),
+  runId: z.string().optional(),
+  agentRunId: z.string().optional(),
   agentId: z.string(),
   message: z.string(),
   threadId: z.string(),
@@ -26,6 +28,8 @@ const piAgentJobOutputSchema = z.object({
   jobId: z.string(),
   jobName: z.string(),
   piSessionId: z.string().optional(),
+  runId: z.string().optional(),
+  agentRunId: z.string().optional(),
   agentId: z.string(),
   threadId: z.string(),
   resourceId: z.string(),
@@ -36,7 +40,7 @@ const piAgentJobOutputSchema = z.object({
   errors: z.array(z.string()),
 });
 
-const runPiAgentJobStep = createStep({
+export const runPiAgentJobStep = createStep({
   id: "run-pi-agent-job",
   inputSchema: piAgentJobInputSchema,
   outputSchema: piAgentJobOutputSchema,
@@ -62,7 +66,7 @@ const runPiAgentJobStep = createStep({
         ...(inputData.input_args && Object.keys(inputData.input_args).length > 0 ? { input_args: inputData.input_args } : {}),
       };
       const streamResult = await agent.stream(formatPrompt(inputData.message, inputData.input_args), {
-        runId: inputData.jobId,
+        runId: inputData.agentRunId ?? inputData.runId ?? inputData.jobId,
         memory: {
           thread: inputData.threadId,
           resource: inputData.resourceId,
@@ -91,6 +95,8 @@ const runPiAgentJobStep = createStep({
         jobId: inputData.jobId,
         jobName: inputData.jobName,
         piSessionId: inputData.piSessionId,
+        runId: inputData.runId,
+        agentRunId: inputData.agentRunId,
         agentId: inputData.agentId,
         threadId: inputData.threadId,
         resourceId: inputData.resourceId,
@@ -106,6 +112,8 @@ const runPiAgentJobStep = createStep({
       jobId: inputData.jobId,
       jobName: inputData.jobName,
       piSessionId: inputData.piSessionId,
+      runId: inputData.runId,
+      agentRunId: inputData.agentRunId,
       agentId: inputData.agentId,
       threadId: inputData.threadId,
       resourceId: inputData.resourceId,

--- a/mastra-agents/src/workflows/pi-agent-job.ts
+++ b/mastra-agents/src/workflows/pi-agent-job.ts
@@ -1,0 +1,170 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { createStep, createWorkflow } from "@mastra/core/workflows";
+import { z } from "zod";
+
+import { resolveWorkspacePath } from "../workspace";
+
+const inputArgsSchema = z.record(z.string()).optional();
+
+const piAgentJobInputSchema = z.object({
+  jobId: z.string(),
+  jobName: z.string(),
+  piSessionId: z.string().optional(),
+  agentId: z.string(),
+  message: z.string(),
+  threadId: z.string(),
+  resourceId: z.string(),
+  requestContext: z.record(z.unknown()).optional(),
+  includeToolResults: z.boolean().optional(),
+  includeReasoning: z.boolean().optional(),
+  input_args: inputArgsSchema,
+  timeoutMs: z.number().optional(),
+});
+
+const piAgentJobOutputSchema = z.object({
+  jobId: z.string(),
+  jobName: z.string(),
+  piSessionId: z.string().optional(),
+  agentId: z.string(),
+  threadId: z.string(),
+  resourceId: z.string(),
+  status: z.enum(["done", "error"]),
+  text: z.string(),
+  artifactPath: z.string(),
+  eventsPath: z.string(),
+  errors: z.array(z.string()),
+});
+
+const runPiAgentJobStep = createStep({
+  id: "run-pi-agent-job",
+  inputSchema: piAgentJobInputSchema,
+  outputSchema: piAgentJobOutputSchema,
+  execute: async ({ inputData, mastra, writer, abortSignal }) => {
+    const artifactDir = resolveWorkspacePath(
+      process.env.MASTRA_PI_AGENT_JOB_DIR ??
+        path.join(
+          "apps/mastra-control/.mastra/pi-agent-jobs",
+          safePathPart(inputData.piSessionId ?? "local-session"),
+          safePathPart(inputData.jobId),
+        ),
+    );
+    await mkdir(artifactDir, { recursive: true });
+    const artifactPath = path.join(artifactDir, "output.txt");
+    const eventsPath = path.join(artifactDir, "events.jsonl");
+    const errors: string[] = [];
+    let text = "";
+
+    try {
+      const agent = resolveAgent(mastra, inputData.agentId);
+      const requestContext = {
+        ...(inputData.requestContext ?? {}),
+        ...(inputData.input_args && Object.keys(inputData.input_args).length > 0 ? { input_args: inputData.input_args } : {}),
+      };
+      const streamResult = await agent.stream(formatPrompt(inputData.message, inputData.input_args), {
+        runId: inputData.jobId,
+        memory: {
+          thread: inputData.threadId,
+          resource: inputData.resourceId,
+        },
+        requestContext,
+        abortSignal,
+      });
+
+      for await (const chunk of streamResult.fullStream as AsyncIterable<unknown>) {
+        await writer.write(chunk);
+        await appendJsonLine(eventsPath, { timestamp: Date.now(), chunk });
+        const delta = textDelta(chunk);
+        if (delta) {
+          text += delta;
+          await appendFile(artifactPath, delta, "utf8");
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+      const chunk = { type: "error", payload: { message }, message };
+      await writer.write(chunk);
+      await appendJsonLine(eventsPath, { timestamp: Date.now(), chunk });
+      await appendFile(artifactPath, `\n[agent job error: ${message}]\n`, "utf8");
+      return {
+        jobId: inputData.jobId,
+        jobName: inputData.jobName,
+        piSessionId: inputData.piSessionId,
+        agentId: inputData.agentId,
+        threadId: inputData.threadId,
+        resourceId: inputData.resourceId,
+        status: "error" as const,
+        text,
+        artifactPath,
+        eventsPath,
+        errors,
+      };
+    }
+
+    return {
+      jobId: inputData.jobId,
+      jobName: inputData.jobName,
+      piSessionId: inputData.piSessionId,
+      agentId: inputData.agentId,
+      threadId: inputData.threadId,
+      resourceId: inputData.resourceId,
+      status: "done" as const,
+      text,
+      artifactPath,
+      eventsPath,
+      errors,
+    };
+  },
+});
+
+const piAgentJobWorkflow = createWorkflow({
+  id: "pi.agent-job",
+  description: "Durable Pi session background Mastra agent job runner.",
+  inputSchema: piAgentJobInputSchema,
+  outputSchema: piAgentJobOutputSchema,
+})
+  .then(runPiAgentJobStep)
+  .commit();
+
+export const piAgentJobWorkflows = {
+  piAgentJob: piAgentJobWorkflow,
+};
+
+function resolveAgent(mastra: any, agentId: string): any {
+  if (typeof mastra.getAgentById === "function") {
+    try {
+      return mastra.getAgentById(agentId);
+    } catch {
+      // Fall through to getAgent, which supports registry keys.
+    }
+  }
+  return mastra.getAgent(agentId);
+}
+
+function formatPrompt(message: string, inputArgs: Record<string, string> | undefined): string {
+  if (!inputArgs || Object.keys(inputArgs).length === 0) return message;
+  const keys = Object.keys(inputArgs).sort((left, right) => Number(left.slice(1)) - Number(right.slice(1)));
+  const lines = keys.map((key) => `- ${key}: ${inputArgs[key]}`);
+  return `${message}\n\nInput arguments:\n${lines.join("\n")}\n\nWhen the prompt references placeholders like $1, $2, etc., use the corresponding input argument above.`;
+}
+
+function textDelta(chunk: unknown): string {
+  if (!isRecord(chunk)) return "";
+  if (typeof chunk.text === "string") return chunk.text;
+  if (typeof chunk.delta === "string") return chunk.delta;
+  if (isRecord(chunk.payload) && typeof chunk.payload.text === "string") return chunk.payload.text;
+  return "";
+}
+
+async function appendJsonLine(filePath: string, value: unknown): Promise<void> {
+  await appendFile(filePath, `${JSON.stringify(value)}\n`, "utf8").catch(() => undefined);
+}
+
+function safePathPart(value: string): string {
+  return value.trim().replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "unknown";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/mastra-agents/test/pi-agent-job.test.js
+++ b/mastra-agents/test/pi-agent-job.test.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createJiti } from "@mariozechner/jiti";
+
+const jiti = createJiti(import.meta.url);
+
+test("pi agent job workflow is exported under the Mastra workflow id expected by Pi", async () => {
+	const { piAgentJobWorkflows } = await jiti.import("../src/workflows/pi-agent-job.ts");
+	assert.deepEqual(Object.keys(piAgentJobWorkflows), ["piAgentJob"]);
+	assert.equal(piAgentJobWorkflows.piAgentJob.id, "pi.agent-job");
+	assert.equal(piAgentJobWorkflows.piAgentJob.steps["run-pi-agent-job"].id, "run-pi-agent-job");
+});
+
+test("pi agent job workflow step streams agent output into artifacts and forwards run metadata", async () => {
+	const artifactDir = await mkdtemp(path.join(os.tmpdir(), "pi-agent-job-"));
+	const previousArtifactDir = process.env.MASTRA_PI_AGENT_JOB_DIR;
+	process.env.MASTRA_PI_AGENT_JOB_DIR = artifactDir;
+	try {
+		const { runPiAgentJobStep } = await jiti.import("../src/workflows/pi-agent-job.ts");
+		const writerChunks = [];
+		let streamPrompt = "";
+		let streamOptions;
+		const mastra = {
+			getAgentById(agentId) {
+				assert.equal(agentId, "validator-agent");
+				return {
+					async stream(prompt, options) {
+						streamPrompt = prompt;
+						streamOptions = options;
+						return {
+							fullStream: [
+								{ type: "text-delta", text: "hello" },
+								{ type: "text-delta", payload: { text: " world" } },
+							],
+						};
+					},
+				};
+			},
+		};
+		const writer = {
+			async write(chunk) {
+				writerChunks.push(chunk);
+			},
+		};
+
+		const result = await runPiAgentJobStep.execute({
+			inputData: {
+				jobId: "job-1",
+				jobName: "review",
+				piSessionId: "session-1",
+				runId: "workflow-run",
+				agentRunId: "agent-run",
+				agentId: "validator-agent",
+				message: "Review $1",
+				threadId: "thread-1",
+				resourceId: "resource-1",
+				requestContext: { tenant: "acme" },
+				input_args: { $1: "diff" },
+			},
+			mastra,
+			writer,
+			abortSignal: new AbortController().signal,
+		});
+
+		assert.equal(result.status, "done");
+		assert.equal(result.text, "hello world");
+		assert.equal(result.runId, "workflow-run");
+		assert.equal(result.agentRunId, "agent-run");
+		assert.equal(streamOptions.runId, "agent-run");
+		assert.deepEqual(streamOptions.memory, { thread: "thread-1", resource: "resource-1" });
+		assert.deepEqual(streamOptions.requestContext, { tenant: "acme", input_args: { $1: "diff" } });
+		assert.match(streamPrompt, /Review \$1/);
+		assert.match(streamPrompt, /- \$1: diff/);
+		assert.deepEqual(writerChunks, [
+			{ type: "text-delta", text: "hello" },
+			{ type: "text-delta", payload: { text: " world" } },
+		]);
+		assert.equal(await readFile(result.artifactPath, "utf8"), "hello world");
+		const events = (await readFile(result.eventsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+		assert.equal(events.length, 2);
+		assert.deepEqual(events.map((event) => event.chunk), writerChunks);
+	} finally {
+		if (previousArtifactDir === undefined) delete process.env.MASTRA_PI_AGENT_JOB_DIR;
+		else process.env.MASTRA_PI_AGENT_JOB_DIR = previousArtifactDir;
+		await rm(artifactDir, { recursive: true, force: true });
+	}
+});
+
+test("pi agent job workflow step reports agent stream errors and writes error artifacts", async () => {
+	const artifactDir = await mkdtemp(path.join(os.tmpdir(), "pi-agent-job-error-"));
+	const previousArtifactDir = process.env.MASTRA_PI_AGENT_JOB_DIR;
+	process.env.MASTRA_PI_AGENT_JOB_DIR = artifactDir;
+	try {
+		const { runPiAgentJobStep } = await jiti.import("../src/workflows/pi-agent-job.ts");
+		const writerChunks = [];
+		const mastra = {
+			getAgentById() {
+				return {
+					async stream() {
+						throw new Error("agent exploded");
+					},
+				};
+			},
+		};
+		const writer = {
+			async write(chunk) {
+				writerChunks.push(chunk);
+			},
+		};
+
+		const result = await runPiAgentJobStep.execute({
+			inputData: {
+				jobId: "job-error",
+				jobName: "review",
+				piSessionId: "session-1",
+				agentId: "validator-agent",
+				message: "Review",
+				threadId: "thread-1",
+				resourceId: "resource-1",
+			},
+			mastra,
+			writer,
+			abortSignal: new AbortController().signal,
+		});
+
+		assert.equal(result.status, "error");
+		assert.deepEqual(result.errors, ["agent exploded"]);
+		assert.equal(writerChunks.length, 1);
+		assert.equal(writerChunks[0].type, "error");
+		assert.match(await readFile(result.artifactPath, "utf8"), /agent job error: agent exploded/);
+		const events = (await readFile(result.eventsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+		assert.equal(events[0].chunk.type, "error");
+	} finally {
+		if (previousArtifactDir === undefined) delete process.env.MASTRA_PI_AGENT_JOB_DIR;
+		else process.env.MASTRA_PI_AGENT_JOB_DIR = previousArtifactDir;
+		await rm(artifactDir, { recursive: true, force: true });
+	}
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14022,7 +14022,8 @@
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.70.5",
         "@mariozechner/pi-tui": "^0.70.5",
-        "typebox": "^1.1.24"
+        "typebox": "^1.1.24",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/pi/README.md
+++ b/pi/README.md
@@ -33,9 +33,19 @@ The extension reads optional project config from `config.yaml` in the active Pi 
 mastra-agent-extension:
   maxCards: 4
   maxLines: 60
+  listMaxLines: 12
+  reservedRows: 10
+  defaultViewMode: list
+  viewModeShortcut: ctrl+h
+  nextAgentShortcut: ctrl+down
+  previousAgentShortcut: ctrl+up
+  debug: true
+  debugPiRedraw: true
 ```
 
-Defaults are `maxCards: 4` and `maxLines: 60`. Agent cards always follow the live terminal width; there is no max-width cap.
+Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 12`, `reservedRows: 10`, and `defaultViewMode: list`. List mode renders a compact above-editor job list with three lines per visible agent. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
+
+`debug: true` writes widget metrics to `~/.pi/agent/mastra-widget-debug.log`; `debugPiRedraw: true` also enables Pi's `~/.pi/agent/pi-debug.log` redraw reasons.
 
 Run the live Mastra smoke check:
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -25,6 +25,18 @@ npm run dev --workspace @mastrasystem/pi
 MASTRA_BASE_URL=http://localhost:4112/api npm run dev --workspace @mastrasystem/pi
 ```
 
+## Mastra Agent Widget Config
+
+The extension reads optional project config from `config.yaml` in the active Pi working directory:
+
+```yaml
+mastra-agent-extension:
+  maxCards: 4
+  maxLines: 60
+```
+
+Defaults are `maxCards: 4` and `maxLines: 60`. Agent cards always follow the live terminal width; there is no max-width cap.
+
 Run the live Mastra smoke check:
 
 ```bash

--- a/pi/README.md
+++ b/pi/README.md
@@ -33,7 +33,8 @@ The extension reads optional project config from `config.yaml` in the active Pi 
 mastra-agent-extension:
   maxCards: 4
   maxLines: 60
-  listMaxLines: 12
+  listMaxLines: 18
+  listMaxAgents: 5
   reservedRows: 10
   defaultViewMode: list
   viewModeShortcut: ctrl+h
@@ -43,7 +44,7 @@ mastra-agent-extension:
   debugPiRedraw: true
 ```
 
-Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 12`, `reservedRows: 10`, and `defaultViewMode: list`. List mode renders a compact above-editor job list with three lines per visible agent. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
+Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 18`, `listMaxAgents: 5`, `reservedRows: 10`, and `defaultViewMode: list`. List mode renders a compact above-editor job list with three lines per visible agent and a `+N more` marker when more than `listMaxAgents` jobs are working. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
 
 `debug: true` writes widget metrics to `~/.pi/agent/mastra-widget-debug.log`; `debugPiRedraw: true` also enables Pi's `~/.pi/agent/pi-debug.log` redraw reasons.
 

--- a/pi/package.json
+++ b/pi/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.70.5",
     "@mariozechner/pi-tui": "^0.70.5",
-    "typebox": "^1.1.24"
+    "typebox": "^1.1.24",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/pi/src/const.ts
+++ b/pi/src/const.ts
@@ -49,10 +49,6 @@ export function workflowStreamPath(workflowId: string, runId: string): string {
 	return `${workflowPath(workflowId)}/stream?runId=${encodeURIComponent(runId)}`;
 }
 
-export function workflowStartAsyncPath(workflowId: string, runId?: string): string {
-	return `${workflowPath(workflowId)}/start-async${runId ? `?runId=${encodeURIComponent(runId)}` : ""}`;
-}
-
 export function workflowObservePath(workflowId: string, runId: string): string {
 	return `${workflowPath(workflowId)}/observe?runId=${encodeURIComponent(runId)}`;
 }

--- a/pi/src/const.ts
+++ b/pi/src/const.ts
@@ -2,8 +2,6 @@ export const MASTRA_API_PREFIX = "/api";
 export const DEFAULT_MASTRA_BASE_URL = `http://localhost:4111${MASTRA_API_PREFIX}`;
 export const MASTRA_BASE_URL_ENV = "MASTRA_BASE_URL";
 
-export const MASTRA_AGENT_CALL_TOOL_NAME = "agent_call";
-export const MASTRA_AGENT_START_TOOL_NAME = "agent_start";
 export const MASTRA_AGENT_READ_TOOL_NAME = "agent_read";
 export const MASTRA_AGENT_ASYNC_STATUS_TOOL_NAME = "agent_async_status";
 export const MASTRA_AGENT_CANCEL_TOOL_NAME = "agent_cancel";
@@ -12,6 +10,7 @@ export const MASTRA_AGENT_INSPECT_TOOL_NAME = "agent_inspect";
 export const MASTRA_AGENT_LIST_TOOL_NAME = "agent_list";
 export const MASTRA_AGENT_STATUS_TOOL_NAME = "agent_status";
 export const MASTRA_AGENT_QUERY_TOOL_NAME = "agent_query";
+export const MASTRA_PI_AGENT_JOB_WORKFLOW_ID = "pi.agent-job";
 export const MASTRA_WORKFLOW_CALL_TOOL_NAME = "workflow_call";
 export const MASTRA_WORKFLOW_LIST_TOOL_NAME = "workflow_list";
 export const MASTRA_WORKFLOW_STATUS_TOOL_NAME = "workflow_status";
@@ -50,6 +49,27 @@ export function workflowStreamPath(workflowId: string, runId: string): string {
 	return `${workflowPath(workflowId)}/stream?runId=${encodeURIComponent(runId)}`;
 }
 
+export function workflowStartAsyncPath(workflowId: string, runId?: string): string {
+	return `${workflowPath(workflowId)}/start-async${runId ? `?runId=${encodeURIComponent(runId)}` : ""}`;
+}
+
+export function workflowObservePath(workflowId: string, runId: string): string {
+	return `${workflowPath(workflowId)}/observe?runId=${encodeURIComponent(runId)}`;
+}
+
+export function workflowRunsPath(
+	workflowId: string,
+	options: { resourceId?: string; status?: string; page?: number; perPage?: number } = {},
+): string {
+	const params = new URLSearchParams();
+	if (options.resourceId) params.set("resourceId", options.resourceId);
+	if (options.status) params.set("status", options.status);
+	if (typeof options.page === "number") params.set("page", String(options.page));
+	if (typeof options.perPage === "number") params.set("perPage", String(options.perPage));
+	const query = params.toString();
+	return `${workflowPath(workflowId)}/runs${query ? `?${query}` : ""}`;
+}
+
 export function workflowRunPath(
 	workflowId: string,
 	runId: string,
@@ -64,4 +84,8 @@ export function workflowRunPath(
 	}
 	const query = params.toString();
 	return `${workflowPath(workflowId)}/runs/${encodeURIComponent(runId)}${query ? `?${query}` : ""}`;
+}
+
+export function workflowCancelRunPath(workflowId: string, runId: string): string {
+	return `${workflowPath(workflowId)}/runs/${encodeURIComponent(runId)}/cancel`;
 }

--- a/pi/src/const.ts
+++ b/pi/src/const.ts
@@ -11,6 +11,7 @@ export const MASTRA_AGENT_RESULT_MESSAGE_TYPE = "mastra-agent-result";
 export const MASTRA_AGENT_INSPECT_TOOL_NAME = "agent_inspect";
 export const MASTRA_AGENT_LIST_TOOL_NAME = "agent_list";
 export const MASTRA_AGENT_STATUS_TOOL_NAME = "agent_status";
+export const MASTRA_AGENT_QUERY_TOOL_NAME = "agent_query";
 export const MASTRA_WORKFLOW_CALL_TOOL_NAME = "workflow_call";
 export const MASTRA_WORKFLOW_LIST_TOOL_NAME = "workflow_list";
 export const MASTRA_WORKFLOW_STATUS_TOOL_NAME = "workflow_status";

--- a/pi/src/extensions/config.test.ts
+++ b/pi/src/extensions/config.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS, loadMastraAgentExtensionConfig } from "./config.js";
+
+test("loadMastraAgentExtensionConfig uses defaults when config.yaml is missing", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-missing-"));
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.found, false);
+	assert.deepEqual(result.options, DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS);
+	assert.equal(result.warning, undefined);
+});
+
+test("loadMastraAgentExtensionConfig reads maxCards and maxLines from config.yaml", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-valid-"));
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n", "utf8");
+
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.found, true);
+	assert.deepEqual(result.options, { maxCards: 4, maxLines: 60 });
+	assert.equal(result.warning, undefined);
+});
+
+test("loadMastraAgentExtensionConfig ignores invalid values and keeps valid values", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-invalid-values-"));
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  maxCards: nope\n  maxLines: 60\n", "utf8");
+
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.found, true);
+	assert.deepEqual(result.options, { maxCards: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards, maxLines: 60 });
+	assert.match(result.warning ?? "", /maxCards/);
+});
+
+test("loadMastraAgentExtensionConfig falls back to defaults for invalid YAML", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-invalid-yaml-"));
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  maxCards: [", "utf8");
+
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.found, true);
+	assert.deepEqual(result.options, DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS);
+	assert.match(result.warning ?? "", /Could not parse/);
+});

--- a/pi/src/extensions/config.test.ts
+++ b/pi/src/extensions/config.test.ts
@@ -25,13 +25,13 @@ test("loadMastraAgentExtensionConfig reads widget and debug values from config.y
 	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-valid-"));
 	await writeFile(
 		join(cwd, "config.yaml"),
-		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  reservedRows: 12\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+h\n  nextAgentShortcut: ctrl+down\n  previousAgentShortcut: ctrl+up\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
+		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  listMaxAgents: 5\n  reservedRows: 12\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+h\n  nextAgentShortcut: ctrl+down\n  previousAgentShortcut: ctrl+up\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
 		"utf8",
 	);
 
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
-	assert.deepEqual(result.options, { maxCards: 4, maxLines: 60, listMaxLines: 10, reservedRows: 12, debug: true, debugLogPath: "/tmp/mastra-widget.log" });
+	assert.deepEqual(result.options, { maxCards: 4, maxLines: 60, listMaxAgents: 5, listMaxLines: 10, reservedRows: 12, debug: true, debugLogPath: "/tmp/mastra-widget.log" });
 	assert.equal(result.debugPiRedraw, true);
 	assert.equal(result.defaultViewMode, "cards");
 	assert.deepEqual(result.shortcuts, {
@@ -44,13 +44,14 @@ test("loadMastraAgentExtensionConfig reads widget and debug values from config.y
 
 test("loadMastraAgentExtensionConfig ignores invalid values and keeps valid values", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-invalid-values-"));
-	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  maxCards: nope\n  maxLines: 60\n", "utf8");
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  maxCards: nope\n  maxLines: 60\n  listMaxAgents: nope\n", "utf8");
 
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
-	assert.deepEqual(result.options, { maxCards: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards, maxLines: 60 });
+	assert.deepEqual(result.options, { maxCards: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards, maxLines: 60, listMaxAgents: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.listMaxAgents });
 	assert.equal(result.debugPiRedraw, false);
 	assert.match(result.warning ?? "", /maxCards/);
+	assert.match(result.warning ?? "", /listMaxAgents/);
 });
 
 test("loadMastraAgentExtensionConfig lets debug enable Pi redraw logging by default", async () => {

--- a/pi/src/extensions/config.test.ts
+++ b/pi/src/extensions/config.test.ts
@@ -3,23 +3,42 @@ import test from "node:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS, loadMastraAgentExtensionConfig } from "./config.js";
+import {
+	DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS,
+	DEFAULT_MASTRA_AGENT_VIEW_MODE,
+	DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS,
+	loadMastraAgentExtensionConfig,
+} from "./config.js";
 
 test("loadMastraAgentExtensionConfig uses defaults when config.yaml is missing", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-missing-"));
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, false);
 	assert.deepEqual(result.options, DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS);
+	assert.equal(result.debugPiRedraw, false);
+	assert.equal(result.defaultViewMode, DEFAULT_MASTRA_AGENT_VIEW_MODE);
+	assert.deepEqual(result.shortcuts, DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS);
 	assert.equal(result.warning, undefined);
 });
 
-test("loadMastraAgentExtensionConfig reads maxCards and maxLines from config.yaml", async () => {
+test("loadMastraAgentExtensionConfig reads widget and debug values from config.yaml", async () => {
 	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-valid-"));
-	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n", "utf8");
+	await writeFile(
+		join(cwd, "config.yaml"),
+		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  reservedRows: 12\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+h\n  nextAgentShortcut: ctrl+down\n  previousAgentShortcut: ctrl+up\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
+		"utf8",
+	);
 
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
-	assert.deepEqual(result.options, { maxCards: 4, maxLines: 60 });
+	assert.deepEqual(result.options, { maxCards: 4, maxLines: 60, listMaxLines: 10, reservedRows: 12, debug: true, debugLogPath: "/tmp/mastra-widget.log" });
+	assert.equal(result.debugPiRedraw, true);
+	assert.equal(result.defaultViewMode, "cards");
+	assert.deepEqual(result.shortcuts, {
+		viewMode: "ctrl+h",
+		nextAgent: "ctrl+down",
+		previousAgent: "ctrl+up",
+	});
 	assert.equal(result.warning, undefined);
 });
 
@@ -30,7 +49,26 @@ test("loadMastraAgentExtensionConfig ignores invalid values and keeps valid valu
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
 	assert.deepEqual(result.options, { maxCards: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards, maxLines: 60 });
+	assert.equal(result.debugPiRedraw, false);
 	assert.match(result.warning ?? "", /maxCards/);
+});
+
+test("loadMastraAgentExtensionConfig lets debug enable Pi redraw logging by default", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-debug-default-"));
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  debug: true\n", "utf8");
+
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.debugPiRedraw, true);
+	assert.deepEqual(result.options, { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS, debug: true });
+});
+
+test("loadMastraAgentExtensionConfig lets debugPiRedraw override debug", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-debug-override-"));
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  debug: true\n  debugPiRedraw: false\n", "utf8");
+
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.debugPiRedraw, false);
+	assert.deepEqual(result.options, { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS, debug: true });
 });
 
 test("loadMastraAgentExtensionConfig falls back to defaults for invalid YAML", async () => {
@@ -40,5 +78,6 @@ test("loadMastraAgentExtensionConfig falls back to defaults for invalid YAML", a
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
 	assert.deepEqual(result.options, DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS);
+	assert.equal(result.debugPiRedraw, false);
 	assert.match(result.warning ?? "", /Could not parse/);
 });

--- a/pi/src/extensions/config.ts
+++ b/pi/src/extensions/config.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse } from "yaml";
+import type { MastraAgentsWidgetOptions } from "../tui/index.js";
+
+export const MASTRA_AGENT_EXTENSION_CONFIG_KEY = "mastra-agent-extension";
+export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidgetOptions, "maxCards" | "maxLines">> = {
+	maxCards: 4,
+	maxLines: 60,
+};
+
+export interface MastraAgentExtensionConfigResult {
+	options: MastraAgentsWidgetOptions;
+	warning?: string;
+	path: string;
+	found: boolean;
+}
+
+export async function loadMastraAgentExtensionConfig(cwd: string): Promise<MastraAgentExtensionConfigResult> {
+	const path = join(cwd, "config.yaml");
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf8");
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return { options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS }, path, found: false };
+		}
+		return {
+			options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
+			path,
+			found: false,
+			warning: `Could not read ${path}: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = parse(raw);
+	} catch (error) {
+		return {
+			options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
+			path,
+			found: true,
+			warning: `Could not parse ${path}: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+
+	const section = isRecord(parsed) ? parsed[MASTRA_AGENT_EXTENSION_CONFIG_KEY] : undefined;
+	if (section === undefined) return { options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS }, path, found: true };
+	if (!isRecord(section)) {
+		return {
+			options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
+			path,
+			found: true,
+			warning: `${MASTRA_AGENT_EXTENSION_CONFIG_KEY} in ${path} must be a mapping`,
+		};
+	}
+
+	const warnings: string[] = [];
+	const maxCards = readPositiveInteger(section.maxCards, "maxCards", warnings);
+	const maxLines = readPositiveInteger(section.maxLines, "maxLines", warnings);
+	return {
+		options: {
+			maxCards: maxCards ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards,
+			maxLines: maxLines ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxLines,
+		},
+		path,
+		found: true,
+		warning: warnings.length > 0 ? `Ignoring invalid ${MASTRA_AGENT_EXTENSION_CONFIG_KEY} values in ${path}: ${warnings.join(", ")}` : undefined,
+	};
+}
+
+function readPositiveInteger(value: unknown, name: string, warnings: string[]): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) return Math.floor(value);
+	warnings.push(name);
+	return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}

--- a/pi/src/extensions/config.ts
+++ b/pi/src/extensions/config.ts
@@ -1,16 +1,32 @@
+import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parse } from "yaml";
-import type { MastraAgentsWidgetOptions } from "../tui/index.js";
+import type { MastraAgentsViewMode, MastraAgentsWidgetOptions } from "../tui/index.js";
 
 export const MASTRA_AGENT_EXTENSION_CONFIG_KEY = "mastra-agent-extension";
 export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidgetOptions, "maxCards" | "maxLines">> = {
 	maxCards: 4,
 	maxLines: 60,
 };
+export const DEFAULT_MASTRA_AGENT_VIEW_MODE: MastraAgentsViewMode = "list";
+export const DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS: MastraAgentExtensionShortcuts = {
+	viewMode: "ctrl+h",
+	nextAgent: "ctrl+down",
+	previousAgent: "ctrl+up",
+};
+
+export interface MastraAgentExtensionShortcuts {
+	viewMode: string;
+	nextAgent: string;
+	previousAgent: string;
+}
 
 export interface MastraAgentExtensionConfigResult {
 	options: MastraAgentsWidgetOptions;
+	debugPiRedraw: boolean;
+	defaultViewMode: MastraAgentsViewMode;
+	shortcuts: MastraAgentExtensionShortcuts;
 	warning?: string;
 	path: string;
 	found: boolean;
@@ -23,35 +39,51 @@ export async function loadMastraAgentExtensionConfig(cwd: string): Promise<Mastr
 		raw = await readFile(path, "utf8");
 	} catch (error) {
 		if (isNodeError(error) && error.code === "ENOENT") {
-			return { options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS }, path, found: false };
+			return defaultConfigResult(path, false);
 		}
 		return {
-			options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
+			...defaultConfigResult(path, false),
 			path,
-			found: false,
 			warning: `Could not read ${path}: ${error instanceof Error ? error.message : String(error)}`,
 		};
 	}
 
+	return parseMastraAgentExtensionConfig(raw, path);
+}
+
+export function loadMastraAgentExtensionConfigSync(cwd: string): MastraAgentExtensionConfigResult {
+	const path = join(cwd, "config.yaml");
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf8");
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return defaultConfigResult(path, false);
+		}
+		return {
+			...defaultConfigResult(path, false),
+			warning: `Could not read ${path}: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	return parseMastraAgentExtensionConfig(raw, path);
+}
+
+function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgentExtensionConfigResult {
 	let parsed: unknown;
 	try {
 		parsed = parse(raw);
 	} catch (error) {
 		return {
-			options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
-			path,
-			found: true,
+			...defaultConfigResult(path, true),
 			warning: `Could not parse ${path}: ${error instanceof Error ? error.message : String(error)}`,
 		};
 	}
 
 	const section = isRecord(parsed) ? parsed[MASTRA_AGENT_EXTENSION_CONFIG_KEY] : undefined;
-	if (section === undefined) return { options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS }, path, found: true };
+	if (section === undefined) return defaultConfigResult(path, true);
 	if (!isRecord(section)) {
 		return {
-			options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
-			path,
-			found: true,
+			...defaultConfigResult(path, true),
 			warning: `${MASTRA_AGENT_EXTENSION_CONFIG_KEY} in ${path} must be a mapping`,
 		};
 	}
@@ -59,10 +91,30 @@ export async function loadMastraAgentExtensionConfig(cwd: string): Promise<Mastr
 	const warnings: string[] = [];
 	const maxCards = readPositiveInteger(section.maxCards, "maxCards", warnings);
 	const maxLines = readPositiveInteger(section.maxLines, "maxLines", warnings);
+	const listMaxLines = readPositiveInteger(section.listMaxLines, "listMaxLines", warnings);
+	const reservedRows = readNonNegativeInteger(section.reservedRows, "reservedRows", warnings);
+	const debug = readBoolean(section.debug, "debug", warnings);
+	const debugPiRedraw = readBoolean(section.debugPiRedraw, "debugPiRedraw", warnings);
+	const debugLogPath = readString(section.debugLogPath, "debugLogPath", warnings);
+	const defaultViewMode = readViewMode(section.defaultViewMode, "defaultViewMode", warnings);
+	const viewModeShortcut = readString(section.viewModeShortcut, "viewModeShortcut", warnings);
+	const nextAgentShortcut = readString(section.nextAgentShortcut, "nextAgentShortcut", warnings);
+	const previousAgentShortcut = readString(section.previousAgentShortcut, "previousAgentShortcut", warnings);
 	return {
 		options: {
 			maxCards: maxCards ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards,
 			maxLines: maxLines ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxLines,
+			...(listMaxLines !== undefined ? { listMaxLines } : {}),
+			...(reservedRows !== undefined ? { reservedRows } : {}),
+			...(debug !== undefined ? { debug } : {}),
+			...(debugLogPath !== undefined ? { debugLogPath } : {}),
+		},
+		debugPiRedraw: debugPiRedraw ?? debug ?? false,
+		defaultViewMode: defaultViewMode ?? DEFAULT_MASTRA_AGENT_VIEW_MODE,
+		shortcuts: {
+			viewMode: viewModeShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.viewMode,
+			nextAgent: nextAgentShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.nextAgent,
+			previousAgent: previousAgentShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.previousAgent,
 		},
 		path,
 		found: true,
@@ -70,9 +122,48 @@ export async function loadMastraAgentExtensionConfig(cwd: string): Promise<Mastr
 	};
 }
 
+function defaultConfigResult(path: string, found: boolean): MastraAgentExtensionConfigResult {
+	return {
+		options: { ...DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS },
+		debugPiRedraw: false,
+		defaultViewMode: DEFAULT_MASTRA_AGENT_VIEW_MODE,
+		shortcuts: { ...DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS },
+		path,
+		found,
+	};
+}
+
 function readPositiveInteger(value: unknown, name: string, warnings: string[]): number | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value === "number" && Number.isFinite(value) && value > 0) return Math.floor(value);
+	warnings.push(name);
+	return undefined;
+}
+
+function readNonNegativeInteger(value: unknown, name: string, warnings: string[]): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) return Math.floor(value);
+	warnings.push(name);
+	return undefined;
+}
+
+function readBoolean(value: unknown, name: string, warnings: string[]): boolean | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "boolean") return value;
+	warnings.push(name);
+	return undefined;
+}
+
+function readString(value: unknown, name: string, warnings: string[]): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "string" && value.trim().length > 0) return value;
+	warnings.push(name);
+	return undefined;
+}
+
+function readViewMode(value: unknown, name: string, warnings: string[]): MastraAgentsViewMode | undefined {
+	if (value === undefined) return undefined;
+	if (value === "list" || value === "cards" || value === "detail") return value;
 	warnings.push(name);
 	return undefined;
 }

--- a/pi/src/extensions/config.ts
+++ b/pi/src/extensions/config.ts
@@ -5,9 +5,10 @@ import { parse } from "yaml";
 import type { MastraAgentsViewMode, MastraAgentsWidgetOptions } from "../tui/index.js";
 
 export const MASTRA_AGENT_EXTENSION_CONFIG_KEY = "mastra-agent-extension";
-export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidgetOptions, "maxCards" | "maxLines">> = {
+export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidgetOptions, "maxCards" | "maxLines" | "listMaxAgents">> = {
 	maxCards: 4,
 	maxLines: 60,
+	listMaxAgents: 5,
 };
 export const DEFAULT_MASTRA_AGENT_VIEW_MODE: MastraAgentsViewMode = "list";
 export const DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS: MastraAgentExtensionShortcuts = {
@@ -92,6 +93,7 @@ function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgent
 	const maxCards = readPositiveInteger(section.maxCards, "maxCards", warnings);
 	const maxLines = readPositiveInteger(section.maxLines, "maxLines", warnings);
 	const listMaxLines = readPositiveInteger(section.listMaxLines, "listMaxLines", warnings);
+	const listMaxAgents = readPositiveInteger(section.listMaxAgents, "listMaxAgents", warnings);
 	const reservedRows = readNonNegativeInteger(section.reservedRows, "reservedRows", warnings);
 	const debug = readBoolean(section.debug, "debug", warnings);
 	const debugPiRedraw = readBoolean(section.debugPiRedraw, "debugPiRedraw", warnings);
@@ -104,6 +106,7 @@ function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgent
 		options: {
 			maxCards: maxCards ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards,
 			maxLines: maxLines ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxLines,
+			listMaxAgents: listMaxAgents ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.listMaxAgents,
 			...(listMaxLines !== undefined ? { listMaxLines } : {}),
 			...(reservedRows !== undefined ? { reservedRows } : {}),
 			...(debug !== undefined ? { debug } : {}),

--- a/pi/src/extensions/index.test.ts
+++ b/pi/src/extensions/index.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MASTRA_AGENT_QUERY_TOOL_NAME, MASTRA_AGENT_RESULT_MESSAGE_TYPE, MASTRA_PI_AGENT_JOB_WORKFLOW_ID, MASTRA_STATUS_KEY } from "../const.js";
+import type { MastraAgentAsyncJobSummary } from "../mastra/index.js";
+import mastraPiExtension, { completionJobIdFromMessageEnd, formatAsyncAgentCompletion, hasCompletionReminder } from "./index.js";
+
+const stubTheme: Record<string, (...args: string[]) => string> = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+	dim: (text: string) => text,
+};
+
+test("formatAsyncAgentCompletion emits a system reminder with queued lifecycle and artifact chaining hint", () => {
+	const text = formatAsyncAgentCompletion(fakeSummary({
+		jobId: "job-1",
+		jobName: "audit",
+		agentId: "validator-agent",
+		status: "done",
+		lifecycleStatus: "agent_response_queued",
+		threadId: "thread-1",
+		runId: "run-1",
+		artifactPath: "/tmp/output.txt",
+		toolCalls: 1,
+		toolResults: 1,
+	}));
+
+	assert.ok(text.startsWith("<system-reminder>\n"));
+	assert.ok(text.endsWith("\n</system-reminder>"));
+	assert.match(text, /Asynchronous Mastra agent task completed: job-1/);
+	assert.match(text, /lifecycleStatus: agent_response_queued/);
+	assert.match(text, /threadId: thread-1/);
+	assert.match(text, /runId: run-1/);
+	assert.match(text, /artifactPath: \/tmp\/output.txt/);
+	assert.match(text, /Use agent_read with jobId=job-1/);
+	assert.match(text, /artifactPath can be passed as an input_args value/);
+});
+
+test("completionJobIdFromMessageEnd only accepts matching custom completion messages", () => {
+	assert.equal(
+		completionJobIdFromMessageEnd({
+			message: {
+				role: "custom",
+				customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE,
+				details: { jobId: "job-1" },
+			},
+		}),
+		"job-1",
+	);
+	assert.equal(
+		completionJobIdFromMessageEnd({
+			message: {
+				role: "custom",
+				customType: "other",
+				details: { jobId: "job-1" },
+			},
+		}),
+		undefined,
+	);
+	assert.equal(
+		completionJobIdFromMessageEnd({
+			message: {
+				role: "assistant",
+				customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE,
+				details: { jobId: "job-1" },
+			},
+		}),
+		undefined,
+	);
+	assert.equal(completionJobIdFromMessageEnd({ message: { role: "custom", customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE, details: {} } }), undefined);
+});
+
+test("hasCompletionReminder matches persisted custom completion entries by job id", () => {
+	const entries = [
+		{ type: "custom_message", customType: "other", details: { jobId: "job-1" } },
+		{ type: "assistant_message", customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE, details: { jobId: "job-1" } },
+		{ type: "custom_message", customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE, details: { jobId: "job-2" } },
+	];
+
+	assert.equal(hasCompletionReminder(entries, "job-1"), false);
+	assert.equal(hasCompletionReminder(entries, "job-2"), true);
+});
+
+test("extension queues async agent completion as steer reminder and message_end collapses activity", async () => {
+	const originalFetch = globalThis.fetch;
+	const registeredTools: any[] = [];
+	const handlers = new Map<string, (...args: any[]) => unknown>();
+	const sentMessages: Array<{ message: any; options: any }> = [];
+	const statusCalls: Array<{ key: string; value: string }> = [];
+	let widgetFactory: ((tui: any, theme: any) => any) | undefined;
+
+	globalThis.fetch = (async (url: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => {
+		const requestUrl = String(url);
+		if (requestUrl.endsWith("/agents?partial=true")) {
+			return new Response(JSON.stringify({ "validator-agent": { id: "validator-agent", name: "Validator" } }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}
+		if (requestUrl.endsWith("/workflows?partial=true")) {
+			return new Response(JSON.stringify({ [MASTRA_PI_AGENT_JOB_WORKFLOW_ID]: { steps: {}, allSteps: {}, stepGraph: [] } }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}
+		if (requestUrl.includes(`/workflows/${encodeURIComponent(MASTRA_PI_AGENT_JOB_WORKFLOW_ID)}/runs?`)) {
+			return new Response(JSON.stringify({ runs: [] }), { status: 200, headers: { "content-type": "application/json" } });
+		}
+		if (requestUrl.includes(`/workflows/${encodeURIComponent(MASTRA_PI_AGENT_JOB_WORKFLOW_ID)}/stream?`)) {
+			return new Response(
+				`data: ${JSON.stringify({ type: "pi-agent-stream-chunk", payload: { chunk: { type: "finish" } } })}\n\ndata: [DONE]\n\n`,
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}
+		if (requestUrl.includes(`/workflows/${encodeURIComponent(MASTRA_PI_AGENT_JOB_WORKFLOW_ID)}/runs/`)) {
+			return new Response(
+				JSON.stringify({
+					workflowName: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
+					runId: requestUrl.split("/runs/")[1]?.split("?")[0] ?? "run",
+					status: "success",
+					result: { text: "extension result" },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}
+		return new Response("not found", { status: 404, statusText: "Not Found" });
+	}) as typeof fetch;
+
+	try {
+		const pi = {
+			registerTool(tool: any) {
+				registeredTools.push(tool);
+			},
+			registerMessageRenderer() {},
+			registerCommand() {},
+			on(event: string, handler: (...args: any[]) => unknown) {
+				handlers.set(event, handler);
+			},
+			sendMessage(message: any, options: any) {
+				sentMessages.push({ message, options });
+			},
+		};
+		mastraPiExtension(pi as any);
+
+		const sessionStart = handlers.get("session_start");
+		assert.equal(typeof sessionStart, "function");
+		await sessionStart?.(
+			{},
+			{
+				cwd: "/workspace/project",
+				hasUI: true,
+				sessionManager: {
+					getSessionId: () => "session-extension",
+					getEntries: () => [],
+				},
+				ui: {
+					notify() {},
+					setWidget(_id: string, factory: (tui: any, theme: any) => any) {
+						widgetFactory = factory;
+					},
+					setStatus(key: string, value: string) {
+						statusCalls.push({ key, value });
+					},
+				},
+			},
+		);
+		assert.equal(typeof widgetFactory, "function");
+		const widget = widgetFactory!({ requestRender() {} }, stubTheme as any);
+
+		const queryTool = registeredTools.find((tool) => tool.name === MASTRA_AGENT_QUERY_TOOL_NAME);
+		assert.ok(queryTool, "agent_query tool should be registered by the extension");
+		await queryTool.execute("call", { agentId: "validator-agent", message: "prompt", jobName: "extension job" });
+
+		await waitFor(() => sentMessages.length === 1);
+		const sent = sentMessages[0];
+		assert.deepEqual(sent.options, { deliverAs: "steer", triggerTurn: true });
+		assert.equal(sent.message.customType, MASTRA_AGENT_RESULT_MESSAGE_TYPE);
+		assert.equal(sent.message.display, true);
+		assert.match(sent.message.content, /^<system-reminder>\nAsynchronous Mastra agent task completed:/);
+		assert.equal(sent.message.details.lifecycleStatus, "agent_response_queued");
+		assert.equal(sent.message.details.status, "done");
+		assert.ok(statusCalls.some((call) => call.key === MASTRA_STATUS_KEY && call.value === "mastra: 1 running"));
+		assert.ok(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "queued completion should keep widget card visible");
+
+		const messageEnd = handlers.get("message_end");
+		assert.equal(typeof messageEnd, "function");
+		await messageEnd?.({
+			message: {
+				role: "custom",
+				customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE,
+				details: { jobId: "other-job" },
+			},
+		});
+		assert.ok(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "unmatched message_end should not collapse the card");
+
+		await messageEnd?.({
+			message: {
+				role: "custom",
+				customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE,
+				details: { jobId: sent.message.details.jobId },
+			},
+		});
+
+		assert.equal(statusCalls.at(-1)?.key, MASTRA_STATUS_KEY);
+		assert.equal(statusCalls.at(-1)?.value, "mastra: 1 agents, 1 workflows");
+		assert.deepEqual(widget.render(100), []);
+		widget.dispose();
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+function fakeSummary(overrides: Partial<MastraAgentAsyncJobSummary> = {}): MastraAgentAsyncJobSummary {
+	return {
+		jobId: "job",
+		jobName: "job",
+		agentId: "agent",
+		threadId: "thread",
+		resourceId: "resource",
+		status: "done",
+		lifecycleStatus: "agent_response_queued",
+		textPreview: "",
+		toolCalls: 0,
+		toolResults: 0,
+		rawChunkCount: 0,
+		chunksTruncated: false,
+		errors: [],
+		...overrides,
+	};
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) throw new Error("Timed out waiting for predicate");
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}

--- a/pi/src/extensions/index.test.ts
+++ b/pi/src/extensions/index.test.ts
@@ -84,9 +84,12 @@ test("extension queues async agent completion as steer reminder and message_end 
 	const originalFetch = globalThis.fetch;
 	const registeredTools: any[] = [];
 	const handlers = new Map<string, (...args: any[]) => unknown>();
+	const shortcuts = new Map<string, { handler: (ctx: any) => unknown }>();
 	const sentMessages: Array<{ message: any; options: any }> = [];
 	const statusCalls: Array<{ key: string; value: string }> = [];
-	let widgetFactory: ((tui: any, theme: any) => any) | undefined;
+	const widgetFactories = new Map<string, (tui: any, theme: any) => any>();
+	let workflowStreamCalls = 0;
+	let agentStreamCalls = 0;
 
 	globalThis.fetch = (async (url: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => {
 		const requestUrl = String(url);
@@ -106,8 +109,22 @@ test("extension queues async agent completion as steer reminder and message_end 
 			return new Response(JSON.stringify({ runs: [] }), { status: 200, headers: { "content-type": "application/json" } });
 		}
 		if (requestUrl.includes(`/workflows/${encodeURIComponent(MASTRA_PI_AGENT_JOB_WORKFLOW_ID)}/stream?`)) {
+			workflowStreamCalls += 1;
 			return new Response(
 				`data: ${JSON.stringify({ type: "pi-agent-stream-chunk", payload: { chunk: { type: "finish" } } })}\n\ndata: [DONE]\n\n`,
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}
+		if (requestUrl.endsWith("/agents/validator-agent/stream")) {
+			agentStreamCalls += 1;
+			return new Response(
+				[
+					`data: ${JSON.stringify({ type: "tool-call", toolCallId: "tool-1", toolName: "read_file", args: { path: "src/index.ts" } })}\n\n`,
+					`data: ${JSON.stringify({ type: "tool-result", toolCallId: "tool-1", toolName: "read_file", result: "ok" })}\n\n`,
+					`data: ${JSON.stringify({ type: "text-delta", text: "extension result" })}\n\n`,
+					`data: ${JSON.stringify({ type: "finish" })}\n\n`,
+					"data: [DONE]\n\n",
+				].join(""),
 				{ status: 200, headers: { "content-type": "text/event-stream" } },
 			);
 		}
@@ -132,6 +149,9 @@ test("extension queues async agent completion as steer reminder and message_end 
 			},
 			registerMessageRenderer() {},
 			registerCommand() {},
+			registerShortcut(shortcut: string, options: { handler: (ctx: any) => unknown }) {
+				shortcuts.set(shortcut, options);
+			},
 			on(event: string, handler: (...args: any[]) => unknown) {
 				handlers.set(event, handler);
 			},
@@ -154,8 +174,9 @@ test("extension queues async agent completion as steer reminder and message_end 
 				},
 				ui: {
 					notify() {},
-					setWidget(_id: string, factory: (tui: any, theme: any) => any) {
-						widgetFactory = factory;
+					setWidget(id: string, factory: ((tui: any, theme: any) => any) | undefined) {
+						if (factory) widgetFactories.set(id, factory);
+						else widgetFactories.delete(id);
 					},
 					setStatus(key: string, value: string) {
 						statusCalls.push({ key, value });
@@ -163,8 +184,10 @@ test("extension queues async agent completion as steer reminder and message_end 
 				},
 			},
 		);
-		assert.equal(typeof widgetFactory, "function");
-		const widget = widgetFactory!({ requestRender() {} }, stubTheme as any);
+		assert.equal(typeof widgetFactories.get("mastra-agents-list"), "function");
+		assert.equal(typeof widgetFactories.get("mastra-agents-region"), "function");
+		const listWidget = widgetFactories.get("mastra-agents-list")!({ requestRender() {} }, stubTheme as any);
+		const regionWidget = widgetFactories.get("mastra-agents-region")!({ requestRender() {} }, stubTheme as any);
 
 		const queryTool = registeredTools.find((tool) => tool.name === MASTRA_AGENT_QUERY_TOOL_NAME);
 		assert.ok(queryTool, "agent_query tool should be registered by the extension");
@@ -178,8 +201,15 @@ test("extension queues async agent completion as steer reminder and message_end 
 		assert.match(sent.message.content, /^<system-reminder>\nAsynchronous Mastra agent task completed:/);
 		assert.equal(sent.message.details.lifecycleStatus, "agent_response_queued");
 		assert.equal(sent.message.details.status, "done");
+		assert.equal(agentStreamCalls, 1);
+		assert.equal(workflowStreamCalls, 0, "agent_query should use direct agent stream, not workflow stream");
 		assert.ok(statusCalls.some((call) => call.key === MASTRA_STATUS_KEY && call.value === "mastra: 1 running"));
-		assert.ok(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "queued completion should keep widget card visible");
+		assert.ok(listWidget.render(100).some((line: string) => line.includes("validator-agent")), "queued completion should stay visible in default list mode");
+		assert.deepEqual(regionWidget.render(100), [], "region widget should be hidden in default list mode");
+
+		assert.ok(shortcuts.has("ctrl+h"), "view mode shortcut should be registered");
+		await shortcuts.get("ctrl+h")!.handler({ ui: { notify() {} } });
+		assert.ok(regionWidget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "card mode should render queued completion in fixed region");
 
 		const messageEnd = handlers.get("message_end");
 		assert.equal(typeof messageEnd, "function");
@@ -190,7 +220,7 @@ test("extension queues async agent completion as steer reminder and message_end 
 				details: { jobId: "other-job" },
 			},
 		});
-		assert.ok(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "unmatched message_end should not collapse the card");
+		assert.ok(regionWidget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "unmatched message_end should not collapse the card");
 
 		await messageEnd?.({
 			message: {
@@ -202,8 +232,10 @@ test("extension queues async agent completion as steer reminder and message_end 
 
 		assert.equal(statusCalls.at(-1)?.key, MASTRA_STATUS_KEY);
 		assert.equal(statusCalls.at(-1)?.value, "mastra: 1 agents, 1 workflows");
-		assert.deepEqual(widget.render(100), []);
-		widget.dispose();
+		assert.deepEqual(listWidget.render(100), []);
+		assert.deepEqual(regionWidget.render(100), []);
+		listWidget.dispose();
+		regionWidget.dispose();
 	} finally {
 		globalThis.fetch = originalFetch;
 	}

--- a/pi/src/extensions/index.test.ts
+++ b/pi/src/extensions/index.test.ts
@@ -88,8 +88,11 @@ test("extension queues async agent completion as steer reminder and message_end 
 	const sentMessages: Array<{ message: any; options: any }> = [];
 	const statusCalls: Array<{ key: string; value: string }> = [];
 	const widgetFactories = new Map<string, (tui: any, theme: any) => any>();
+	const clearedWidgetIds: string[] = [];
+	const widgetCalls: Array<{ id: string; hasFactory: boolean; placement?: string }> = [];
 	let workflowStreamCalls = 0;
 	let agentStreamCalls = 0;
+	let releaseAgentFinish: (() => void) | undefined;
 
 	globalThis.fetch = (async (url: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => {
 		const requestUrl = String(url);
@@ -117,14 +120,21 @@ test("extension queues async agent completion as steer reminder and message_end 
 		}
 		if (requestUrl.endsWith("/agents/validator-agent/stream")) {
 			agentStreamCalls += 1;
+			const encoder = new TextEncoder();
 			return new Response(
-				[
-					`data: ${JSON.stringify({ type: "tool-call", toolCallId: "tool-1", toolName: "read_file", args: { path: "src/index.ts" } })}\n\n`,
-					`data: ${JSON.stringify({ type: "tool-result", toolCallId: "tool-1", toolName: "read_file", result: "ok" })}\n\n`,
-					`data: ${JSON.stringify({ type: "text-delta", text: "extension result" })}\n\n`,
-					`data: ${JSON.stringify({ type: "finish" })}\n\n`,
-					"data: [DONE]\n\n",
-				].join(""),
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode([
+							`data: ${JSON.stringify({ type: "tool-call", toolCallId: "tool-1", toolName: "read_file", args: { path: "src/index.ts" } })}\n\n`,
+							`data: ${JSON.stringify({ type: "tool-result", toolCallId: "tool-1", toolName: "read_file", result: "ok" })}\n\n`,
+							`data: ${JSON.stringify({ type: "text-delta", text: "extension result" })}\n\n`,
+						].join("")));
+						releaseAgentFinish = () => {
+							controller.enqueue(encoder.encode([`data: ${JSON.stringify({ type: "finish" })}\n\n`, "data: [DONE]\n\n"].join("")));
+							controller.close();
+						};
+					},
+				}),
 				{ status: 200, headers: { "content-type": "text/event-stream" } },
 			);
 		}
@@ -174,9 +184,13 @@ test("extension queues async agent completion as steer reminder and message_end 
 				},
 				ui: {
 					notify() {},
-					setWidget(id: string, factory: ((tui: any, theme: any) => any) | undefined) {
+					setWidget(id: string, factory: ((tui: any, theme: any) => any) | undefined, options?: { placement?: string }) {
+						widgetCalls.push({ id, hasFactory: typeof factory === "function", placement: options?.placement });
 						if (factory) widgetFactories.set(id, factory);
-						else widgetFactories.delete(id);
+						else {
+							clearedWidgetIds.push(id);
+							widgetFactories.delete(id);
+						}
 					},
 					setStatus(key: string, value: string) {
 						statusCalls.push({ key, value });
@@ -184,14 +198,25 @@ test("extension queues async agent completion as steer reminder and message_end 
 				},
 			},
 		);
-		assert.equal(typeof widgetFactories.get("mastra-agents-list"), "function");
-		assert.equal(typeof widgetFactories.get("mastra-agents-region"), "function");
-		const listWidget = widgetFactories.get("mastra-agents-list")!({ requestRender() {} }, stubTheme as any);
-		const regionWidget = widgetFactories.get("mastra-agents-region")!({ requestRender() {} }, stubTheme as any);
+		assert.deepEqual(clearedWidgetIds.slice(0, 3), ["mastra-agents", "mastra-agents-list", "mastra-agents-region"]);
+		assert.equal(widgetFactories.has("mastra-agents-list"), false);
+		assert.equal(widgetFactories.has("mastra-agents-region"), false);
+		assert.equal(widgetFactories.has("mastra-agents"), false, "single widget should stay unmounted until active work starts");
 
 		const queryTool = registeredTools.find((tool) => tool.name === MASTRA_AGENT_QUERY_TOOL_NAME);
 		assert.ok(queryTool, "agent_query tool should be registered by the extension");
-		await queryTool.execute("call", { agentId: "validator-agent", message: "prompt", jobName: "extension job" });
+		const queryPromise = queryTool.execute("call", { agentId: "validator-agent", message: "prompt", jobName: "extension job" });
+		await waitFor(() => widgetFactories.has("mastra-agents"));
+		const widget = widgetFactories.get("mastra-agents")!({ requestRender() {}, terminal: { rows: 30 } }, stubTheme as any);
+		assert.ok(widget.render(100).some((line: string) => line.includes("validator-agent")), "running job should mount the compact list surface");
+		assert.equal(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), false, "default list mode should not render a card");
+		assert.ok(shortcuts.has("ctrl+h"), "view mode shortcut should be registered");
+		await shortcuts.get("ctrl+h")!.handler({ ui: { notify() {} } });
+		assert.ok(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "card mode should render running work in fixed region");
+
+		await waitFor(() => typeof releaseAgentFinish === "function");
+		releaseAgentFinish?.();
+		await queryPromise;
 
 		await waitFor(() => sentMessages.length === 1);
 		const sent = sentMessages[0];
@@ -204,12 +229,16 @@ test("extension queues async agent completion as steer reminder and message_end 
 		assert.equal(agentStreamCalls, 1);
 		assert.equal(workflowStreamCalls, 0, "agent_query should use direct agent stream, not workflow stream");
 		assert.ok(statusCalls.some((call) => call.key === MASTRA_STATUS_KEY && call.value === "mastra: 1 running"));
-		assert.ok(listWidget.render(100).some((line: string) => line.includes("validator-agent")), "queued completion should stay visible in default list mode");
-		assert.deepEqual(regionWidget.render(100), [], "region widget should be hidden in default list mode");
-
-		assert.ok(shortcuts.has("ctrl+h"), "view mode shortcut should be registered");
-		await shortcuts.get("ctrl+h")!.handler({ ui: { notify() {} } });
-		assert.ok(regionWidget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "card mode should render queued completion in fixed region");
+		await waitFor(() => !widgetFactories.has("mastra-agents"));
+		const legacyMounts = widgetCalls.filter((call) => (call.id === "mastra-agents-list" || call.id === "mastra-agents-region") && call.hasFactory);
+		const activeMounts = widgetCalls.filter((call) => call.id === "mastra-agents" && call.hasFactory);
+		const activeMountIndex = widgetCalls.findIndex((call) => call.id === "mastra-agents" && call.hasFactory);
+		const activeUnmountsAfterMount = widgetCalls.slice(activeMountIndex + 1).filter((call) => call.id === "mastra-agents" && !call.hasFactory);
+		assert.deepEqual(legacyMounts, []);
+		assert.equal(activeMounts.length, 1, "active updates should not repeatedly remount the same widget");
+		assert.equal(activeMounts[0]?.placement, "aboveEditor");
+		assert.equal(activeUnmountsAfterMount.length, 1, "completion should unmount the active widget once");
+		assert.deepEqual(widget.render(100), [], "queued completion should no longer occupy widget rows");
 
 		const messageEnd = handlers.get("message_end");
 		assert.equal(typeof messageEnd, "function");
@@ -220,7 +249,7 @@ test("extension queues async agent completion as steer reminder and message_end 
 				details: { jobId: "other-job" },
 			},
 		});
-		assert.ok(regionWidget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "unmatched message_end should not collapse the card");
+		assert.equal(widgetFactories.has("mastra-agents"), false, "unmatched message_end should not remount completed work");
 
 		await messageEnd?.({
 			message: {
@@ -232,10 +261,8 @@ test("extension queues async agent completion as steer reminder and message_end 
 
 		assert.equal(statusCalls.at(-1)?.key, MASTRA_STATUS_KEY);
 		assert.equal(statusCalls.at(-1)?.value, "mastra: 1 agents, 1 workflows");
-		assert.deepEqual(listWidget.render(100), []);
-		assert.deepEqual(regionWidget.render(100), []);
-		listWidget.dispose();
-		regionWidget.dispose();
+		assert.deepEqual(widget.render(100), []);
+		widget.dispose();
 	} finally {
 		globalThis.fetch = originalFetch;
 	}

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -2,9 +2,12 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-cod
 import { Text, type KeyId } from "@mariozechner/pi-tui";
 import { MASTRA_AGENT_RESULT_MESSAGE_TYPE, MASTRA_STATUS_KEY } from "../const.js";
 import { MastraAsyncAgentManager, MastraHttpClient, createMastraTools } from "../mastra/index.js";
-import { MastraAgentActivityStore, MastraAgentsListWidget, MastraAgentsWidget, MastraAgentsWidgetViewController, type MastraAgentsViewMode } from "../tui/index.js";
+import { MastraAgentActivityStore, MastraAgentsWidget, MastraAgentsWidgetViewController, type MastraAgentsViewMode } from "../tui/index.js";
 import type { MastraAgentAsyncJobSummary, MastraAgentInfo, MastraWorkflowInfo, MastraWorkflowRun } from "../mastra/index.js";
 import { loadMastraAgentExtensionConfig, loadMastraAgentExtensionConfigSync, type MastraAgentExtensionShortcuts } from "./config.js";
+
+const MASTRA_AGENT_WIDGET_ID = "mastra-agents";
+const LEGACY_MASTRA_AGENT_WIDGET_IDS = [MASTRA_AGENT_WIDGET_ID, "mastra-agents-list", "mastra-agents-region"] as const;
 
 export default function mastraPiExtension(pi: ExtensionAPI) {
 	const client = new MastraHttpClient();
@@ -31,6 +34,7 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 		},
 	});
 	let unsubscribeActivityStatus: (() => void) | undefined;
+	let unmountMastraWidget: (() => void) | undefined;
 	let statusLabel = "offline";
 
 	registerMastraWidgetShortcuts(pi, startupWidgetConfig.shortcuts, viewController, activityStore);
@@ -99,31 +103,46 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		unsubscribeActivityStatus?.();
+		unmountMastraWidget?.();
+		unmountMastraWidget = undefined;
 		const piSessionId = ctx.sessionManager.getSessionId();
 		asyncAgentManager.configureSession({
 			piSessionId,
 			cwd: ctx.cwd,
 			isCompletionAcknowledged: (jobId) => hasCompletionReminder(ctx.sessionManager.getEntries(), jobId),
 		});
+		let syncMastraWidget = () => undefined;
 		if (ctx.hasUI) {
 			const widgetConfig = await loadMastraAgentExtensionConfig(ctx.cwd);
 			viewController.setMode(widgetConfig.defaultViewMode);
 			if (widgetConfig.warning) ctx.ui.notify(widgetConfig.warning, "warning");
 			if (widgetConfig.debugPiRedraw && process.env.PI_DEBUG_REDRAW === undefined) process.env.PI_DEBUG_REDRAW = "1";
-			ctx.ui.setWidget("mastra-agents", undefined);
-			ctx.ui.setWidget(
-				"mastra-agents-list",
-				(tui, theme) => new MastraAgentsListWidget(tui, theme, activityStore, { ...widgetConfig.options, viewController }),
-				{ placement: "aboveEditor" },
-			);
-			ctx.ui.setWidget(
-				"mastra-agents-region",
-				(tui, theme) => new MastraAgentsWidget(tui, theme, activityStore, { ...widgetConfig.options, fixedRegion: true, viewController }),
-				{ placement: "aboveEditor" },
-			);
+			for (const widgetId of LEGACY_MASTRA_AGENT_WIDGET_IDS) ctx.ui.setWidget(widgetId, undefined);
+			let widgetMounted = false;
+			const mountWidget = () => {
+				if (widgetMounted) return;
+				ctx.ui.setWidget(
+					MASTRA_AGENT_WIDGET_ID,
+					(tui, theme) => new MastraAgentsWidget(tui, theme, activityStore, { ...widgetConfig.options, fixedRegion: true, viewController }),
+					{ placement: "aboveEditor" },
+				);
+				widgetMounted = true;
+			};
+			const unmountWidget = () => {
+				if (!widgetMounted) return;
+				ctx.ui.setWidget(MASTRA_AGENT_WIDGET_ID, undefined);
+				widgetMounted = false;
+			};
+			syncMastraWidget = () => {
+				if (activityStore.hasVisibleActivity()) mountWidget();
+				else unmountWidget();
+			};
+			unmountMastraWidget = unmountWidget;
+			syncMastraWidget();
 		}
 		unsubscribeActivityStatus = activityStore.subscribe(() => {
 			const running = activityStore.snapshot({ includeFinished: false }).length;
+			syncMastraWidget();
 			ctx.ui.setStatus(MASTRA_STATUS_KEY, running > 0 ? `mastra: ${running} running` : `mastra: ${statusLabel}`);
 		});
 
@@ -146,6 +165,8 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async () => {
 		asyncAgentManager.detachAll("Pi session shutdown");
+		unmountMastraWidget?.();
+		unmountMastraWidget = undefined;
 		unsubscribeActivityStatus?.();
 		unsubscribeActivityStatus = undefined;
 	});

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -1,16 +1,19 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import { Text, type KeyId } from "@mariozechner/pi-tui";
 import { MASTRA_AGENT_RESULT_MESSAGE_TYPE, MASTRA_STATUS_KEY } from "../const.js";
 import { MastraAsyncAgentManager, MastraHttpClient, createMastraTools } from "../mastra/index.js";
-import { MastraAgentActivityStore, MastraAgentsWidget } from "../tui/index.js";
+import { MastraAgentActivityStore, MastraAgentsListWidget, MastraAgentsWidget, MastraAgentsWidgetViewController, type MastraAgentsViewMode } from "../tui/index.js";
 import type { MastraAgentAsyncJobSummary, MastraAgentInfo, MastraWorkflowInfo, MastraWorkflowRun } from "../mastra/index.js";
-import { loadMastraAgentExtensionConfig } from "./config.js";
+import { loadMastraAgentExtensionConfig, loadMastraAgentExtensionConfigSync, type MastraAgentExtensionShortcuts } from "./config.js";
 
 export default function mastraPiExtension(pi: ExtensionAPI) {
 	const client = new MastraHttpClient();
 	const activityStore = new MastraAgentActivityStore();
+	const startupWidgetConfig = loadMastraAgentExtensionConfigSync(process.cwd());
+	const viewController = new MastraAgentsWidgetViewController(startupWidgetConfig.defaultViewMode);
 	const asyncAgentManager = new MastraAsyncAgentManager(client, {
 		activitySink: activityStore,
+		useWorkflowJobs: false,
 		onComplete: (summary) => {
 			// Live deltas stay in MastraAgentsWidget; only the final summary becomes a
 			// transcript reminder. "steer" queues it as a system reminder as soon as
@@ -29,6 +32,8 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 	});
 	let unsubscribeActivityStatus: (() => void) | undefined;
 	let statusLabel = "offline";
+
+	registerMastraWidgetShortcuts(pi, startupWidgetConfig.shortcuts, viewController, activityStore);
 
 	for (const tool of createMastraTools(client, { agentActivitySink: activityStore, asyncAgentManager })) {
 		pi.registerTool(tool as any);
@@ -102,10 +107,18 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 		});
 		if (ctx.hasUI) {
 			const widgetConfig = await loadMastraAgentExtensionConfig(ctx.cwd);
+			viewController.setMode(widgetConfig.defaultViewMode);
 			if (widgetConfig.warning) ctx.ui.notify(widgetConfig.warning, "warning");
+			if (widgetConfig.debugPiRedraw && process.env.PI_DEBUG_REDRAW === undefined) process.env.PI_DEBUG_REDRAW = "1";
+			ctx.ui.setWidget("mastra-agents", undefined);
 			ctx.ui.setWidget(
-				"mastra-agents",
-				(tui, theme) => new MastraAgentsWidget(tui, theme, activityStore, widgetConfig.options),
+				"mastra-agents-list",
+				(tui, theme) => new MastraAgentsListWidget(tui, theme, activityStore, { ...widgetConfig.options, viewController }),
+				{ placement: "aboveEditor" },
+			);
+			ctx.ui.setWidget(
+				"mastra-agents-region",
+				(tui, theme) => new MastraAgentsWidget(tui, theme, activityStore, { ...widgetConfig.options, fixedRegion: true, viewController }),
 				{ placement: "aboveEditor" },
 			);
 		}
@@ -136,6 +149,44 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 		unsubscribeActivityStatus?.();
 		unsubscribeActivityStatus = undefined;
 	});
+}
+
+function registerMastraWidgetShortcuts(
+	pi: ExtensionAPI,
+	shortcuts: MastraAgentExtensionShortcuts,
+	viewController: MastraAgentsWidgetViewController,
+	activityStore: MastraAgentActivityStore,
+): void {
+	const registered = new Set<string>();
+	const register = (shortcut: string, description: string, handler: Parameters<ExtensionAPI["registerShortcut"]>[1]["handler"]) => {
+		if (registered.has(shortcut)) return;
+		registered.add(shortcut);
+		pi.registerShortcut(shortcut as KeyId, { description, handler });
+	};
+
+	register(shortcuts.viewMode, "Cycle Mastra agent widget view", (ctx) => {
+		const mode = viewController.cycleMode();
+		if (mode === "detail") viewController.focusNext(activityStore.snapshot({ includeFinished: false }), 0);
+		ctx.ui.notify(`Mastra agents: ${formatViewMode(mode)}`, "info");
+	});
+
+	register(shortcuts.nextAgent, "Focus next Mastra agent in detail view", (ctx) => {
+		viewController.setMode("detail");
+		const activity = viewController.focusNext(activityStore.snapshot({ includeFinished: false }), 1);
+		ctx.ui.notify(activity ? `Mastra detail: ${activity.agentId}` : "No Mastra agent jobs", "info");
+	});
+
+	register(shortcuts.previousAgent, "Focus previous Mastra agent in detail view", (ctx) => {
+		viewController.setMode("detail");
+		const activity = viewController.focusNext(activityStore.snapshot({ includeFinished: false }), -1);
+		ctx.ui.notify(activity ? `Mastra detail: ${activity.agentId}` : "No Mastra agent jobs", "info");
+	});
+}
+
+function formatViewMode(mode: MastraAgentsViewMode): string {
+	if (mode === "cards") return "card region";
+	if (mode === "detail") return "detail region";
+	return "compact list";
 }
 
 async function showStatus(client: MastraHttpClient, ctx: ExtensionCommandContext): Promise<void> {

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -4,6 +4,7 @@ import { MASTRA_AGENT_RESULT_MESSAGE_TYPE, MASTRA_STATUS_KEY } from "../const.js
 import { MastraAsyncAgentManager, MastraHttpClient, createMastraTools } from "../mastra/index.js";
 import { MastraAgentActivityStore, MastraAgentsWidget } from "../tui/index.js";
 import type { MastraAgentAsyncJobSummary, MastraAgentInfo, MastraWorkflowInfo, MastraWorkflowRun } from "../mastra/index.js";
+import { loadMastraAgentExtensionConfig } from "./config.js";
 
 export default function mastraPiExtension(pi: ExtensionAPI) {
 	const client = new MastraHttpClient();
@@ -12,8 +13,9 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 		activitySink: activityStore,
 		onComplete: (summary) => {
 			// Live deltas stay in MastraAgentsWidget; only the final summary becomes a
-			// transcript message. triggerTurn wakes the parent agent if the async job
-			// finishes after the original Pi turn has gone idle.
+			// transcript reminder. "steer" queues it as a system reminder as soon as
+			// Pi can accept context between tool calls; message_end is the ack that
+			// collapses the card.
 			pi.sendMessage(
 				{
 					customType: MASTRA_AGENT_RESULT_MESSAGE_TYPE,
@@ -21,7 +23,7 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 					display: true,
 					details: summary,
 				},
-				{ deliverAs: "followUp", triggerTurn: true },
+				{ deliverAs: "steer", triggerTurn: true },
 			);
 		},
 	});
@@ -92,8 +94,20 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		unsubscribeActivityStatus?.();
+		const piSessionId = ctx.sessionManager.getSessionId();
+		asyncAgentManager.configureSession({
+			piSessionId,
+			cwd: ctx.cwd,
+			isCompletionAcknowledged: (jobId) => hasCompletionReminder(ctx.sessionManager.getEntries(), jobId),
+		});
 		if (ctx.hasUI) {
-			ctx.ui.setWidget("mastra-agents", (tui, theme) => new MastraAgentsWidget(tui, theme, activityStore), { placement: "aboveEditor" });
+			const widgetConfig = await loadMastraAgentExtensionConfig(ctx.cwd);
+			if (widgetConfig.warning) ctx.ui.notify(widgetConfig.warning, "warning");
+			ctx.ui.setWidget(
+				"mastra-agents",
+				(tui, theme) => new MastraAgentsWidget(tui, theme, activityStore, widgetConfig.options),
+				{ placement: "aboveEditor" },
+			);
 		}
 		unsubscribeActivityStatus = activityStore.subscribe(() => {
 			const running = activityStore.snapshot({ includeFinished: false }).length;
@@ -108,10 +122,19 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 			statusLabel = "offline";
 			ctx.ui.setStatus(MASTRA_STATUS_KEY, "mastra: offline");
 		}
+
+		void asyncAgentManager.restoreSessionJobs().catch(() => undefined);
+	});
+
+	pi.on("message_end", async (event) => {
+		const message = event.message as { role?: string; customType?: string; details?: Partial<MastraAgentAsyncJobSummary> } | undefined;
+		if (message?.role !== "custom" || message.customType !== MASTRA_AGENT_RESULT_MESSAGE_TYPE) return;
+		const jobId = message.details?.jobId;
+		if (jobId) asyncAgentManager.markEnded(jobId);
 	});
 
 	pi.on("session_shutdown", async () => {
-		asyncAgentManager.cancelAll("Pi session shutdown", { suppressCompletionMessage: true });
+		asyncAgentManager.detachAll("Pi session shutdown");
 		unsubscribeActivityStatus?.();
 		unsubscribeActivityStatus = undefined;
 	});
@@ -220,16 +243,35 @@ function formatWorkflowRun(run: MastraWorkflowRun): string {
 
 function formatAsyncAgentCompletion(summary: MastraAgentAsyncJobSummary): string {
 	const lines = [
-		`Async Mastra agent job completed: ${summary.jobId}`,
+		"<system-reminder>",
+		`Asynchronous Mastra agent task completed: ${summary.jobId}`,
+		summary.jobName ? `jobName: ${summary.jobName}` : undefined,
 		`agentId: ${summary.agentId}`,
 		`status: ${summary.status}`,
+		summary.lifecycleStatus ? `lifecycleStatus: ${summary.lifecycleStatus}` : undefined,
+		summary.terminalReason ? `terminalReason: ${summary.terminalReason}` : undefined,
+		summary.incomplete ? "incomplete: true" : undefined,
 		summary.elapsedMs !== undefined ? `elapsed: ${formatDuration(summary.elapsedMs)}` : undefined,
 		summary.toolCalls + summary.toolResults > 0 ? `tools: ${summary.toolCalls + summary.toolResults}` : undefined,
+		summary.threadId ? `threadId: ${summary.threadId}` : undefined,
+		summary.runId ? `runId: ${summary.runId}` : undefined,
 		summary.artifactPath ? `artifactPath: ${summary.artifactPath}` : undefined,
 		`Use agent_read with jobId=${summary.jobId} before finalizing unless the initial user prompt explicitly said "pass the output" or "don't read the output".`,
+		summary.artifactPath ? "The artifactPath can be passed as an input_args value to another Mastra agent when chaining work." : undefined,
 		summary.errors.length > 0 ? `errors: ${summary.errors.join("; ")}` : undefined,
+		"</system-reminder>",
 	];
 	return lines.filter(Boolean).join("\n");
+}
+
+function hasCompletionReminder(entries: readonly unknown[], jobId: string): boolean {
+	return entries.some((entry) => {
+		if (typeof entry !== "object" || entry === null) return false;
+		const record = entry as Record<string, unknown>;
+		if (record.type !== "custom_message" || record.customType !== MASTRA_AGENT_RESULT_MESSAGE_TYPE) return false;
+		const details = record.details;
+		return typeof details === "object" && details !== null && (details as { jobId?: unknown }).jobId === jobId;
+	});
 }
 
 function formatDuration(ms: number): string {

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -127,9 +127,7 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("message_end", async (event) => {
-		const message = event.message as { role?: string; customType?: string; details?: Partial<MastraAgentAsyncJobSummary> } | undefined;
-		if (message?.role !== "custom" || message.customType !== MASTRA_AGENT_RESULT_MESSAGE_TYPE) return;
-		const jobId = message.details?.jobId;
+		const jobId = completionJobIdFromMessageEnd(event);
 		if (jobId) asyncAgentManager.markEnded(jobId);
 	});
 
@@ -241,7 +239,7 @@ function formatWorkflowRun(run: MastraWorkflowRun): string {
 		.join("\n");
 }
 
-function formatAsyncAgentCompletion(summary: MastraAgentAsyncJobSummary): string {
+export function formatAsyncAgentCompletion(summary: MastraAgentAsyncJobSummary): string {
 	const lines = [
 		"<system-reminder>",
 		`Asynchronous Mastra agent task completed: ${summary.jobId}`,
@@ -264,7 +262,19 @@ function formatAsyncAgentCompletion(summary: MastraAgentAsyncJobSummary): string
 	return lines.filter(Boolean).join("\n");
 }
 
-function hasCompletionReminder(entries: readonly unknown[], jobId: string): boolean {
+export function completionJobIdFromMessageEnd(event: unknown): string | undefined {
+	if (typeof event !== "object" || event === null) return undefined;
+	const message = (event as { message?: unknown }).message;
+	if (typeof message !== "object" || message === null) return undefined;
+	const record = message as { role?: unknown; customType?: unknown; details?: unknown };
+	if (record.role !== "custom" || record.customType !== MASTRA_AGENT_RESULT_MESSAGE_TYPE) return undefined;
+	const details = record.details;
+	if (typeof details !== "object" || details === null) return undefined;
+	const jobId = (details as { jobId?: unknown }).jobId;
+	return typeof jobId === "string" && jobId.length > 0 ? jobId : undefined;
+}
+
+export function hasCompletionReminder(entries: readonly unknown[], jobId: string): boolean {
 	return entries.some((entry) => {
 		if (typeof entry !== "object" || entry === null) return false;
 		const record = entry as Record<string, unknown>;

--- a/pi/src/mastra/client.test.ts
+++ b/pi/src/mastra/client.test.ts
@@ -118,26 +118,6 @@ test("streamWorkflow posts workflow payload and yields parsed chunks until DONE"
 	assert.equal(requestBody, JSON.stringify({ inputData: { hello: "world" } }));
 });
 
-test("startWorkflowAsync posts start-async payload with runId", async () => {
-	let requestUrl = "";
-	let requestBody = "";
-	const client = new MastraHttpClient({
-		fetchImpl: async (url, init) => {
-			requestUrl = String(url);
-			requestBody = String(init?.body);
-			return new Response(JSON.stringify({ runId: "run-1" }), {
-				status: 200,
-				headers: { "content-type": "application/json" },
-			});
-		},
-	});
-
-	const result = await client.startWorkflowAsync("pi.agent-job", "run-1", { inputData: { jobId: "job" }, resourceId: "resource" });
-	assert.deepEqual(result, { runId: "run-1" });
-	assert.match(requestUrl, /\/workflows\/pi\.agent-job\/start-async\?runId=run-1$/);
-	assert.equal(requestBody, JSON.stringify({ inputData: { jobId: "job" }, resourceId: "resource" }));
-});
-
 test("observeWorkflow posts observe payload and yields parsed chunks until DONE", async () => {
 	let requestUrl = "";
 	const body = new ReadableStream<Uint8Array>({
@@ -178,6 +158,35 @@ test("listWorkflowRuns parses runs wrapper and forwards resourceId", async () =>
 	const runs = await client.listWorkflowRuns("pi.agent-job", { resourceId: "pi:abc" });
 	assert.equal(runs[0].runId, "run-1");
 	assert.match(requestUrl, /\/workflows\/pi\.agent-job\/runs\?resourceId=pi%3Aabc$/);
+});
+
+test("listWorkflowRuns normalizes Mastra snapshot entries", async () => {
+	const client = new MastraHttpClient({
+		fetchImpl: async () => {
+			return new Response(
+				JSON.stringify({
+					runs: [
+						{
+							workflowName: "pi.agent-job",
+							runId: "canonical-run",
+							resourceId: "resource",
+							snapshot: JSON.stringify({
+								status: "success",
+								context: { input: { jobId: "job", piSessionId: "session" } },
+								result: { status: "error", text: "partial", errors: ["agent failed"] },
+							}),
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		},
+	});
+
+	const runs = await client.listWorkflowRuns("pi.agent-job");
+	assert.equal(runs[0].status, "success");
+	assert.deepEqual(runs[0].payload, { jobId: "job", piSessionId: "session" });
+	assert.deepEqual(runs[0].result, { status: "error", text: "partial", errors: ["agent failed"] });
 });
 
 test("cancelWorkflowRun posts cancel endpoint", async () => {

--- a/pi/src/mastra/client.test.ts
+++ b/pi/src/mastra/client.test.ts
@@ -118,6 +118,81 @@ test("streamWorkflow posts workflow payload and yields parsed chunks until DONE"
 	assert.equal(requestBody, JSON.stringify({ inputData: { hello: "world" } }));
 });
 
+test("startWorkflowAsync posts start-async payload with runId", async () => {
+	let requestUrl = "";
+	let requestBody = "";
+	const client = new MastraHttpClient({
+		fetchImpl: async (url, init) => {
+			requestUrl = String(url);
+			requestBody = String(init?.body);
+			return new Response(JSON.stringify({ runId: "run-1" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+
+	const result = await client.startWorkflowAsync("pi.agent-job", "run-1", { inputData: { jobId: "job" }, resourceId: "resource" });
+	assert.deepEqual(result, { runId: "run-1" });
+	assert.match(requestUrl, /\/workflows\/pi\.agent-job\/start-async\?runId=run-1$/);
+	assert.equal(requestBody, JSON.stringify({ inputData: { jobId: "job" }, resourceId: "resource" }));
+});
+
+test("observeWorkflow posts observe payload and yields parsed chunks until DONE", async () => {
+	let requestUrl = "";
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			const encoder = new TextEncoder();
+			controller.enqueue(encoder.encode('data: {"type":"workflow-step-output","payload":{"output":{"type":"text-delta","payload":{"text":"hi"}}}}\n\n'));
+			controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+			controller.close();
+		},
+	});
+	const client = new MastraHttpClient({
+		fetchImpl: async (url) => {
+			requestUrl = String(url);
+			return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+		},
+	});
+
+	const chunks = [];
+	for await (const chunk of client.observeWorkflow("pi.agent-job", "run-1", { resourceId: "resource" })) {
+		chunks.push(chunk);
+	}
+	assert.equal(chunks.length, 1);
+	assert.match(requestUrl, /\/workflows\/pi\.agent-job\/observe\?runId=run-1$/);
+});
+
+test("listWorkflowRuns parses runs wrapper and forwards resourceId", async () => {
+	let requestUrl = "";
+	const client = new MastraHttpClient({
+		fetchImpl: async (url) => {
+			requestUrl = String(url);
+			return new Response(JSON.stringify({ runs: [{ workflowName: "pi.agent-job", runId: "run-1", status: "running" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+
+	const runs = await client.listWorkflowRuns("pi.agent-job", { resourceId: "pi:abc" });
+	assert.equal(runs[0].runId, "run-1");
+	assert.match(requestUrl, /\/workflows\/pi\.agent-job\/runs\?resourceId=pi%3Aabc$/);
+});
+
+test("cancelWorkflowRun posts cancel endpoint", async () => {
+	let requestUrl = "";
+	const client = new MastraHttpClient({
+		fetchImpl: async (url) => {
+			requestUrl = String(url);
+			return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+		},
+	});
+
+	await client.cancelWorkflowRun("pi.agent-job", "run-1");
+	assert.match(requestUrl, /\/workflows\/pi\.agent-job\/runs\/run-1\/cancel$/);
+});
+
 test("streamAgent honors pre-aborted signals before fetch", async () => {
 	const abortController = new AbortController();
 	abortController.abort(new Error("already cancelled"));

--- a/pi/src/mastra/client.ts
+++ b/pi/src/mastra/client.ts
@@ -4,7 +4,11 @@ import {
 	agentsPath,
 	agentStreamPath,
 	workflowPath,
+	workflowCancelRunPath,
+	workflowObservePath,
 	workflowRunPath,
+	workflowRunsPath,
+	workflowStartAsyncPath,
 	workflowsPath,
 	workflowStreamPath,
 } from "../const.js";
@@ -15,6 +19,8 @@ import type {
 	MastraStreamRequest,
 	MastraWorkflowInfo,
 	MastraWorkflowRun,
+	MastraWorkflowRunsListInput,
+	MastraWorkflowAsyncStartRequest,
 	MastraWorkflowStreamRequest,
 	MastraWorkflowsResponse,
 } from "./types.js";
@@ -82,6 +88,49 @@ export class MastraHttpClient {
 		return body as MastraWorkflowRun;
 	}
 
+	async listWorkflowRuns(
+		workflowId: string,
+		options: MastraWorkflowRunsListInput & { signal?: AbortSignal } = {},
+	): Promise<MastraWorkflowRun[]> {
+		const body = await this.getJson(
+			workflowRunsPath(workflowId, options),
+			"Mastra workflow runs request failed",
+			options.signal,
+		);
+		if (Array.isArray(body)) return body as MastraWorkflowRun[];
+		if (isRecord(body) && Array.isArray(body.runs)) return body.runs as MastraWorkflowRun[];
+		throw new Error("Mastra workflow runs response was not an array");
+	}
+
+	async startWorkflowAsync(
+		workflowId: string,
+		runId: string,
+		payload: MastraWorkflowAsyncStartRequest,
+		options: { signal?: AbortSignal } = {},
+	): Promise<{ runId: string }> {
+		const body = await this.postJson(
+			workflowStartAsyncPath(workflowId, runId),
+			payload,
+			"Mastra workflow async start request failed",
+			options.signal,
+		);
+		if (isRecord(body) && typeof body.runId === "string") return { runId: body.runId };
+		return { runId };
+	}
+
+	async cancelWorkflowRun(
+		workflowId: string,
+		runId: string,
+		options: { signal?: AbortSignal } = {},
+	): Promise<unknown> {
+		return this.postJson(
+			workflowCancelRunPath(workflowId, runId),
+			{},
+			"Mastra workflow cancel request failed",
+			options.signal,
+		);
+	}
+
 	async *streamWorkflow(
 		workflowId: string,
 		runId: string,
@@ -92,6 +141,20 @@ export class MastraHttpClient {
 			workflowStreamPath(workflowId, runId),
 			payload,
 			"Mastra workflow stream request failed",
+			options,
+		);
+	}
+
+	async *observeWorkflow(
+		workflowId: string,
+		runId: string,
+		payload: MastraWorkflowStreamRequest = {},
+		options: { signal?: AbortSignal; timeoutMs?: number } = {},
+	): AsyncGenerator<unknown> {
+		yield* this.streamJsonEvents(
+			workflowObservePath(workflowId, runId),
+			payload,
+			"Mastra workflow observe request failed",
 			options,
 		);
 	}
@@ -115,6 +178,26 @@ export class MastraHttpClient {
 		}
 
 		return (await response.json()) as unknown;
+	}
+
+	private async postJson(path: string, payload: unknown, errorPrefix: string, signal?: AbortSignal): Promise<unknown> {
+		const response = await this.fetchImpl(joinMastraPath(this.baseUrl, path), {
+			method: "POST",
+			headers: {
+				accept: "application/json",
+				"content-type": "application/json",
+			},
+			body: JSON.stringify(payload),
+			signal,
+		});
+
+		if (!response.ok) {
+			throw new Error(`${errorPrefix}: ${response.status} ${response.statusText}: ${await response.text()}`);
+		}
+
+		const text = await response.text();
+		if (!text.trim()) return {};
+		return JSON.parse(text) as unknown;
 	}
 
 	private async *streamJsonEvents(

--- a/pi/src/mastra/client.ts
+++ b/pi/src/mastra/client.ts
@@ -8,7 +8,6 @@ import {
 	workflowObservePath,
 	workflowRunPath,
 	workflowRunsPath,
-	workflowStartAsyncPath,
 	workflowsPath,
 	workflowStreamPath,
 } from "../const.js";
@@ -20,7 +19,6 @@ import type {
 	MastraWorkflowInfo,
 	MastraWorkflowRun,
 	MastraWorkflowRunsListInput,
-	MastraWorkflowAsyncStartRequest,
 	MastraWorkflowStreamRequest,
 	MastraWorkflowsResponse,
 } from "./types.js";
@@ -85,7 +83,7 @@ export class MastraHttpClient {
 		if (!isRecord(body)) {
 			throw new Error("Mastra workflow run response was not an object");
 		}
-		return body as MastraWorkflowRun;
+		return normalizeWorkflowRun(body as MastraWorkflowRun);
 	}
 
 	async listWorkflowRuns(
@@ -97,25 +95,11 @@ export class MastraHttpClient {
 			"Mastra workflow runs request failed",
 			options.signal,
 		);
-		if (Array.isArray(body)) return body as MastraWorkflowRun[];
-		if (isRecord(body) && Array.isArray(body.runs)) return body.runs as MastraWorkflowRun[];
+		if (Array.isArray(body)) return body.map((run) => normalizeWorkflowRun(run as MastraWorkflowRun));
+		if (isRecord(body) && Array.isArray(body.runs)) {
+			return body.runs.map((run) => normalizeWorkflowRun(run as MastraWorkflowRun));
+		}
 		throw new Error("Mastra workflow runs response was not an array");
-	}
-
-	async startWorkflowAsync(
-		workflowId: string,
-		runId: string,
-		payload: MastraWorkflowAsyncStartRequest,
-		options: { signal?: AbortSignal } = {},
-	): Promise<{ runId: string }> {
-		const body = await this.postJson(
-			workflowStartAsyncPath(workflowId, runId),
-			payload,
-			"Mastra workflow async start request failed",
-			options.signal,
-		);
-		if (isRecord(body) && typeof body.runId === "string") return { runId: body.runId };
-		return { runId };
 	}
 
 	async cancelWorkflowRun(
@@ -264,4 +248,51 @@ export class MastraHttpClient {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeWorkflowRun(run: MastraWorkflowRun): MastraWorkflowRun {
+	const snapshot = parseWorkflowSnapshot(run.snapshot);
+	if (!snapshot) return run;
+	const normalized: MastraWorkflowRun = { ...run };
+	const status = stringField(run, "status") ?? stringField(snapshot, "status") ?? workflowSnapshotCurrentState(snapshot);
+	if (status) normalized.status = status;
+	if (normalized.result === undefined && "result" in snapshot) normalized.result = snapshot.result;
+	if (normalized.error === undefined && "error" in snapshot) normalized.error = snapshot.error;
+	if (normalized.payload === undefined) {
+		normalized.payload = workflowSnapshotInput(snapshot);
+	}
+	if (normalized.initialState === undefined && "value" in snapshot) normalized.initialState = snapshot.value;
+	if (normalized.serializedStepGraph === undefined && Array.isArray(snapshot.serializedStepGraph)) {
+		normalized.serializedStepGraph = snapshot.serializedStepGraph as Array<Record<string, unknown>>;
+	}
+	return normalized;
+}
+
+function parseWorkflowSnapshot(value: unknown): Record<string, unknown> | undefined {
+	if (isRecord(value)) return value;
+	if (typeof value !== "string") return undefined;
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function workflowSnapshotInput(snapshot: Record<string, unknown>): unknown {
+	const context = snapshot.context;
+	if (isRecord(context) && "input" in context) return context.input;
+	if ("input" in snapshot) return snapshot.input;
+	return undefined;
+}
+
+function workflowSnapshotCurrentState(snapshot: Record<string, unknown>): string | undefined {
+	const value = snapshot.value;
+	if (isRecord(value)) return stringField(value, "currentState");
+	return undefined;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+	const value = record[key];
+	return typeof value === "string" ? value : undefined;
 }

--- a/pi/src/mastra/memory.ts
+++ b/pi/src/mastra/memory.ts
@@ -9,7 +9,43 @@ export function defaultThreadId(agentId: string, cwd = process.cwd()): string {
 	return `${PI_THREAD_PREFIX}:${shortHash(`${cwd}:${process.pid}`)}:${agentId}`;
 }
 
+export function defaultPiSessionThreadId(params: {
+	piSessionId: string;
+	jobName: string;
+	agentName: string;
+	resourceId: string;
+}): string {
+	return [
+		PI_THREAD_PREFIX,
+		params.piSessionId,
+		params.jobName,
+		params.agentName,
+		params.resourceId,
+	].map(safeIdPart).join("-");
+}
+
+export function defaultPiSessionRunId(params: {
+	piSessionId: string;
+	jobName: string;
+	agentName: string;
+	resourceId: string;
+	jobId: string;
+}): string {
+	return [
+		PI_RESOURCE_PREFIX,
+		params.piSessionId,
+		params.jobName,
+		params.agentName,
+		params.resourceId,
+		params.jobId,
+	].map(safeIdPart).join("-");
+}
+
+export function safeIdPart(value: string): string {
+	const normalized = value.trim().replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+	return normalized || "unknown";
+}
+
 function shortHash(input: string): string {
 	return createHash("sha256").update(input).digest("hex").slice(0, 12);
 }
-

--- a/pi/src/mastra/normalize.test.ts
+++ b/pi/src/mastra/normalize.test.ts
@@ -62,6 +62,14 @@ test("sets final status and usage on finish", () => {
 	applyNormalizedEvent(details, normalizeMastraChunk({ type: "finish", usage: { totalTokens: 42 } }));
 	assert.equal(details.status, "done");
 	assert.equal(details.usage?.totalTokens, 42);
+	assert.equal(details.terminalReason, "finish");
+});
+
+test("does not treat step-finish as a terminal job finish", () => {
+	const details = makeDetails();
+	applyNormalizedEvent(details, normalizeMastraChunk({ type: "step-finish", usage: { totalTokens: 42 } }));
+	assert.equal(details.status, "running");
+	assert.equal(details.terminalReason, undefined);
 });
 
 test("records stream errors", () => {
@@ -69,6 +77,7 @@ test("records stream errors", () => {
 	applyNormalizedEvent(details, normalizeMastraChunk({ type: "error", message: "boom" }));
 	assert.equal(details.status, "error");
 	assert.deepEqual(details.errors, ["boom"]);
+	assert.equal(details.terminalReason, "error");
 });
 
 test("truncates text deterministically", () => {

--- a/pi/src/mastra/normalize.ts
+++ b/pi/src/mastra/normalize.ts
@@ -33,7 +33,6 @@ export function normalizeMastraChunk(chunk: unknown): NormalizedMastraEvent {
 		case TOOL_INPUT_END:
 			return { kind: "tool", event: makeToolEvent("input-end", chunk) };
 		case "finish":
-		case "step-finish":
 			return { kind: "finish", usage: usageFrom(chunk), raw: chunk };
 		case "error":
 			return { kind: "error", message: textFrom(chunk, "message", "error", "text") || "Mastra stream error", raw: chunk };
@@ -68,6 +67,8 @@ export function applyNormalizedEvent(details: MastraAgentCallDetails, event: Nor
 	if (event.kind === "finish") {
 		details.status = "done";
 		details.completedAt = details.updatedAt;
+		details.terminalReason = "finish";
+		details.incomplete = false;
 		if (event.usage) details.usage = event.usage;
 		return;
 	}
@@ -75,6 +76,8 @@ export function applyNormalizedEvent(details: MastraAgentCallDetails, event: Nor
 	if (event.kind === "error") {
 		details.status = "error";
 		details.completedAt = details.updatedAt;
+		details.terminalReason = "error";
+		details.incomplete = false;
 		details.errors.push(event.message);
 	}
 }

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -10,6 +10,9 @@ import {
 	normalizeInspectAgentIds,
 	MASTRA_AGENT_QUERY_PARAMETERS,
 } from "./tool.js";
+import { MASTRA_PI_AGENT_JOB_WORKFLOW_ID } from "../const.js";
+import { MastraHttpClient } from "./client.js";
+import { defaultResourceId } from "./memory.js";
 
 test("omitted modeId leaves requestContext unchanged", () => {
 	const request = createStreamRequest(
@@ -183,6 +186,29 @@ test("async agent manager uses unique default threads for concurrent jobs", asyn
 	assert.match(requests[1].memory.thread, /^pi-local-session-job-two-agent-pi-[a-f0-9]{12}$/);
 });
 
+test("async agent manager uses configured Pi session in derived thread and run ids", async () => {
+	const requests: any[] = [];
+	const manager = new MastraAsyncAgentManager({
+		async *streamAgent(_agentId: string, request: unknown) {
+			requests.push(request);
+			yield { type: "finish" };
+		},
+	} as any);
+	manager.configureSession({ piSessionId: "session-abc", cwd: "/workspace/project" });
+
+	await manager.start({ agentId: "validator-agent", message: "check this", jobId: "job-one", jobName: "review pass", finalMessage: false });
+
+	await waitFor(() => requests.length === 1);
+	const summary = manager.get("job-one");
+	const resourceId = defaultResourceId("/workspace/project");
+	assert.equal(summary?.piSessionId, "session-abc");
+	assert.equal(summary?.resourceId, resourceId);
+	assert.equal(requests[0].memory.resource, resourceId);
+	assert.equal(requests[0].memory.thread, `pi-session-abc-review-pass-validator-agent-${resourceId.replace(":", "-")}`);
+	assert.equal(summary?.threadId, requests[0].memory.thread);
+	assert.equal(summary?.runId, `pi-session-abc-review-pass-validator-agent-${resourceId.replace(":", "-")}-job-one`);
+});
+
 
 test("createMastraTools registers agent_query and preserves workflow tools", () => {
 	const manager = { start: async () => fakeAsyncSummary() } as any;
@@ -334,7 +360,8 @@ test("async agent manager honors explicit thread ids", async () => {
 
 test("async agent manager starts immediately and captures streamed output", async () => {
 	let updates = 0;
-	let completed = false;
+	const sinkEvents: string[] = [];
+	const completions: any[] = [];
 	const manager = new MastraAsyncAgentManager(
 		{
 			async *streamAgent() {
@@ -345,14 +372,19 @@ test("async agent manager starts immediately and captures streamed output", asyn
 		} as any,
 		{
 			activitySink: {
-				start() {},
+				start() {
+					sinkEvents.push("start");
+				},
 				update() {
 					updates += 1;
+					sinkEvents.push("update");
 				},
-				finish() {},
+				finish() {
+					sinkEvents.push("finish");
+				},
 			},
-			onComplete() {
-				completed = true;
+			onComplete(summary) {
+				completions.push(summary);
 			},
 		},
 	);
@@ -367,12 +399,944 @@ test("async agent manager starts immediately and captures streamed output", asyn
 	});
 	const summary = manager.get("test-job");
 	assert.equal(summary?.status, "done");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
 	assert.equal(summary?.prompt, "prompt");
 	assert.ok(updates >= 2);
-	assert.ok(completed, "onComplete should fire when finalMessage: true");
+	assert.deepEqual(sinkEvents.filter((event) => event === "finish"), ["finish"]);
+	assert.equal(completions.length, 1, "onComplete should fire once when finalMessage: true");
+	assert.equal(completions[0].lifecycleStatus, "agent_response_queued");
 
 	const output = await manager.read({ jobId: "test-job", mode: "full" });
 	assert.equal(output.text, "hello world");
+});
+
+test("async agent manager drives workflow jobs through working to queued completion", async () => {
+	const workflowStarts: any[] = [];
+	const workflowObserves: any[] = [];
+	const workflowRunReads: any[] = [];
+	const sinkEvents: string[] = [];
+	const completions: any[] = [];
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamWorkflow(workflowId: string, runId: string, payload: unknown) {
+				workflowStarts.push({ workflowId, runId, payload });
+				yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "text-delta", text: "hello" } } };
+				yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "finish", usage: { totalTokens: 7 } } } };
+			},
+			async *observeWorkflow(workflowId: string, runId: string, payload: unknown) {
+				workflowObserves.push({ workflowId, runId, payload });
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				workflowRunReads.push({ workflowId, runId });
+				return {
+					workflowName: workflowId,
+					runId,
+					status: "success",
+					result: { text: "final from workflow", artifactPath: "/tmp/output.txt", eventsPath: "/tmp/events.jsonl" },
+				};
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {
+					sinkEvents.push("start");
+				},
+				update() {
+					sinkEvents.push("update");
+				},
+				finish() {
+					sinkEvents.push("finish");
+				},
+			},
+			onComplete(summary) {
+				completions.push(summary);
+			},
+		},
+	);
+	manager.configureSession({ piSessionId: "session-abc", cwd: "/workspace/project" });
+
+	const started = await manager.start({
+		agentId: "validator-agent",
+		message: "audit this",
+		jobId: "workflow-job",
+		jobName: "audit slice",
+		requestContext: { tenant: "acme" },
+		input_args: { $1: "context" },
+	});
+
+	assert.equal(started.lifecycleStatus, "working");
+	assert.equal(started.status, "running");
+
+	await waitFor(() => manager.get("workflow-job")?.lifecycleStatus === "agent_response_queued");
+	const summary = manager.get("workflow-job");
+	const startPayload = workflowStarts[0].payload;
+	assert.equal(workflowStarts.length, 1);
+	assert.equal(workflowStarts[0].workflowId, MASTRA_PI_AGENT_JOB_WORKFLOW_ID);
+	assert.equal(startPayload.resourceId, defaultResourceId("/workspace/project"));
+	assert.equal(startPayload.inputData.jobId, "workflow-job");
+	assert.equal(startPayload.inputData.jobName, "audit-slice");
+	assert.equal(startPayload.inputData.piSessionId, "session-abc");
+	assert.equal(startPayload.inputData.runId, summary?.runId);
+	assert.equal(startPayload.inputData.agentRunId, startPayload.inputData.runId);
+	assert.equal(startPayload.inputData.threadId, summary?.threadId);
+	assert.equal(startPayload.inputData.resourceId, summary?.resourceId);
+	assert.deepEqual(startPayload.inputData.requestContext, { tenant: "acme" });
+	assert.deepEqual(startPayload.inputData.input_args, { $1: "context" });
+	assert.equal(workflowObserves.length, 0);
+	assert.equal(workflowRunReads.length, 1);
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.equal(summary?.textPreview, "hello");
+	assert.equal(summary?.artifactPath, "/tmp/output.txt");
+	assert.equal(summary?.eventsPath, "/tmp/events.jsonl");
+	assert.ok(sinkEvents.filter((event) => event === "update").length >= 2, "workflow chunks should update the live activity card");
+	assert.deepEqual(sinkEvents.filter((event) => event === "finish"), ["finish"]);
+	assert.equal(completions.length, 1);
+	assert.equal(completions[0].lifecycleStatus, "agent_response_queued");
+});
+
+test("async agent manager streams workflow jobs with deterministic run id and recovers final result text", async () => {
+	const streamCalls: any[] = [];
+	const getRunCalls: any[] = [];
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow(workflowId: string, runId: string, payload: unknown) {
+			streamCalls.push({ workflowId, runId, payload });
+			yield { type: "workflow-finish", payload: { workflowStatus: "success" } };
+		},
+		async getWorkflowRun(workflowId: string, runId: string) {
+			getRunCalls.push({ workflowId, runId });
+			return { workflowName: workflowId, runId, status: "success", result: { text: "final result text" } };
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "canonical-job", jobName: "canonical" });
+	await waitFor(() => manager.get("canonical-job")?.lifecycleStatus === "agent_response_queued");
+
+	const summary = manager.get("canonical-job");
+	assert.equal(streamCalls[0].runId, summary?.runId);
+	assert.equal(getRunCalls[0].runId, summary?.runId);
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.textPreview, "final result text");
+});
+
+test("async agent manager treats agent-level workflow output errors as failed jobs", async () => {
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow() {
+			yield { type: "workflow-finish", payload: { workflowStatus: "success" } };
+		},
+		async getWorkflowRun(workflowId: string, runId: string) {
+			return {
+				workflowName: workflowId,
+				runId,
+				status: "success",
+				result: { status: "error", text: "partial output", errors: ["agent failed"] },
+			};
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "output-error-job", jobName: "output error" });
+	await waitFor(() => manager.get("output-error-job")?.lifecycleStatus === "agent_response_queued");
+
+	const summary = manager.get("output-error-job");
+	assert.equal(summary?.status, "error");
+	assert.equal(summary?.textPreview, "partial output");
+	assert.ok(summary?.errors.includes("agent failed"));
+});
+
+test("async agent manager surfaces workflow failure as queued completion", async () => {
+	const completions: any[] = [];
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamWorkflow() {
+				yield { type: "workflow-finish", payload: { workflowStatus: "failed" } };
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "failed", error: "boom" };
+			},
+		} as any,
+		{
+			onComplete(summary) {
+				completions.push(summary);
+			},
+		},
+	);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "failed-workflow" });
+	await waitFor(() => manager.get("failed-workflow")?.lifecycleStatus === "agent_response_queued");
+
+	const summary = manager.get("failed-workflow");
+	assert.equal(summary?.status, "error");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.match(summary?.errors.join("\n") ?? "", /failed|boom/);
+	assert.equal(completions.length, 1);
+	assert.equal(completions[0].status, "error");
+});
+
+test("async agent manager detachAll aborts workflow observers without queueing completion", async () => {
+	let observeStarted = false;
+	let completed = false;
+	const sinkEvents: string[] = [];
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamWorkflow(_workflowId: string, _runId: string, _payload: unknown, options: { signal?: AbortSignal } = {}) {
+				observeStarted = true;
+				await new Promise((_resolve, reject) => {
+					options.signal?.addEventListener("abort", () => reject(options.signal?.reason ?? new Error("aborted")), { once: true });
+				});
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "running" };
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {
+					sinkEvents.push("start");
+				},
+				update() {
+					sinkEvents.push("update");
+				},
+				finish() {
+					sinkEvents.push("finish");
+				},
+				end() {
+					sinkEvents.push("end");
+				},
+				reset() {
+					sinkEvents.push("reset");
+				},
+			},
+			onComplete() {
+				completed = true;
+			},
+		},
+	);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "detach-workflow" });
+	await waitFor(() => observeStarted);
+	manager.detachAll("test shutdown");
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(manager.get("detach-workflow"), undefined);
+	assert.deepEqual(sinkEvents.filter((event) => event === "finish"), []);
+	assert.deepEqual(sinkEvents.filter((event) => event === "end"), ["end"]);
+	assert.deepEqual(sinkEvents.filter((event) => event === "reset"), ["reset"]);
+	assert.equal(completed, false);
+});
+
+test("async agent manager detachAll also stops direct fallback jobs without completion", async () => {
+	let streamStarted = false;
+	let completed = false;
+	const sinkEvents: string[] = [];
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamAgent(_agentId: string, _request: unknown, options: { signal?: AbortSignal } = {}) {
+				streamStarted = true;
+				await new Promise((_resolve, reject) => {
+					options.signal?.addEventListener("abort", () => reject(options.signal?.reason ?? new Error("aborted")), { once: true });
+				});
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {
+					sinkEvents.push("start");
+				},
+				update() {
+					sinkEvents.push("update");
+				},
+				finish() {
+					sinkEvents.push("finish");
+				},
+				end() {
+					sinkEvents.push("end");
+				},
+				reset() {
+					sinkEvents.push("reset");
+				},
+			},
+			onComplete() {
+				completed = true;
+			},
+			useWorkflowJobs: false,
+		},
+	);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "detach-direct" });
+	await waitFor(() => streamStarted);
+	manager.detachAll("test shutdown");
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(manager.get("detach-direct"), undefined);
+	assert.deepEqual(sinkEvents.filter((event) => event === "finish"), []);
+	assert.deepEqual(sinkEvents.filter((event) => event === "end"), ["end"]);
+	assert.deepEqual(sinkEvents.filter((event) => event === "reset"), ["reset"]);
+	assert.equal(completed, false);
+});
+
+test("async agent manager cancels workflow jobs without queueing a completion reminder", async () => {
+	const cancelCalls: any[] = [];
+	let observeStarted = false;
+	let completed = false;
+	const sinkEvents: string[] = [];
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamWorkflow(_workflowId: string, _runId: string, _payload: unknown, options: { signal?: AbortSignal } = {}) {
+				observeStarted = true;
+				await new Promise((_resolve, reject) => {
+					options.signal?.addEventListener("abort", () => reject(options.signal?.reason ?? new Error("aborted")), { once: true });
+				});
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "running" };
+			},
+			async cancelWorkflowRun(workflowId: string, runId: string) {
+				cancelCalls.push({ workflowId, runId });
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {
+					sinkEvents.push("start");
+				},
+				update() {
+					sinkEvents.push("update");
+				},
+				finish() {
+					sinkEvents.push("finish");
+				},
+				end() {
+					sinkEvents.push("end");
+				},
+			},
+			onComplete() {
+				completed = true;
+			},
+		},
+	);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "cancel-workflow" });
+	await waitFor(() => observeStarted);
+	const summary = await manager.cancel("cancel-workflow", "stop now");
+
+	assert.equal(summary?.status, "aborted");
+	assert.equal(summary?.lifecycleStatus, "ended");
+	assert.equal(cancelCalls.length, 1);
+	assert.deepEqual(sinkEvents.filter((event) => event === "finish"), []);
+	assert.deepEqual(sinkEvents.filter((event) => event === "end"), ["end"]);
+	assert.equal(completed, false);
+});
+
+test("async agent manager records remote workflow cancel failures", async () => {
+	let observeStarted = false;
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow(_workflowId: string, _runId: string, _payload: unknown, options: { signal?: AbortSignal } = {}) {
+			observeStarted = true;
+			await new Promise((_resolve, reject) => {
+				options.signal?.addEventListener("abort", () => reject(options.signal?.reason ?? new Error("aborted")), { once: true });
+			});
+		},
+		async getWorkflowRun(workflowId: string, runId: string) {
+			return { workflowName: workflowId, runId, status: "running" };
+		},
+		async cancelWorkflowRun() {
+			throw new Error("remote still running");
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "cancel-failure" });
+	await waitFor(() => observeStarted);
+	const summary = await manager.cancel("cancel-failure", "stop now");
+
+	assert.equal(summary?.status, "aborted");
+	assert.equal(summary?.lifecycleStatus, "ended");
+	assert.match(summary?.errors.join("\n") ?? "", /Remote workflow cancellation failed: remote still running/);
+});
+
+test("async agent manager does not rewrite already-finished jobs as aborted on cancel", async () => {
+	let releaseObserve!: () => void;
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow() {
+			yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "finish" } } };
+			await new Promise<void>((resolve) => {
+				releaseObserve = resolve;
+			});
+		},
+		async getWorkflowRun(workflowId: string, runId: string) {
+			return { workflowName: workflowId, runId, status: "success" };
+		},
+		async cancelWorkflowRun() {
+			throw new Error("cancel should not reach server after finish");
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "finish-race" });
+	await waitFor(() => manager.get("finish-race")?.status === "done");
+	const summary = await manager.cancel("finish-race", "too late");
+	releaseObserve();
+
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.equal(summary?.terminalReason, "finish");
+});
+
+test("async agent manager refreshes remote terminal workflow before canceling local-running jobs", async () => {
+	let observeStarted = false;
+	let releaseObserve!: () => void;
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow() {
+			observeStarted = true;
+			await new Promise<void>((resolve) => {
+				releaseObserve = resolve;
+			});
+		},
+		async getWorkflowRun(workflowId: string, runId: string) {
+			return { workflowName: workflowId, runId, status: "success", result: { text: "remote done" } };
+		},
+		async cancelWorkflowRun() {
+			throw new Error("cancel should not be called for terminal workflow");
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "remote-finished" });
+	await waitFor(() => observeStarted);
+	const summary = await manager.cancel("remote-finished", "too late");
+
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.equal(summary?.textPreview, "remote done");
+	releaseObserve();
+});
+
+test("async agent manager falls back to direct stream when workflow stream fails before agent chunks", async () => {
+	const directRequests: any[] = [];
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow() {
+			throw new Error("stream route missing");
+		},
+		async *streamAgent(_agentId: string, request: unknown) {
+			directRequests.push(request);
+			yield { type: "text-delta", text: "fallback" };
+			yield { type: "finish" };
+		},
+	} as any);
+	manager.configureSession({ piSessionId: "session-fallback", cwd: "/workspace/project" });
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "fallback-job", jobName: "fallback job" });
+	await waitFor(() => manager.get("fallback-job")?.lifecycleStatus === "agent_response_queued");
+
+	const summary = manager.get("fallback-job");
+	assert.equal(directRequests.length, 1);
+	assert.equal(directRequests[0].memory.thread, summary?.threadId);
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.textPreview, "fallback");
+	assert.match(summary?.errors.join("\n") ?? "", /Workflow job runner unavailable, falling back to direct stream: stream route missing/);
+});
+
+test("async agent manager does not fall back to direct stream after workflow agent chunks", async () => {
+	let directCalls = 0;
+	const manager = new MastraAsyncAgentManager({
+		async *streamWorkflow() {
+			yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "text-delta", text: "partial" } } };
+			throw new Error("workflow failed after streaming");
+		},
+		async *streamAgent() {
+			directCalls += 1;
+			throw new Error("direct fallback should not be called after workflow chunks");
+		},
+	} as any);
+	manager.configureSession({ piSessionId: "session-no-fallback", cwd: "/workspace/project" });
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "no-fallback-job", jobName: "no fallback" });
+	await waitFor(() => manager.get("no-fallback-job")?.lifecycleStatus === "agent_response_queued");
+
+	const summary = manager.get("no-fallback-job");
+	assert.equal(directCalls, 0);
+	assert.equal(summary?.status, "error");
+	assert.equal(summary?.textPreview, "partial");
+	assert.match(summary?.errors.join("\n") ?? "", /workflow failed after streaming/);
+});
+
+test("restoring terminal workflow jobs queues each completion reminder once", async () => {
+	const finishEvents: string[] = [];
+	const completions: any[] = [];
+	const resourceId = defaultResourceId("/workspace/project");
+	const runId = `pi-session-restore-review-agent-${resourceId.replace(":", "-")}-restore-job`;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *observeWorkflow() {
+				throw new Error("terminal restored jobs should not be observed");
+			},
+			async listWorkflowRuns(workflowId: string) {
+				return [
+					{
+						workflowName: workflowId,
+						runId,
+						resourceId,
+						status: "success",
+						result: { text: "restored output" },
+						inputData: {
+							jobId: "restore-job",
+							jobName: "review",
+							piSessionId: "session-restore",
+							agentId: "agent",
+							message: "prompt",
+							threadId: `pi-session-restore-review-agent-${resourceId.replace(":", "-")}`,
+							resourceId,
+						},
+					},
+				];
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "success", result: { text: "restored output" } };
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {},
+				update() {},
+				finish() {
+					finishEvents.push("finish");
+				},
+			},
+			onComplete(summary) {
+				completions.push(summary);
+			},
+		},
+	);
+	manager.configureSession({ piSessionId: "session-restore", cwd: "/workspace/project", isCompletionAcknowledged: () => false });
+
+	await manager.restoreSessionJobs();
+	await manager.restoreSessionJobs();
+
+	const summary = manager.get("restore-job");
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.deepEqual(finishEvents, ["finish"]);
+	assert.equal(completions.length, 1);
+});
+
+test("restoring acknowledged terminal workflow jobs marks ended without queueing another reminder", async () => {
+	const finishEvents: string[] = [];
+	const endEvents: string[] = [];
+	const completions: any[] = [];
+	const resourceId = defaultResourceId("/workspace/project");
+	const runId = `pi-session-ack-review-agent-${resourceId.replace(":", "-")}-ack-job`;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *observeWorkflow() {
+				throw new Error("terminal restored jobs should not be observed");
+			},
+			async listWorkflowRuns(workflowId: string) {
+				return [
+					{
+						workflowName: workflowId,
+						runId,
+						resourceId,
+						status: "success",
+						result: { text: "already reminded" },
+						inputData: {
+							jobId: "ack-job",
+							jobName: "review",
+							piSessionId: "session-ack",
+							agentId: "agent",
+							message: "prompt",
+							threadId: `pi-session-ack-review-agent-${resourceId.replace(":", "-")}`,
+							resourceId,
+						},
+					},
+				];
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "success", result: { text: "already reminded" } };
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {},
+				update() {},
+				finish(jobId) {
+					finishEvents.push(jobId);
+				},
+				end(jobId) {
+					endEvents.push(jobId);
+				},
+			},
+			onComplete(summary) {
+				completions.push(summary);
+			},
+		},
+	);
+	manager.configureSession({ piSessionId: "session-ack", cwd: "/workspace/project", isCompletionAcknowledged: (jobId) => jobId === "ack-job" });
+
+	await manager.restoreSessionJobs();
+
+	const summary = manager.get("ack-job");
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.lifecycleStatus, "ended");
+	assert.deepEqual(finishEvents, []);
+	assert.deepEqual(endEvents, ["ack-job"]);
+	assert.deepEqual(completions, []);
+});
+
+test("restoring terminal workflow jobs uses input piSessionId before run id naming and preserves output errors", async () => {
+	const completions: any[] = [];
+	const resourceId = defaultResourceId("/workspace/project");
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *observeWorkflow() {
+				throw new Error("terminal restored jobs should not be observed");
+			},
+			async listWorkflowRuns(workflowId: string) {
+				return [
+					{
+						workflowName: workflowId,
+						runId: "canonical-run-from-store",
+						resourceId,
+						status: "success",
+						result: { status: "error", text: "partial restored output", errors: ["restored agent failed"] },
+						inputData: {
+							jobId: "canonical-restore-job",
+							jobName: "review",
+							piSessionId: "session-canonical",
+							agentId: "agent",
+							message: "prompt",
+							threadId: "pi-session-canonical-review-agent-resource",
+							resourceId,
+						},
+					},
+				];
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return {
+					workflowName: workflowId,
+					runId,
+					status: "success",
+					result: { status: "error", text: "partial restored output", errors: ["restored agent failed"] },
+				};
+			},
+		} as any,
+		{
+			onComplete(summary) {
+				completions.push(summary);
+			},
+		},
+	);
+	manager.configureSession({ piSessionId: "session-canonical", cwd: "/workspace/project", isCompletionAcknowledged: () => false });
+
+	await manager.restoreSessionJobs();
+
+	const summary = manager.get("canonical-restore-job");
+	assert.equal(summary?.runId, "canonical-run-from-store");
+	assert.equal(summary?.status, "error");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.equal(summary?.textPreview, "partial restored output");
+	assert.ok(summary?.errors.includes("restored agent failed"));
+	assert.equal(completions.length, 1);
+});
+
+test("restoring terminal workflow jobs handles real Mastra snapshot list shape", async () => {
+	const completions: any[] = [];
+	const requestUrls: string[] = [];
+	const resourceId = defaultResourceId("/workspace/project");
+	const inputData = {
+		jobId: "snapshot-restore-job",
+		jobName: "review",
+		piSessionId: "session-snapshot",
+		agentId: "agent",
+		message: "prompt",
+		threadId: "pi-session-snapshot-review-agent-resource",
+		resourceId,
+	};
+	const client = new MastraHttpClient({
+		fetchImpl: async (url) => {
+			requestUrls.push(String(url));
+			if (String(url).includes("/runs?")) {
+				return new Response(
+					JSON.stringify({
+						runs: [
+							{
+								workflowName: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
+								runId: "canonical-snapshot-run",
+								resourceId,
+								createdAt: "2026-04-29T00:00:00.000Z",
+								updatedAt: "2026-04-29T00:01:00.000Z",
+								snapshot: JSON.stringify({
+									status: "success",
+									context: { input: inputData },
+									result: { status: "error", text: "snapshot partial", errors: ["snapshot agent failed"] },
+								}),
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					workflowName: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
+					runId: "canonical-snapshot-run",
+					resourceId,
+					status: "success",
+					payload: inputData,
+					result: { status: "error", text: "snapshot partial", errors: ["snapshot agent failed"] },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		},
+	});
+	const manager = new MastraAsyncAgentManager(client as any, {
+		onComplete(summary) {
+			completions.push(summary);
+		},
+	});
+	manager.configureSession({ piSessionId: "session-snapshot", cwd: "/workspace/project", isCompletionAcknowledged: () => false });
+
+	await manager.restoreSessionJobs();
+
+	const summary = manager.get("snapshot-restore-job");
+	assert.equal(summary?.runId, "canonical-snapshot-run");
+	assert.equal(summary?.status, "error");
+	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
+	assert.equal(summary?.textPreview, "snapshot partial");
+	assert.ok(summary?.errors.includes("snapshot agent failed"));
+	assert.equal(completions.length, 1);
+	assert.ok(requestUrls.some((url) => url.includes("/runs?resourceId=")));
+	assert.ok(requestUrls.some((url) => url.includes("/runs/canonical-snapshot-run?fields=result%2Cerror%2Cpayload")));
+	assert.ok(!requestUrls.some((url) => url.includes("fields=result%2Cerror%2Cstatus")));
+});
+
+test("restoring active workflow jobs attaches only one observer", async () => {
+	let releaseObserve!: () => void;
+	let observeCalls = 0;
+	const resourceId = defaultResourceId("/workspace/project");
+	const runId = `pi-session-active-review-agent-${resourceId.replace(":", "-")}-active-job`;
+	const manager = new MastraAsyncAgentManager({
+		async *observeWorkflow() {
+			observeCalls += 1;
+			yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "text-delta", text: "tick" } } };
+			await new Promise<void>((resolve) => {
+				releaseObserve = resolve;
+			});
+			yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "finish" } } };
+		},
+		async listWorkflowRuns(workflowId: string) {
+			return [
+				{
+					workflowName: workflowId,
+					runId,
+					resourceId,
+					status: "running",
+					inputData: {
+						jobId: "active-job",
+						jobName: "review",
+						piSessionId: "session-active",
+						agentId: "agent",
+						message: "prompt",
+						threadId: `pi-session-active-review-agent-${resourceId.replace(":", "-")}`,
+						resourceId,
+					},
+				},
+			];
+		},
+		async getWorkflowRun(workflowId: string, runId: string) {
+			return { workflowName: workflowId, runId, status: "success" };
+		},
+	} as any);
+	manager.configureSession({ piSessionId: "session-active", cwd: "/workspace/project" });
+
+	await manager.restoreSessionJobs();
+	await waitFor(() => manager.get("active-job")?.textPreview === "tick");
+	await manager.restoreSessionJobs();
+	assert.equal(observeCalls, 1);
+	releaseObserve();
+	await waitFor(() => manager.get("active-job")?.lifecycleStatus === "agent_response_queued");
+});
+
+test("restoring active workflow jobs handles real Mastra snapshot list shape", async () => {
+	let releaseObserve!: () => void;
+	let observeCalls = 0;
+	const requestUrls: string[] = [];
+	const resourceId = defaultResourceId("/workspace/project");
+	const inputData = {
+		jobId: "active-snapshot-job",
+		jobName: "review",
+		piSessionId: "session-active-snapshot",
+		agentId: "agent",
+		message: "prompt",
+		threadId: `pi-session-active-snapshot-review-agent-${resourceId.replace(":", "-")}`,
+		resourceId,
+	};
+	const client = new MastraHttpClient({
+		fetchImpl: async (url) => {
+			const requestUrl = String(url);
+			requestUrls.push(requestUrl);
+			if (requestUrl.includes("/runs?")) {
+				return new Response(
+					JSON.stringify({
+						runs: [
+							{
+								workflowName: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
+								runId: "active-snapshot-run",
+								resourceId,
+								snapshot: JSON.stringify({
+									status: "running",
+									context: { input: inputData },
+								}),
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			if (requestUrl.includes("/observe?")) {
+				observeCalls += 1;
+				const body = new ReadableStream<Uint8Array>({
+					start(controller) {
+						const encoder = new TextEncoder();
+						controller.enqueue(encoder.encode('data: {"type":"pi-agent-stream-chunk","payload":{"chunk":{"type":"text-delta","text":"tick"}}}\n\n'));
+						releaseObserve = () => {
+							controller.enqueue(encoder.encode('data: {"type":"pi-agent-stream-chunk","payload":{"chunk":{"type":"finish"}}}\n\n'));
+							controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+							controller.close();
+						};
+					},
+				});
+				return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+			}
+			return new Response(
+				JSON.stringify({
+					workflowName: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
+					runId: "active-snapshot-run",
+					resourceId,
+					status: "success",
+					payload: inputData,
+					result: { text: "final active result" },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		},
+	});
+	const manager = new MastraAsyncAgentManager(client as any);
+	manager.configureSession({ piSessionId: "session-active-snapshot", cwd: "/workspace/project" });
+
+	await manager.restoreSessionJobs();
+	await waitFor(() => manager.get("active-snapshot-job")?.textPreview === "tick");
+	await manager.restoreSessionJobs();
+	assert.equal(observeCalls, 1);
+	releaseObserve();
+	await waitFor(() => manager.get("active-snapshot-job")?.lifecycleStatus === "agent_response_queued");
+
+	const summary = manager.get("active-snapshot-job");
+	assert.equal(summary?.status, "done");
+	assert.equal(summary?.textPreview, "tick");
+	assert.ok(requestUrls.some((url) => url.includes("/runs?resourceId=")));
+	assert.ok(requestUrls.some((url) => url.includes("/observe?runId=active-snapshot-run")));
+	assert.ok(requestUrls.some((url) => url.includes("/runs/active-snapshot-run?fields=result%2Cerror%2Cpayload")));
+});
+
+test("restoring terminal workflow retries completion reminder if previous send failed", async () => {
+	let attempts = 0;
+	const resourceId = defaultResourceId("/workspace/project");
+	const runId = `pi-session-retry-review-agent-${resourceId.replace(":", "-")}-retry-job`;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *observeWorkflow() {
+				throw new Error("terminal restored jobs should not be observed");
+			},
+			async listWorkflowRuns(workflowId: string) {
+				return [
+					{
+						workflowName: workflowId,
+						runId,
+						resourceId,
+						status: "success",
+						result: { text: "restored output" },
+						inputData: {
+							jobId: "retry-job",
+							jobName: "review",
+							piSessionId: "session-retry",
+							agentId: "agent",
+							message: "prompt",
+							threadId: `pi-session-retry-review-agent-${resourceId.replace(":", "-")}`,
+							resourceId,
+						},
+					},
+				];
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "success", result: { text: "restored output" } };
+			},
+		} as any,
+		{
+			onComplete() {
+				attempts += 1;
+				if (attempts === 1) throw new Error("send failed");
+			},
+		},
+	);
+	manager.configureSession({ piSessionId: "session-retry", cwd: "/workspace/project", isCompletionAcknowledged: () => false });
+
+	await manager.restoreSessionJobs();
+	assert.equal(attempts, 1);
+	assert.match(manager.get("retry-job")?.errors.join("\n") ?? "", /Completion reminder failed/);
+
+	await manager.restoreSessionJobs();
+	assert.equal(attempts, 2);
+});
+
+test("restoring terminal workflow retries queued activity sink notification if previous finish failed", async () => {
+	let finishAttempts = 0;
+	const resourceId = defaultResourceId("/workspace/project");
+	const runId = `pi-session-sink-review-agent-${resourceId.replace(":", "-")}-sink-job`;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *observeWorkflow() {
+				throw new Error("terminal restored jobs should not be observed");
+			},
+			async listWorkflowRuns(workflowId: string) {
+				return [
+					{
+						workflowName: workflowId,
+						runId,
+						resourceId,
+						status: "success",
+						result: { text: "restored output" },
+						inputData: {
+							jobId: "sink-job",
+							jobName: "review",
+							piSessionId: "session-sink",
+							agentId: "agent",
+							message: "prompt",
+							threadId: `pi-session-sink-review-agent-${resourceId.replace(":", "-")}`,
+							resourceId,
+						},
+					},
+				];
+			},
+			async getWorkflowRun(workflowId: string, runId: string) {
+				return { workflowName: workflowId, runId, status: "success", result: { text: "restored output" } };
+			},
+		} as any,
+		{
+			activitySink: {
+				start() {},
+				update() {},
+				finish() {
+					finishAttempts += 1;
+					if (finishAttempts === 1) throw new Error("sink failed");
+				},
+			},
+		},
+	);
+	manager.configureSession({ piSessionId: "session-sink", cwd: "/workspace/project", isCompletionAcknowledged: () => false });
+
+	await manager.restoreSessionJobs();
+	assert.equal(finishAttempts, 1);
+	assert.match(manager.get("sink-job")?.errors.join("\n") ?? "", /Completion activity sink failed/);
+
+	await manager.restoreSessionJobs();
+	assert.equal(finishAttempts, 2);
 });
 
 test("async agent manager fires onComplete callback by default", async () => {
@@ -521,6 +1485,8 @@ test("agent inspect with no ids lists available agents and current session jobs"
 		listAgents: async () => ({
 			"developer-agent": { id: "developer-agent", name: "Developer" },
 			"validator-agent": { id: "validator-agent", name: "Validator" },
+			"reviewer-agent": { id: "reviewer-agent", name: "Reviewer" },
+			"free-agent": { id: "free-agent", name: "Free" },
 		}),
 	} as any, {
 		inspectJobs: () => [
@@ -532,15 +1498,79 @@ test("agent inspect with no ids lists available agents and current session jobs"
 				threadId: "thread",
 				resourceId: "resource",
 			},
+			{
+				jobId: "job-2",
+				jobName: "validation",
+				agentId: "validator-agent",
+				status: "agent_response_queued",
+				threadId: "thread-2",
+				resourceId: "resource",
+				runId: "run-2",
+			},
+			{
+				jobId: "job-3",
+				jobName: "review",
+				agentId: "reviewer-agent",
+				status: "ended",
+				threadId: "thread-3",
+				resourceId: "resource",
+				runId: "run-3",
+			},
 		],
 	} as any);
 
 	const result = await tool.execute("call", {});
 	assert.equal(result.details.availableAgents?.length, 1);
-	assert.equal(result.details.availableAgents?.[0]?.agentId, "validator-agent");
+	assert.equal(result.details.availableAgents?.[0]?.agentId, "free-agent");
 	assert.equal(result.details.availableAgents?.[0]?.status, "available");
-	assert.equal(result.details.jobs?.[0]?.jobId, "job-1");
+	assert.deepEqual(result.details.jobs?.map((job) => [job.jobId, job.status]), [
+		["job-1", "working"],
+		["job-2", "agent_response_queued"],
+		["job-3", "ended"],
+	]);
 	assert.match("text" in result.content[0] ? result.content[0].text : "", /availableAgents/);
+	assert.match("text" in result.content[0] ? result.content[0].text : "", /agent_response_queued/);
+	assert.match("text" in result.content[0] ? result.content[0].text : "", /ended/);
+});
+
+test("agent inspect can list real manager job statuses across lifecycle states", async () => {
+	let releaseWorking!: () => void;
+	const manager = new MastraAsyncAgentManager({
+		async *streamAgent(agentId: string, _request: unknown) {
+			if (agentId === "queued-agent") {
+				yield { type: "finish" };
+				return;
+			}
+			await new Promise<void>((resolve) => {
+				releaseWorking = resolve;
+			});
+			yield { type: "finish" };
+		},
+	} as any);
+	const tool = createMastraAgentInspectTool({
+		listAgents: async () => ({
+			"working-agent": { id: "working-agent", name: "Working" },
+			"queued-agent": { id: "queued-agent", name: "Queued" },
+			"free-agent": { id: "free-agent", name: "Free" },
+		}),
+	} as any, manager);
+
+	await manager.start({ agentId: "working-agent", message: "hold", jobId: "working-job", finalMessage: false });
+	await manager.start({ agentId: "queued-agent", message: "done", jobId: "queued-job", finalMessage: false });
+	await waitFor(() => manager.get("queued-job")?.lifecycleStatus === "agent_response_queued");
+
+	const queuedResult = await tool.execute("call", {});
+	const queuedStatuses = new Map(queuedResult.details.jobs?.map((job) => [job.jobId, job.status]));
+	assert.equal(queuedStatuses.get("working-job"), "working");
+	assert.equal(queuedStatuses.get("queued-job"), "agent_response_queued");
+	assert.deepEqual(queuedResult.details.availableAgents?.map((agent) => agent.agentId), ["free-agent"]);
+
+	manager.markEnded("queued-job");
+	const endedResult = await tool.execute("call", {});
+	const endedStatuses = new Map(endedResult.details.jobs?.map((job) => [job.jobId, job.status]));
+	assert.equal(endedStatuses.get("queued-job"), "ended");
+	releaseWorking();
+	await waitFor(() => manager.get("working-job")?.lifecycleStatus === "agent_response_queued");
 });
 
 

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { MastraAsyncAgentManager, createMastraAgentInspectTool, createStreamRequest, createWorkflowStreamRequest, normalizeInspectAgentIds } from "./tool.js";
+import {
+	MastraAsyncAgentManager,
+	createMastraAgentInspectTool,
+	createMastraAgentQueryTool,
+	createMastraTools,
+	createStreamRequest,
+	createWorkflowStreamRequest,
+	normalizeInspectAgentIds,
+	MASTRA_AGENT_QUERY_PARAMETERS,
+} from "./tool.js";
 
 test("omitted modeId leaves requestContext unchanged", () => {
 	const request = createStreamRequest(
@@ -174,6 +183,131 @@ test("async agent manager uses unique default threads for concurrent jobs", asyn
 	assert.match(requests[1].memory.thread, /:job-two$/);
 });
 
+
+test("createMastraTools registers agent_query and preserves workflow tools", () => {
+	const manager = { start: async () => fakeAsyncSummary() } as any;
+	const tools = createMastraTools({} as any, { asyncAgentManager: manager });
+	const names = tools.map((tool) => tool.name);
+	assert.equal(names[0], "agent_query");
+	assert.equal((tools[0] as any).renderShell, "self");
+	assert.ok(names.includes("agent_call"));
+	assert.ok(names.includes("agent_start"));
+	assert.ok(names.includes("workflow_call"));
+	assert.ok(names.includes("workflow_list"));
+	assert.ok(names.includes("workflow_status"));
+});
+
+test("agent_query schema is narrower than lower-level agent tools", () => {
+	const properties = (MASTRA_AGENT_QUERY_PARAMETERS as any).properties;
+	for (const key of ["agentId", "message", "synchronous", "threadId", "resourceId", "requestContext", "includeToolResults", "includeReasoning", "timeoutMs", "input_args"]) {
+		assert.ok(key in properties, `${key} should be exposed`);
+	}
+	assert.equal("maxSteps" in properties, false);
+	assert.equal("activeTools" in properties, false);
+	assert.equal("modeId" in properties, false);
+	assert.equal("jobId" in properties, false);
+	assert.equal("finalMessage" in properties, false);
+});
+
+test("agent_query defaults to async and returns a job handle", async () => {
+	const starts: any[] = [];
+	const tool = createMastraAgentQueryTool({
+		start: async (params: any) => {
+			starts.push(params);
+			return fakeAsyncSummary({ jobId: "query-job", agentId: params.agentId, threadId: "thread", resourceId: "resource" });
+		},
+	} as any, {} as any);
+
+	const result = await tool.execute("call", { agentId: "agent", message: "hello" });
+	assert.equal(starts.length, 1);
+	assert.equal(starts[0].includeReasoning, false);
+	assert.equal("maxSteps" in starts[0], false);
+	assert.equal("activeTools" in starts[0], false);
+	assert.equal((result.details as any).jobId, "query-job");
+	assert.match("text" in result.content[0] ? result.content[0].text : "", /Started async Mastra agent job: query-job/);
+});
+
+test("agent_query async path passes supported options through", async () => {
+	const starts: any[] = [];
+	const tool = createMastraAgentQueryTool({
+		start: async (params: any) => {
+			starts.push(params);
+			return fakeAsyncSummary({ agentId: params.agentId, threadId: params.threadId, resourceId: params.resourceId });
+		},
+	} as any, {} as any);
+
+	await tool.execute("call", {
+		agentId: "agent",
+		message: "hello $1",
+		threadId: "thread-x",
+		resourceId: "resource-x",
+		requestContext: { tenant: "acme" },
+		includeReasoning: true,
+		includeToolResults: true,
+		timeoutMs: 123,
+		input_args: { $1: "world" },
+	});
+
+	assert.equal(starts[0].includeReasoning, true);
+	assert.equal(starts[0].includeToolResults, true);
+	assert.equal(starts[0].threadId, "thread-x");
+	assert.equal(starts[0].resourceId, "resource-x");
+	assert.equal(starts[0].timeoutMs, 123);
+	assert.deepEqual(starts[0].requestContext, { tenant: "acme" });
+	assert.deepEqual(starts[0].input_args, { $1: "world" });
+});
+
+test("agent_query supports synchronous execution and input_args formatting", async () => {
+	const requests: any[] = [];
+	const tool = createMastraAgentQueryTool({
+		start: async () => {
+			throw new Error("async start should not be used for synchronous query");
+		},
+	} as any, {
+		async *streamAgent(agentId: string, request: unknown) {
+			requests.push({ agentId, request });
+			yield { type: "text-delta", text: "answer" };
+			yield { type: "reasoning-delta", text: "hidden" };
+			yield { type: "finish" };
+		},
+	} as any);
+
+	const result = await tool.execute("call", {
+		agentId: "agent",
+		message: "Use $1",
+		synchronous: true,
+		requestContext: { tenant: "acme" },
+		input_args: { $1: "value" },
+	});
+
+	assert.equal((result.details as any).text, "answer");
+	assert.equal("text" in result.content[0] ? result.content[0].text.includes("Reasoning:" ) : true, false);
+	assert.equal(requests[0].agentId, "agent");
+	assert.match(requests[0].request.messages[0].content, /Use \$1\n\nInput arguments:\n- \$1: value/);
+	assert.deepEqual(requests[0].request.requestContext, { tenant: "acme", input_args: { $1: "value" } });
+});
+
+test("agent_query renderers distinguish async summaries and sync details", () => {
+	const tool = createMastraAgentQueryTool({ start: async () => fakeAsyncSummary() } as any, {} as any) as any;
+	const asyncCallLines = tool.renderCall({ agentId: "agent", message: "hello" }, stubTheme).render(80).join("\n");
+	const syncCallLines = tool.renderCall({ agentId: "agent", message: "hello", synchronous: true }, stubTheme).render(80).join("\n");
+	assert.match(asyncCallLines, /mastra query/);
+	assert.match(asyncCallLines, /agent/);
+	assert.match(asyncCallLines, /mode=async/);
+	assert.match(syncCallLines, /mode=sync/);
+
+	const asyncLines = tool
+		.renderResult({ content: [{ type: "text", text: "started" }], details: fakeAsyncSummary() }, {}, stubTheme)
+		.render(80);
+	assert.deepEqual(asyncLines, []);
+
+	const syncLines = tool
+		.renderResult({ content: [{ type: "text", text: "answer" }], details: fakeCallDetails({ text: "answer" }) }, {}, stubTheme)
+		.render(80);
+	assert.ok(syncLines.length > 0);
+	assert.ok(syncLines.join("\n").includes("answer"));
+});
+
 test("async agent manager honors explicit thread ids", async () => {
 	const requests: any[] = [];
 	const manager = new MastraAsyncAgentManager({
@@ -306,6 +440,46 @@ test("agent inspect can include instructions when requested", async () => {
 	assert.equal(result.content[0].type, "text");
 	assert.match("text" in result.content[0] ? result.content[0].text : "", /Use evidence/);
 });
+
+
+const stubTheme: Record<string, (...args: string[]) => string> = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+	dim: (text: string) => text,
+};
+
+function fakeAsyncSummary(overrides: Record<string, unknown> = {}): any {
+	return {
+		jobId: "job",
+		agentId: "agent",
+		threadId: "thread",
+		resourceId: "resource",
+		status: "running",
+		textPreview: "",
+		toolCalls: 0,
+		toolResults: 0,
+		rawChunkCount: 0,
+		chunksTruncated: false,
+		errors: [],
+		...overrides,
+	};
+}
+
+function fakeCallDetails(overrides: Record<string, unknown> = {}): any {
+	return {
+		agentId: "agent",
+		threadId: "thread",
+		resourceId: "resource",
+		status: "done",
+		text: "answer",
+		toolCalls: [],
+		toolResults: [],
+		chunksTruncated: false,
+		errors: [],
+		rawChunkCount: 1,
+		...overrides,
+	};
+}
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
 	const start = Date.now();

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -179,8 +179,8 @@ test("async agent manager uses unique default threads for concurrent jobs", asyn
 
 	await waitFor(() => requests.length === 2);
 	assert.notEqual(requests[0].memory.thread, requests[1].memory.thread);
-	assert.match(requests[0].memory.thread, /:job-one$/);
-	assert.match(requests[1].memory.thread, /:job-two$/);
+	assert.match(requests[0].memory.thread, /^pi-local-session-job-one-agent-pi-[a-f0-9]{12}$/);
+	assert.match(requests[1].memory.thread, /^pi-local-session-job-two-agent-pi-[a-f0-9]{12}$/);
 });
 
 
@@ -190,8 +190,12 @@ test("createMastraTools registers agent_query and preserves workflow tools", () 
 	const names = tools.map((tool) => tool.name);
 	assert.equal(names[0], "agent_query");
 	assert.equal((tools[0] as any).renderShell, "self");
-	assert.ok(names.includes("agent_call"));
-	assert.ok(names.includes("agent_start"));
+	assert.equal(names.includes("agent_call"), false);
+	assert.equal(names.includes("agent_start"), false);
+	assert.equal(names.includes("agent_list"), false);
+	assert.equal(names.includes("agent_status"), false);
+	assert.equal(names.includes("agent_async_status"), false);
+	assert.ok(names.includes("agent_inspect"));
 	assert.ok(names.includes("workflow_call"));
 	assert.ok(names.includes("workflow_list"));
 	assert.ok(names.includes("workflow_status"));
@@ -199,7 +203,7 @@ test("createMastraTools registers agent_query and preserves workflow tools", () 
 
 test("agent_query schema is narrower than lower-level agent tools", () => {
 	const properties = (MASTRA_AGENT_QUERY_PARAMETERS as any).properties;
-	for (const key of ["agentId", "message", "synchronous", "threadId", "resourceId", "requestContext", "includeToolResults", "includeReasoning", "timeoutMs", "input_args"]) {
+	for (const key of ["agentId", "message", "jobName", "synchronous", "threadId", "resourceId", "requestContext", "includeToolResults", "includeReasoning", "timeoutMs", "input_args"]) {
 		assert.ok(key in properties, `${key} should be exposed`);
 	}
 	assert.equal("maxSteps" in properties, false);
@@ -221,6 +225,7 @@ test("agent_query defaults to async and returns a job handle", async () => {
 	const result = await tool.execute("call", { agentId: "agent", message: "hello" });
 	assert.equal(starts.length, 1);
 	assert.equal(starts[0].includeReasoning, false);
+	assert.equal(starts[0].finalMessage, true);
 	assert.equal("maxSteps" in starts[0], false);
 	assert.equal("activeTools" in starts[0], false);
 	assert.equal((result.details as any).jobId, "query-job");
@@ -239,6 +244,7 @@ test("agent_query async path passes supported options through", async () => {
 	await tool.execute("call", {
 		agentId: "agent",
 		message: "hello $1",
+		jobName: "review-pass",
 		threadId: "thread-x",
 		resourceId: "resource-x",
 		requestContext: { tenant: "acme" },
@@ -250,6 +256,7 @@ test("agent_query async path passes supported options through", async () => {
 
 	assert.equal(starts[0].includeReasoning, true);
 	assert.equal(starts[0].includeToolResults, true);
+	assert.equal(starts[0].jobName, "review-pass");
 	assert.equal(starts[0].threadId, "thread-x");
 	assert.equal(starts[0].resourceId, "resource-x");
 	assert.equal(starts[0].timeoutMs, 123);
@@ -350,18 +357,86 @@ test("async agent manager starts immediately and captures streamed output", asyn
 		},
 	);
 
-	const started = await manager.start({ agentId: "agent", message: "prompt", jobId: "test-job" });
+	const started = await manager.start({ agentId: "agent", message: "prompt", jobId: "test-job", finalMessage: true });
 	assert.equal(started.jobId, "test-job");
 	assert.equal(started.status, "running");
 
-	await waitFor(() => completed);
+	await waitFor(() => {
+		const job = manager.get("test-job");
+		return job?.status === "done";
+	});
 	const summary = manager.get("test-job");
 	assert.equal(summary?.status, "done");
 	assert.equal(summary?.prompt, "prompt");
 	assert.ok(updates >= 2);
+	assert.ok(completed, "onComplete should fire when finalMessage: true");
 
 	const output = await manager.read({ jobId: "test-job", mode: "full" });
 	assert.equal(output.text, "hello world");
+});
+
+test("async agent manager fires onComplete callback by default", async () => {
+	let completed = false;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamAgent() {
+				yield { type: "finish" };
+			},
+		} as any,
+		{
+			onComplete() {
+				completed = true;
+			},
+		},
+	);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "default-no-message" });
+	await waitFor(() => manager.get("default-no-message")?.status === "done");
+	assert.equal(completed, true);
+});
+
+test("async agent manager suppresses onComplete during shutdown even if start is racing", async () => {
+	let completed = false;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamAgent() {
+				yield { type: "finish" };
+			},
+		} as any,
+		{
+			onComplete() {
+				completed = true;
+			},
+		},
+	);
+
+	void manager.start({ agentId: "agent", message: "prompt", jobId: "shutdown-job", finalMessage: true });
+	manager.cancelAll("test shutdown", { suppressCompletionMessage: true });
+	await waitFor(() => {
+		const job = manager.get("shutdown-job");
+		return job !== undefined && job.status !== "running";
+	});
+	assert.equal(completed, false);
+});
+
+test("async agent manager marks stream EOF without finish as incomplete error", async () => {
+	const manager = new MastraAsyncAgentManager({
+		async *streamAgent() {
+			yield { type: "text-delta", text: "partial output" };
+		},
+	} as any);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "incomplete-job" });
+	await waitFor(() => manager.get("incomplete-job")?.status === "error");
+
+	const summary = manager.get("incomplete-job");
+	assert.equal(summary?.terminalReason, "stream_eof");
+	assert.equal(summary?.incomplete, true);
+	assert.match(summary?.errors.join("\n") ?? "", /terminal finish event/);
+
+	const output = await manager.read({ jobId: "incomplete-job", mode: "tail" });
+	assert.match(output.text, /partial output/);
+	assert.match(output.text, /async job incomplete/);
 });
 
 test("uses Mastra workflow stream payload shape", () => {
@@ -439,6 +514,33 @@ test("agent inspect can include instructions when requested", async () => {
 	assert.equal(result.details.agents[0].instructions, "Use evidence.");
 	assert.equal(result.content[0].type, "text");
 	assert.match("text" in result.content[0] ? result.content[0].text : "", /Use evidence/);
+});
+
+test("agent inspect with no ids lists available agents and current session jobs", async () => {
+	const tool = createMastraAgentInspectTool({
+		listAgents: async () => ({
+			"developer-agent": { id: "developer-agent", name: "Developer" },
+			"validator-agent": { id: "validator-agent", name: "Validator" },
+		}),
+	} as any, {
+		inspectJobs: () => [
+			{
+				jobId: "job-1",
+				jobName: "implementation",
+				agentId: "developer-agent",
+				status: "working",
+				threadId: "thread",
+				resourceId: "resource",
+			},
+		],
+	} as any);
+
+	const result = await tool.execute("call", {});
+	assert.equal(result.details.availableAgents?.length, 1);
+	assert.equal(result.details.availableAgents?.[0]?.agentId, "validator-agent");
+	assert.equal(result.details.availableAgents?.[0]?.status, "available");
+	assert.equal(result.details.jobs?.[0]?.jobId, "job-1");
+	assert.match("text" in result.content[0] ? result.content[0].text : "", /availableAgents/);
 });
 
 

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -1520,8 +1520,13 @@ test("agent inspect with no ids lists available agents and current session jobs"
 	} as any);
 
 	const result = await tool.execute("call", {});
-	assert.equal(result.details.availableAgents?.length, 1);
-	assert.equal(result.details.availableAgents?.[0]?.agentId, "free-agent");
+	assert.equal(result.details.availableAgents?.length, 4);
+	assert.deepEqual(result.details.availableAgents?.map((agent) => agent.agentId), [
+		"developer-agent",
+		"validator-agent",
+		"reviewer-agent",
+		"free-agent",
+	]);
 	assert.equal(result.details.availableAgents?.[0]?.status, "available");
 	assert.deepEqual(result.details.jobs?.map((job) => [job.jobId, job.status]), [
 		["job-1", "working"],
@@ -1563,7 +1568,11 @@ test("agent inspect can list real manager job statuses across lifecycle states",
 	const queuedStatuses = new Map(queuedResult.details.jobs?.map((job) => [job.jobId, job.status]));
 	assert.equal(queuedStatuses.get("working-job"), "working");
 	assert.equal(queuedStatuses.get("queued-job"), "agent_response_queued");
-	assert.deepEqual(queuedResult.details.availableAgents?.map((agent) => agent.agentId), ["free-agent"]);
+	assert.deepEqual(queuedResult.details.availableAgents?.map((agent) => agent.agentId), [
+		"working-agent",
+		"queued-agent",
+		"free-agent",
+	]);
 
 	manager.markEnded("queued-job");
 	const endedResult = await tool.execute("call", {});

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -11,6 +11,7 @@ import {
 	MASTRA_AGENT_QUERY_PARAMETERS,
 } from "./tool.js";
 import { MASTRA_PI_AGENT_JOB_WORKFLOW_ID } from "../const.js";
+import { MastraAgentActivityStore } from "../tui/index.js";
 import { MastraHttpClient } from "./client.js";
 import { defaultResourceId } from "./memory.js";
 
@@ -672,6 +673,36 @@ test("async agent manager detachAll also stops direct fallback jobs without comp
 	assert.deepEqual(sinkEvents.filter((event) => event === "end"), ["end"]);
 	assert.deepEqual(sinkEvents.filter((event) => event === "reset"), ["reset"]);
 	assert.equal(completed, false);
+});
+
+test("async agent manager cancellation keeps late direct stream updates out of activity store", async () => {
+	const activityStore = new MastraAgentActivityStore();
+	let streamStarted = false;
+	const manager = new MastraAsyncAgentManager(
+		{
+			async *streamAgent(_agentId: string, _request: unknown, options: { signal?: AbortSignal } = {}) {
+				streamStarted = true;
+				yield { type: "text-delta", text: "started" };
+				await new Promise<void>((resolve) => {
+					options.signal?.addEventListener("abort", () => resolve(), { once: true });
+				});
+				yield { type: "text-delta", text: "late update after cancel" };
+			},
+		} as any,
+		{
+			activitySink: activityStore,
+			useWorkflowJobs: false,
+		},
+	);
+
+	await manager.start({ agentId: "agent", message: "prompt", jobId: "cancel-direct-late" });
+	await waitFor(() => streamStarted && activityStore.snapshot().length === 1);
+	const summary = await manager.cancel("cancel-direct-late", "stop now");
+	assert.equal(summary?.lifecycleStatus, "ended");
+	assert.deepEqual(activityStore.snapshot(), []);
+
+	await waitFor(() => manager.get("cancel-direct-late")?.status === "aborted");
+	assert.deepEqual(activityStore.snapshot(), []);
 });
 
 test("async agent manager cancels workflow jobs without queueing a completion reminder", async () => {

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -683,6 +683,7 @@ export function createMastraTools(client = new MastraHttpClient(), options: Mast
 		new MastraAsyncAgentManager(client, {
 			activitySink: options.agentActivitySink,
 			onComplete: options.onAsyncAgentComplete,
+			useWorkflowJobs: false,
 		});
 	return [
 		createMastraAgentQueryTool(asyncAgentManager, client, options.agentActivitySink),

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -128,6 +128,10 @@ interface MastraAsyncAgentJob {
 	suppressCompletionMessage?: boolean;
 	lifecycleStatus: Exclude<MastraAgentLifecycleStatus, "available">;
 	usesWorkflow: boolean;
+	completionQueuedNotified?: boolean;
+	completionMessageSent?: boolean;
+	suppressQueuedCompletion?: boolean;
+	workflowObserverActive?: boolean;
 }
 
 export interface MastraAsyncAgentManagerOptions {
@@ -206,10 +210,9 @@ export class MastraAsyncAgentManager {
 		this.jobs.set(jobId, job);
 		this.options.activitySink?.start(jobId, effectiveParams, details);
 
-		if (this.canUseWorkflowJobs()) {
+		if (this.canStartWorkflowJobs()) {
 			try {
-				await this.startWorkflowJob(job);
-				void this.observeWorkflowJob(job);
+				this.startWorkflowJob(job);
 				return this.summary(job);
 			} catch (error) {
 				// During local development the Pi package can be newer than the running
@@ -262,20 +265,32 @@ export class MastraAsyncAgentManager {
 	async cancel(jobId: string, reason = "cancelled"): Promise<MastraAgentAsyncJobSummary | undefined> {
 		const job = this.jobs.get(jobId);
 		if (!job) return undefined;
-		if (job.lifecycleStatus === "working" || job.details.status === "running") {
-			job.details.errors.push(reason);
+		if (job.details.status === "running" && job.usesWorkflow && job.workflowId && job.runId && this.hasClientMethod("getWorkflowRun")) {
+			await this.refreshWorkflowRun(job).catch(() => undefined);
+		}
+		if (job.details.status !== "running") {
+			if (job.lifecycleStatus === "working") await this.completeJob(job);
+			else if (job.lifecycleStatus === "agent_response_queued") this.markEnded(jobId);
+			return this.summary(job);
+		}
+		if (job.lifecycleStatus === "working") {
+			job.suppressQueuedCompletion = true;
+			job.suppressCompletionMessage = true;
+			pushUniqueError(job.details, reason);
 			job.controller.abort(new Error(reason));
 			if (job.usesWorkflow && job.workflowId && job.runId && this.hasClientMethod("cancelWorkflowRun")) {
 				await this.client.cancelWorkflowRun(job.workflowId, job.runId).catch((error) => {
-					job.details.errors.push(error instanceof Error ? error.message : String(error));
+					pushUniqueError(job.details, `Remote workflow cancellation failed: ${error instanceof Error ? error.message : String(error)}`);
 				});
 			}
 			job.details.status = "aborted";
 			job.details.updatedAt = Date.now();
 			job.details.completedAt = job.details.updatedAt;
 			job.details.terminalReason = "abort";
+			this.markEnded(jobId);
+		} else {
+			this.markEnded(jobId);
 		}
-		this.markEnded(jobId);
 		return this.summary(job);
 	}
 
@@ -291,9 +306,14 @@ export class MastraAsyncAgentManager {
 	}
 
 	detachAll(reason = "session shutdown"): void {
-		for (const job of this.jobs.values()) {
-			if (job.usesWorkflow && job.lifecycleStatus === "working") {
+		for (const job of Array.from(this.jobs.values())) {
+			if (job.lifecycleStatus === "working") {
+				job.suppressQueuedCompletion = true;
+				job.suppressCompletionMessage = true;
+				pushUniqueError(job.details, reason);
+				this.markEnded(job.jobId);
 				job.controller.abort(new Error(reason));
+				this.jobs.delete(job.jobId);
 			}
 		}
 		this.options.activitySink?.reset?.();
@@ -302,13 +322,14 @@ export class MastraAsyncAgentManager {
 	markEnded(jobId: string): MastraAgentAsyncJobSummary | undefined {
 		const job = this.jobs.get(jobId);
 		if (!job) return undefined;
+		if (job.lifecycleStatus === "ended") return this.summary(job);
 		job.lifecycleStatus = "ended";
 		this.options.activitySink?.end?.(jobId);
 		return this.summary(job);
 	}
 
 	async restoreSessionJobs(): Promise<MastraAgentAsyncJobSummary[]> {
-		if (!this.canUseWorkflowJobs() || !this.piSessionId) return [];
+		if (!this.canRestoreWorkflowJobs() || !this.piSessionId) return [];
 		const resourceId = defaultResourceId(this.cwd);
 		let runs: MastraWorkflowRun[];
 		try {
@@ -318,22 +339,24 @@ export class MastraAsyncAgentManager {
 		}
 
 		const restored: MastraAgentAsyncJobSummary[] = [];
-		for (const run of runs.filter((candidate) => this.isSessionRun(candidate.runId))) {
+		for (const run of runs.filter((candidate) => this.isSessionWorkflowRun(candidate))) {
 			const job = this.jobFromWorkflowRun(run);
 			if (!job) continue;
-			restored.push(this.summary(job));
 
-			if (isActiveWorkflowStatus(run.status) && !job.controller.signal.aborted) {
+			const status = workflowRunStatus(run);
+			if (isActiveWorkflowStatus(status) && !job.controller.signal.aborted) {
 				void this.observeWorkflowJob(job);
+				restored.push(this.summary(job));
 				continue;
 			}
 
 			await this.refreshWorkflowRun(job).catch(() => undefined);
 			if (this.options.isCompletionAcknowledged?.(job.jobId)) {
 				this.markEnded(job.jobId);
-			} else if (isTerminalWorkflowStatus(run.status)) {
+			} else if (isTerminalWorkflowStatus(status)) {
 				await this.completeJob(job);
 			}
+			restored.push(this.summary(job));
 		}
 		return restored;
 	}
@@ -370,80 +393,128 @@ export class MastraAsyncAgentManager {
 		}
 	}
 
-	private async startWorkflowJob(job: MastraAsyncAgentJob): Promise<void> {
+	private startWorkflowJob(job: MastraAsyncAgentJob): void {
 		if (!job.workflowId || !job.runId) throw new Error("Workflow job is missing workflow/run id");
-		await this.client.startWorkflowAsync(job.workflowId, job.runId, {
-			resourceId: job.details.resourceId,
-			inputData: {
-				jobId: job.jobId,
-				jobName: job.jobName,
-				piSessionId: job.piSessionId,
-				agentId: job.params.agentId,
-				message: job.params.message,
-				threadId: job.details.threadId,
-				resourceId: job.details.resourceId,
-				requestContext: job.params.requestContext,
-				includeToolResults: job.params.includeToolResults,
-				includeReasoning: job.params.includeReasoning ?? false,
-				input_args: job.params.input_args,
-				timeoutMs: job.params.timeoutMs,
-			},
-			requestContext: job.params.requestContext,
-		}, { signal: job.controller.signal });
 		job.usesWorkflow = true;
+		void this.streamWorkflowJob(job);
+	}
+
+	private async streamWorkflowJob(job: MastraAsyncAgentJob): Promise<void> {
+		if (!job.workflowId || !job.runId) return;
+		if (job.workflowObserverActive) return;
+		job.workflowObserverActive = true;
+		let fallbackStarted = false;
+		try {
+			const timeoutMs = job.params.timeoutMs ?? DEFAULT_ASYNC_AGENT_TIMEOUT_MS;
+			for await (const chunk of this.client.streamWorkflow(job.workflowId, job.runId, workflowJobRequest(job), { signal: job.controller.signal, timeoutMs })) {
+				await this.applyWorkflowJobChunk(job, chunk);
+			}
+			await this.refreshWorkflowRun(job);
+			if (job.details.status === "running") markStreamEofIncomplete(job.details);
+		} catch (error) {
+			job.workflowObserverActive = false;
+			fallbackStarted = await this.fallbackWorkflowStreamToDirect(job, error);
+			if (!fallbackStarted) markStreamError(job.details, error, job.controller.signal.aborted);
+		} finally {
+			job.workflowObserverActive = false;
+			if (!fallbackStarted) await this.completeJob(job);
+		}
+	}
+
+	private async fallbackWorkflowStreamToDirect(job: MastraAsyncAgentJob, error: unknown): Promise<boolean> {
+		if (job.controller.signal.aborted || job.details.status !== "running" || job.details.rawChunkCount > 0 || !this.hasClientMethod("streamAgent")) {
+			return false;
+		}
+		pushUniqueError(job.details, `Workflow job runner unavailable, falling back to direct stream: ${error instanceof Error ? error.message : String(error)}`);
+		try {
+			const artifactDir = await mkdtemp(join(tmpdir(), `${job.jobId}-`));
+			job.artifactPath = join(artifactDir, "output.txt");
+			job.eventsPath = join(artifactDir, "events.jsonl");
+			job.usesWorkflow = false;
+			await this.runDirect(job, createStreamRequest(job.params, job.details.threadId, job.details.resourceId));
+			return true;
+		} catch (fallbackError) {
+			pushUniqueError(job.details, `Direct fallback failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`);
+			return false;
+		}
 	}
 
 	private async observeWorkflowJob(job: MastraAsyncAgentJob): Promise<void> {
 		if (!job.workflowId || !job.runId) return;
+		if (job.workflowObserverActive) return;
+		job.workflowObserverActive = true;
 		try {
 			const timeoutMs = job.params.timeoutMs ?? DEFAULT_ASYNC_AGENT_TIMEOUT_MS;
 			for await (const chunk of this.client.observeWorkflow(job.workflowId, job.runId, { resourceId: job.details.resourceId }, { signal: job.controller.signal, timeoutMs })) {
-				const agentChunk = unwrapWorkflowAgentChunk(chunk);
-				if (agentChunk !== undefined) {
-					const normalized = normalizeMastraChunk(agentChunk);
-					await this.persistChunk(job, agentChunk, normalized);
-					applyNormalizedEvent(job.details, normalized);
-					this.options.activitySink?.update(job.jobId, job.details);
-					continue;
-				}
-				applyWorkflowLifecycleChunk(job.details, chunk);
-				this.options.activitySink?.update(job.jobId, job.details);
+				await this.applyWorkflowJobChunk(job, chunk);
 			}
 			await this.refreshWorkflowRun(job);
 			if (job.details.status === "running") markStreamEofIncomplete(job.details);
 		} catch (error) {
 			markStreamError(job.details, error, job.controller.signal.aborted);
 		} finally {
+			job.workflowObserverActive = false;
 			await this.completeJob(job);
 		}
 	}
 
+	private async applyWorkflowJobChunk(job: MastraAsyncAgentJob, chunk: unknown): Promise<void> {
+		const agentChunk = unwrapWorkflowAgentChunk(chunk);
+		if (agentChunk !== undefined) {
+			const normalized = normalizeMastraChunk(agentChunk);
+			await this.persistChunk(job, agentChunk, normalized);
+			applyNormalizedEvent(job.details, normalized);
+			this.options.activitySink?.update(job.jobId, job.details);
+			return;
+		}
+		applyWorkflowLifecycleChunk(job.details, chunk);
+		this.options.activitySink?.update(job.jobId, job.details);
+	}
+
 	private async refreshWorkflowRun(job: MastraAsyncAgentJob): Promise<void> {
 		if (!job.workflowId || !job.runId || !this.hasClientMethod("getWorkflowRun")) return;
-		const run = await this.client.getWorkflowRun(job.workflowId, job.runId, { fields: ["result", "error", "status"] });
+		const run = await this.client.getWorkflowRun(job.workflowId, job.runId, { fields: ["result", "error", "payload"] });
 		const output = workflowJobOutput(run.result);
+		const status = workflowRunStatus(run);
 		if (output.artifactPath) job.artifactPath = output.artifactPath;
 		if (output.eventsPath) job.eventsPath = output.eventsPath;
 		if (output.text && !job.details.text) job.details.text = output.text;
+		for (const error of output.errors ?? []) pushUniqueError(job.details, error);
 
-		if (run.status === "success" && job.details.status === "running") {
+		if (output.status === "error" && job.details.status !== "aborted") {
+			markStreamError(job.details, output.errors?.[0] ?? run.error ?? "Workflow agent job returned error", false);
+		} else if (status === "success" && job.details.status === "running") {
 			job.details.status = "done";
 			job.details.updatedAt = Date.now();
 			job.details.completedAt = job.details.updatedAt;
 			job.details.terminalReason = "finish";
-		} else if (run.status === "canceled" && job.details.status === "running") {
+		} else if (status === "canceled" && job.details.status === "running") {
 			markStreamError(job.details, "Workflow run canceled", true);
-		} else if (isFailedWorkflowStatus(run.status) && job.details.status === "running") {
-			markStreamError(job.details, run.error ?? `Workflow run failed with status ${run.status}`, false);
+		} else if (isFailedWorkflowStatus(status) && job.details.status === "running") {
+			markStreamError(job.details, run.error ?? `Workflow run failed with status ${status}`, false);
 		}
 	}
 
 	private async completeJob(job: MastraAsyncAgentJob): Promise<void> {
 		if (job.lifecycleStatus === "ended") return;
+		if (job.suppressQueuedCompletion) return;
+		const shouldNotifyQueued = job.lifecycleStatus !== "agent_response_queued" || job.completionQueuedNotified !== true;
 		job.lifecycleStatus = "agent_response_queued";
-		this.options.activitySink?.finish(job.jobId, job.details);
-		if (job.finalMessage && !job.suppressCompletionMessage && !this.options.isCompletionAcknowledged?.(job.jobId)) {
-			await this.options.onComplete?.(this.summary(job));
+		if (shouldNotifyQueued) {
+			try {
+				this.options.activitySink?.finish(job.jobId, job.details);
+				job.completionQueuedNotified = true;
+			} catch (error) {
+				pushUniqueError(job.details, `Completion activity sink failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
+		if (job.finalMessage && !job.suppressCompletionMessage && !job.completionMessageSent && !this.options.isCompletionAcknowledged?.(job.jobId)) {
+			try {
+				await this.options.onComplete?.(this.summary(job));
+				job.completionMessageSent = true;
+			} catch (error) {
+				pushUniqueError(job.details, `Completion reminder failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
 		}
 	}
 
@@ -462,6 +533,7 @@ export class MastraAsyncAgentManager {
 		});
 		const existing = this.jobs.get(jobId);
 		if (existing) return existing;
+		const output = workflowJobOutput(run.result);
 
 		const params: MastraAgentStartInput = {
 			agentId,
@@ -479,15 +551,24 @@ export class MastraAsyncAgentManager {
 			finalMessage: true,
 		};
 		const details = createInitialDetails(params);
-		details.status = isActiveWorkflowStatus(run.status) ? "running" : run.status === "success" ? "done" : isFailedWorkflowStatus(run.status) ? "error" : "aborted";
+		const status = workflowRunStatus(run);
+		details.status = isActiveWorkflowStatus(status)
+			? "running"
+			: output.status === "error"
+				? "error"
+				: status === "success"
+					? "done"
+					: isFailedWorkflowStatus(status)
+						? "error"
+						: "aborted";
 		if (details.status !== "running") {
 			details.updatedAt = Date.now();
 			details.completedAt = details.updatedAt;
 			details.terminalReason = details.status === "done" ? "finish" : details.status === "aborted" ? "abort" : "error";
 		}
 
-		const output = workflowJobOutput(run.result);
 		if (output.text) details.text = output.text;
+		for (const error of output.errors ?? []) pushUniqueError(details, error);
 		const job: MastraAsyncAgentJob = {
 			jobId,
 			jobName,
@@ -500,17 +581,27 @@ export class MastraAsyncAgentManager {
 			artifactPath: output.artifactPath,
 			eventsPath: output.eventsPath,
 			finalMessage: true,
-			lifecycleStatus: isActiveWorkflowStatus(run.status) ? "working" : "agent_response_queued",
+			lifecycleStatus: "working",
 			usesWorkflow: true,
 		};
 		this.jobs.set(jobId, job);
 		this.options.activitySink?.start(jobId, params, details);
-		if (job.lifecycleStatus !== "working") this.options.activitySink?.finish(jobId, details);
 		return job;
 	}
 
-	private canUseWorkflowJobs(): boolean {
-		return this.options.useWorkflowJobs !== false && this.hasClientMethod("startWorkflowAsync") && this.hasClientMethod("observeWorkflow");
+	private canStartWorkflowJobs(): boolean {
+		return this.options.useWorkflowJobs !== false && this.hasClientMethod("streamWorkflow");
+	}
+
+	private canRestoreWorkflowJobs(): boolean {
+		return this.options.useWorkflowJobs !== false && this.hasClientMethod("listWorkflowRuns") && this.hasClientMethod("observeWorkflow");
+	}
+
+	private isSessionWorkflowRun(run: MastraWorkflowRun): boolean {
+		if (!this.piSessionId) return false;
+		const input = workflowRunInput(run);
+		const piSessionId = stringField(input, "piSessionId");
+		return piSessionId ? piSessionId === this.piSessionId : this.isSessionRun(run.runId);
 	}
 
 	private hasClientMethod(name: keyof MastraHttpClient): boolean {
@@ -574,6 +665,10 @@ export class MastraAsyncAgentManager {
 			eventsPath: job.eventsPath,
 		};
 	}
+}
+
+function workflowRunStatus(run: MastraWorkflowRun): string {
+	return typeof run.status === "string" ? run.status : "running";
 }
 
 export interface MastraToolOptions {
@@ -1124,6 +1219,29 @@ export function createWorkflowStreamRequest(params: MastraWorkflowCallInput): Ma
 	};
 }
 
+function workflowJobRequest(job: MastraAsyncAgentJob): MastraWorkflowStreamRequest {
+	return {
+		resourceId: job.details.resourceId,
+		inputData: {
+			jobId: job.jobId,
+			jobName: job.jobName,
+			piSessionId: job.piSessionId,
+			runId: job.runId,
+			agentRunId: job.runId,
+			agentId: job.params.agentId,
+			message: job.params.message,
+			threadId: job.details.threadId,
+			resourceId: job.details.resourceId,
+			requestContext: job.params.requestContext,
+			includeToolResults: job.params.includeToolResults,
+			includeReasoning: job.params.includeReasoning ?? false,
+			input_args: job.params.input_args,
+			timeoutMs: job.params.timeoutMs,
+		},
+		requestContext: job.params.requestContext,
+	};
+}
+
 function createInitialDetails(params: MastraAgentCallInput): MastraAgentCallDetails {
 	const resourceId = params.resourceId ?? defaultResourceId();
 	const now = Date.now();
@@ -1164,6 +1282,10 @@ function markStreamError(details: MastraAgentCallDetails, error: unknown, aborte
 	details.terminalReason = aborted ? "abort" : "error";
 	details.incomplete = false;
 	const message = error instanceof Error ? error.message : String(error);
+	pushUniqueError(details, message);
+}
+
+function pushUniqueError(details: MastraAgentCallDetails, message: string): void {
 	if (!details.errors.includes(message)) details.errors.push(message);
 }
 
@@ -1495,15 +1617,21 @@ function applyWorkflowLifecycleChunk(details: MastraAgentCallDetails, chunk: unk
 	}
 }
 
-function workflowJobOutput(value: unknown): { text?: string; artifactPath?: string; eventsPath?: string } {
+function workflowJobOutput(value: unknown): { status?: "done" | "error"; text?: string; artifactPath?: string; eventsPath?: string; errors?: string[] } {
 	const candidates = objectCandidates(value);
+	let output: { status?: "done" | "error"; text?: string; artifactPath?: string; eventsPath?: string; errors?: string[] } = {};
 	for (const candidate of candidates) {
-		const artifactPath = stringField(candidate, "artifactPath");
-		const eventsPath = stringField(candidate, "eventsPath");
-		const text = stringField(candidate, "text") ?? stringField(candidate, "output") ?? stringField(candidate, "textPreview");
-		if (artifactPath || eventsPath || text) return { artifactPath, eventsPath, text };
+		const rawStatus = stringField(candidate, "status");
+		const status = rawStatus === "done" || rawStatus === "error" ? rawStatus : undefined;
+		output = {
+			status: output.status ?? status,
+			artifactPath: output.artifactPath ?? stringField(candidate, "artifactPath"),
+			eventsPath: output.eventsPath ?? stringField(candidate, "eventsPath"),
+			text: output.text ?? stringField(candidate, "text") ?? stringField(candidate, "output") ?? stringField(candidate, "textPreview"),
+			errors: output.errors ?? stringArrayField(candidate, "errors"),
+		};
 	}
-	return {};
+	return output;
 }
 
 function workflowRunInput(run: MastraWorkflowRun): Record<string, unknown> {
@@ -1561,6 +1689,13 @@ function recordStringField(record: Record<string, unknown>, key: string): Record
 	if (!isRecord(value)) return undefined;
 	const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string");
 	return entries.length === Object.keys(value).length ? Object.fromEntries(entries) : undefined;
+}
+
+function stringArrayField(record: Record<string, unknown>, key: string): string[] | undefined {
+	const value = record[key];
+	if (!Array.isArray(value)) return undefined;
+	const strings = value.filter((entry): entry is string => typeof entry === "string");
+	return strings.length === value.length ? strings : undefined;
 }
 
 function isActiveWorkflowStatus(status: string): boolean {

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -914,10 +914,7 @@ export function createMastraAgentInspectTool(client = new MastraHttpClient(), ma
 				try {
 					const agents = await client.listAgents(signal);
 					const jobs = manager?.inspectJobs() ?? [];
-					const calledAgentIds = new Set(jobs.filter((job) => job.jobId || job.threadId || job.runId).map((job) => job.agentId));
-					const availableAgents = Object.entries(agents)
-						.filter(([agentId]) => !calledAgentIds.has(agentId))
-						.map(([agentId]) => ({ agentId, status: "available" as const }));
+					const availableAgents = Object.entries(agents).map(([agentId]) => ({ agentId, status: "available" as const }));
 					const details: MastraAgentInspectDetails = { agents: [], count: availableAgents.length, errors: [], availableAgents, jobs };
 					return {
 						content: [{ type: "text", text: truncateText(formatAgentInspectSessionResult(details), DEFAULT_MODEL_CONTENT_LIMIT).text }],

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -13,6 +13,7 @@ import {
 	MASTRA_AGENT_CANCEL_TOOL_NAME,
 	MASTRA_AGENT_INSPECT_TOOL_NAME,
 	MASTRA_AGENT_LIST_TOOL_NAME,
+	MASTRA_AGENT_QUERY_TOOL_NAME,
 	MASTRA_AGENT_READ_TOOL_NAME,
 	MASTRA_AGENT_START_TOOL_NAME,
 	MASTRA_AGENT_STATUS_TOOL_NAME,
@@ -35,6 +36,7 @@ import type {
 	MastraAgentInspectDetails,
 	MastraAgentInspectInput,
 	MastraAgentInspection,
+	MastraAgentQueryInput,
 	MastraAgentReadInput,
 	MastraAgentStartInput,
 	MastraAgentStatusInput,
@@ -75,6 +77,19 @@ export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
 	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
 	jobId: Type.Optional(Type.String({ description: "Optional caller-provided async job id" })),
 	finalMessage: Type.Optional(Type.Boolean({ description: "Post a custom final transcript message when the async run completes. Defaults to true." })),
+	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
+});
+
+export const MASTRA_AGENT_QUERY_PARAMETERS = Type.Object({
+	agentId: Type.String({ description: "Mastra agent id to query" }),
+	message: Type.String({ description: "User message to send to the Mastra agent" }),
+	synchronous: Type.Optional(Type.Boolean({ description: "Execute synchronously and return final result. Defaults to false (async-by-default). When false, returns a job id immediately and streams progress to the Pi TUI." })),
+	threadId: Type.Optional(Type.String({ description: "Mastra memory thread id" })),
+	resourceId: Type.Optional(Type.String({ description: "Mastra memory resource id" })),
+	requestContext: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Request-scoped context for Mastra" })),
+	includeToolResults: Type.Optional(Type.Boolean({ description: "Include tool result summaries in model-facing text" })),
+	includeReasoning: Type.Optional(Type.Boolean({ description: "Include reasoning deltas in model-facing text. Defaults to false." })),
+	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
 	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
 });
 
@@ -122,6 +137,7 @@ export const MASTRA_WORKFLOW_STATUS_PARAMETERS = Type.Object({
 	fields: Type.Optional(Type.Array(Type.String(), { description: "Optional workflow run fields to request" })),
 	withNestedWorkflows: Type.Optional(Type.Boolean({ description: "Include nested workflow data in steps" })),
 });
+
 
 const DEFAULT_ASYNC_AGENT_TIMEOUT_MS = 60 * 60_000;
 
@@ -323,6 +339,7 @@ export function createMastraTools(client = new MastraHttpClient(), options: Mast
 			onComplete: options.onAsyncAgentComplete,
 		});
 	return [
+		createMastraAgentQueryTool(asyncAgentManager, client, options.agentActivitySink),
 		createMastraAgentTool(client, options.agentActivitySink),
 		createMastraAgentStartTool(asyncAgentManager),
 		createMastraAgentAsyncStatusTool(asyncAgentManager),
@@ -447,6 +464,127 @@ export function createMastraAgentStartTool(manager: MastraAsyncAgentManager) {
 			return emptyComponent();
 		},
 		renderResult() {
+			return emptyComponent();
+		},
+	};
+}
+
+export function createMastraAgentQueryTool(
+	manager: MastraAsyncAgentManager,
+	client = new MastraHttpClient(),
+	activitySink?: MastraAgentActivitySink,
+) {
+	return {
+		name: MASTRA_AGENT_QUERY_TOOL_NAME,
+		label: "Mastra Agent Query",
+		description: "Call a Mastra agent with async-by-default execution. Returns a job id immediately unless synchronous=true. Supports input_args, includeToolResults, and includeReasoning (default: false). Does not expose maxSteps or activeTools.",
+		promptSnippet: "Query a Mastra agent with async-by-default execution, using a narrower schema than agent_call.",
+		promptGuidelines: [
+			"Use agent_query for Mastra agent delegation when async-by-default behavior is preferred and maxSteps/activeTools are not needed.",
+			"After agent_query returns a jobId (async mode), use agent_read to retrieve output unless the initial prompt explicitly opts out.",
+		],
+		parameters: MASTRA_AGENT_QUERY_PARAMETERS,
+		renderShell: "self" as const,
+		async execute(
+			_toolCallId: string,
+			params: MastraAgentQueryInput,
+			signal?: AbortSignal,
+			onUpdate?: AgentToolUpdateCallback<MastraAgentCallDetails>,
+		): Promise<AgentToolResult<MastraAgentCallDetails | Record<string, unknown>>> {
+			// Default to async unless synchronous is explicitly true
+			if (params.synchronous !== true) {
+				if (signal?.aborted) {
+					return {
+						content: [{ type: "text", text: "Async Mastra agent query was aborted before launch." }],
+						details: {
+							jobId: "",
+							agentId: params.agentId,
+							modeId: undefined,
+							threadId: params.threadId ?? defaultThreadId(params.agentId),
+							resourceId: params.resourceId ?? defaultResourceId(),
+							status: "aborted",
+							prompt: params.message,
+							textPreview: "",
+							toolCalls: 0,
+							toolResults: 0,
+							rawChunkCount: 0,
+							chunksTruncated: false,
+							errors: ["aborted before launch"],
+						} as unknown as Record<string, unknown>,
+					};
+				}
+				try {
+					const summary = await manager.start({
+						agentId: params.agentId,
+						message: params.message,
+						threadId: params.threadId,
+						resourceId: params.resourceId,
+						requestContext: params.requestContext,
+						includeToolResults: params.includeToolResults,
+						includeReasoning: params.includeReasoning ?? false,
+						timeoutMs: params.timeoutMs,
+						input_args: params.input_args,
+					});
+					return {
+						content: [{ type: "text", text: formatAsyncStartResult(summary) }],
+						details: summary as unknown as Record<string, unknown>,
+					};
+				} catch (error) {
+					return errorResult(error, { jobId: "", agentId: params.agentId, status: "error" });
+				}
+			}
+
+			// Synchronous path: stream via client.streamAgent (same pattern as agent_call)
+			const details = createInitialDetails({
+				agentId: params.agentId,
+				message: params.message,
+				threadId: params.threadId,
+				resourceId: params.resourceId,
+				requestContext: params.requestContext,
+				includeToolResults: params.includeToolResults,
+				includeReasoning: params.includeReasoning,
+				timeoutMs: params.timeoutMs,
+				input_args: params.input_args,
+			});
+			const request = createStreamRequest(params, details.threadId, details.resourceId);
+			const emitUpdate = () => {
+				details.updatedAt = Date.now();
+				activitySink?.update(_toolCallId, details);
+				onUpdate?.(makeToolResult(details, params));
+			};
+
+			activitySink?.start(_toolCallId, params, details);
+			emitUpdate();
+
+			try {
+				for await (const chunk of client.streamAgent(params.agentId, request, { signal, timeoutMs: params.timeoutMs })) {
+					applyNormalizedEvent(details, normalizeMastraChunk(chunk));
+					emitUpdate();
+				}
+
+				if (details.status === "running") details.status = "done";
+				details.updatedAt = Date.now();
+				details.completedAt = details.completedAt ?? details.updatedAt;
+				activitySink?.finish(_toolCallId, details);
+				return makeToolResult(details, params);
+			} catch (error) {
+				details.status = signal?.aborted ? "aborted" : "error";
+				details.updatedAt = Date.now();
+				details.completedAt = details.updatedAt;
+				details.errors.push(error instanceof Error ? error.message : String(error));
+				activitySink?.finish(_toolCallId, details);
+				return makeToolResult(details, params);
+			}
+		},
+		renderCall(args: MastraAgentQueryInput, theme: any) {
+			const mode = args.synchronous ? "sync" : "async";
+			return new Text(`${theme.fg("toolTitle", theme.bold("mastra query "))}${theme.fg("accent", args.agentId)}${theme.fg("dim", ` mode=${mode}`)}`, 0, 0);
+		},
+		renderResult(result: AgentToolResult<MastraAgentCallDetails | Record<string, unknown>>, options: { expanded?: boolean; isPartial?: boolean }, theme: any) {
+			// If result has text/toolCalls it's a sync call details; otherwise async summary
+			if (result.details && "text" in (result.details as any) && "toolCalls" in (result.details as any)) {
+				return new MastraAgentCard(result.details as MastraAgentCallDetails, options, theme);
+			}
 			return emptyComponent();
 		},
 	};

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -9,14 +9,13 @@ import { Type } from "typebox";
 import {
 	DEFAULT_MODEL_CONTENT_LIMIT,
 	MASTRA_AGENT_ASYNC_STATUS_TOOL_NAME,
-	MASTRA_AGENT_CALL_TOOL_NAME,
 	MASTRA_AGENT_CANCEL_TOOL_NAME,
 	MASTRA_AGENT_INSPECT_TOOL_NAME,
 	MASTRA_AGENT_LIST_TOOL_NAME,
 	MASTRA_AGENT_QUERY_TOOL_NAME,
 	MASTRA_AGENT_READ_TOOL_NAME,
-	MASTRA_AGENT_START_TOOL_NAME,
 	MASTRA_AGENT_STATUS_TOOL_NAME,
+	MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
 	MASTRA_WORKFLOW_CALL_TOOL_NAME,
 	MASTRA_WORKFLOW_LIST_TOOL_NAME,
 	MASTRA_WORKFLOW_STATUS_TOOL_NAME,
@@ -24,7 +23,7 @@ import {
 } from "../const.js";
 import { MastraAgentCard } from "../tui/index.js";
 import { MastraHttpClient } from "./client.js";
-import { defaultResourceId, defaultThreadId } from "./memory.js";
+import { defaultPiSessionRunId, defaultPiSessionThreadId, defaultResourceId, defaultThreadId, safeIdPart } from "./memory.js";
 import { applyNormalizedEvent, normalizeMastraChunk, truncateText } from "./normalize.js";
 import type {
 	MastraAgentAsyncJobSummary,
@@ -32,10 +31,12 @@ import type {
 	MastraAgentCallDetails,
 	MastraAgentCallInput,
 	MastraAgentCancelInput,
+	MastraAgentInspectJob,
 	MastraAgentInfo,
 	MastraAgentInspectDetails,
 	MastraAgentInspectInput,
 	MastraAgentInspection,
+	MastraAgentLifecycleStatus,
 	MastraAgentQueryInput,
 	MastraAgentReadInput,
 	MastraAgentStartInput,
@@ -50,39 +51,10 @@ import type {
 	MastraWorkflowStreamRequest,
 } from "./types.js";
 
-export const MASTRA_AGENT_CALL_PARAMETERS = Type.Object({
-	agentId: Type.String({ description: "Mastra agent id to call" }),
-	message: Type.String({ description: "User message to send to the Mastra agent" }),
-	modeId: Type.Optional(Type.String({ description: "Agent harness mode id, forwarded as requestContext.modeId" })),
-	threadId: Type.Optional(Type.String({ description: "Mastra memory thread id" })),
-	resourceId: Type.Optional(Type.String({ description: "Mastra memory resource id" })),
-	maxSteps: Type.Optional(Type.Number({ description: "Maximum Mastra agent steps" })),
-	activeTools: Type.Optional(Type.Array(Type.String(), { description: "Mastra active tool allow-list" })),
-	requestContext: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Request-scoped context for Mastra" })),
-	includeToolResults: Type.Optional(Type.Boolean({ description: "Include tool result summaries in model-facing text" })),
-	includeReasoning: Type.Optional(Type.Boolean({ description: "Include reasoning deltas in model-facing text" })),
-	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
-	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
-});
-
-export const MASTRA_AGENT_START_PARAMETERS = Type.Object({
-	agentId: Type.String({ description: "Mastra agent id to call asynchronously" }),
-	message: Type.String({ description: "User message to send to the Mastra agent" }),
-	modeId: Type.Optional(Type.String({ description: "Agent harness mode id, forwarded as requestContext.modeId" })),
-	threadId: Type.Optional(Type.String({ description: "Mastra memory thread id" })),
-	resourceId: Type.Optional(Type.String({ description: "Mastra memory resource id" })),
-	maxSteps: Type.Optional(Type.Number({ description: "Maximum Mastra agent steps" })),
-	activeTools: Type.Optional(Type.Array(Type.String(), { description: "Mastra active tool allow-list" })),
-	requestContext: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Request-scoped context for Mastra" })),
-	timeoutMs: Type.Optional(Type.Number({ description: "Stream timeout in milliseconds" })),
-	jobId: Type.Optional(Type.String({ description: "Optional caller-provided async job id" })),
-	finalMessage: Type.Optional(Type.Boolean({ description: "Post a custom final transcript message when the async run completes. Defaults to true." })),
-	input_args: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Optional key-value pairs providing contextual bindings for literal placeholders like $1, $2 in the prompt body. Values are appended to the prompt section and mirrored into requestContext. Keys are sorted numerically." })),
-});
-
 export const MASTRA_AGENT_QUERY_PARAMETERS = Type.Object({
 	agentId: Type.String({ description: "Mastra agent id to query" }),
 	message: Type.String({ description: "User message to send to the Mastra agent" }),
+	jobName: Type.Optional(Type.String({ description: "Short semantic name for this background job. Used in the Mastra thread id; omit to derive one from the prompt." })),
 	synchronous: Type.Optional(Type.Boolean({ description: "Execute synchronously and return final result. Defaults to false (async-by-default). When false, returns a job id immediately and streams progress to the Pi TUI." })),
 	threadId: Type.Optional(Type.String({ description: "Mastra memory thread id" })),
 	resourceId: Type.Optional(Type.String({ description: "Mastra memory resource id" })),
@@ -143,6 +115,10 @@ const DEFAULT_ASYNC_AGENT_TIMEOUT_MS = 60 * 60_000;
 
 interface MastraAsyncAgentJob {
 	jobId: string;
+	jobName: string;
+	piSessionId?: string;
+	runId?: string;
+	workflowId?: string;
 	params: MastraAgentStartInput;
 	details: MastraAgentCallDetails;
 	controller: AbortController;
@@ -150,51 +126,103 @@ interface MastraAsyncAgentJob {
 	eventsPath?: string;
 	finalMessage: boolean;
 	suppressCompletionMessage?: boolean;
+	lifecycleStatus: Exclude<MastraAgentLifecycleStatus, "available">;
+	usesWorkflow: boolean;
 }
 
 export interface MastraAsyncAgentManagerOptions {
 	activitySink?: MastraAgentActivitySink;
 	onComplete?: (summary: MastraAgentAsyncJobSummary) => void | Promise<void>;
+	useWorkflowJobs?: boolean;
+	isCompletionAcknowledged?: (jobId: string) => boolean;
+	cwd?: string;
+	piSessionId?: string;
 }
 
 export class MastraAsyncAgentManager {
 	private readonly jobs = new Map<string, MastraAsyncAgentJob>();
+	private suppressCompletionMessages = false;
+	private piSessionId: string | undefined;
+	private cwd: string;
 
 	constructor(
 		private readonly client = new MastraHttpClient(),
 		private readonly options: MastraAsyncAgentManagerOptions = {},
-	) {}
+	) {
+		this.piSessionId = options.piSessionId;
+		this.cwd = options.cwd ?? process.cwd();
+	}
+
+	configureSession(params: { piSessionId: string; cwd: string; isCompletionAcknowledged?: (jobId: string) => boolean }): void {
+		this.piSessionId = params.piSessionId;
+		this.cwd = params.cwd;
+		this.options.isCompletionAcknowledged = params.isCompletionAcknowledged;
+	}
 
 	async start(params: MastraAgentStartInput): Promise<MastraAgentAsyncJobSummary> {
-		const jobId = normalizeJobId(params.jobId);
+		const jobName = normalizeJobName(params.jobName ?? params.jobId ?? params.message);
+		const jobId = normalizeJobId(params.jobId ?? `${jobName}-${Date.now()}-${randomUUID().slice(0, 8)}`);
 		if (this.jobs.has(jobId)) throw new Error(`Async Mastra agent job already exists: ${jobId}`);
 
-		// Async jobs for the same agent can run concurrently. If they share the
-		// normal per-agent default thread, Mastra's thread-scoped memory and
-		// observability can serialize or merge their streams, making TUI cards look
-		// like only one job is live. Use the normalized job id to isolate default
-		// async runs while still honoring an explicit caller-provided threadId.
+		const piSessionId = params.piSessionId ?? this.piSessionId ?? "local-session";
+		const resourceId = params.resourceId ?? defaultResourceId(this.cwd);
+		const threadId = params.threadId ?? defaultPiSessionThreadId({
+			piSessionId,
+			jobName,
+			agentName: params.agentId,
+			resourceId,
+		});
+		const runId = defaultPiSessionRunId({
+			piSessionId,
+			jobName,
+			agentName: params.agentId,
+			resourceId,
+			jobId,
+		});
 		const effectiveParams: MastraAgentStartInput = {
 			...params,
 			jobId,
-			threadId: params.threadId ?? defaultAsyncThreadId(params.agentId, jobId),
+			jobName,
+			piSessionId,
+			threadId,
+			resourceId,
+			finalMessage: params.finalMessage ?? true,
 		};
 		const details = createInitialDetails(effectiveParams);
-		const artifactDir = await mkdtemp(join(tmpdir(), `${jobId}-`));
 		const job: MastraAsyncAgentJob = {
 			jobId,
+			jobName,
+			piSessionId,
+			runId,
+			workflowId: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
 			params: effectiveParams,
 			details,
 			controller: new AbortController(),
-			artifactPath: join(artifactDir, "output.txt"),
-			eventsPath: join(artifactDir, "events.jsonl"),
 			finalMessage: effectiveParams.finalMessage !== false,
+			suppressCompletionMessage: this.suppressCompletionMessages,
+			lifecycleStatus: "working",
+			usesWorkflow: false,
 		};
 		this.jobs.set(jobId, job);
 		this.options.activitySink?.start(jobId, effectiveParams, details);
 
-		const request = createStreamRequest(effectiveParams, details.threadId, details.resourceId);
-		void this.run(job, request);
+		if (this.canUseWorkflowJobs()) {
+			try {
+				await this.startWorkflowJob(job);
+				void this.observeWorkflowJob(job);
+				return this.summary(job);
+			} catch (error) {
+				// During local development the Pi package can be newer than the running
+				// Mastra server. Fall back to the direct stream so agent_query remains
+				// usable, but keep the session/thread id convention identical.
+				job.details.errors.push(`Workflow job runner unavailable, falling back to direct stream: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
+
+		const artifactDir = await mkdtemp(join(tmpdir(), `${jobId}-`));
+		job.artifactPath = join(artifactDir, "output.txt");
+		job.eventsPath = join(artifactDir, "events.jsonl");
+		void this.runDirect(job, createStreamRequest(effectiveParams, details.threadId, details.resourceId));
 		return this.summary(job);
 	}
 
@@ -220,7 +248,7 @@ export class MastraAsyncAgentManager {
 			return { text: formatAsyncJobSummary(summary), summary };
 		}
 
-		const output = await this.readArtifact(job);
+		const output = appendIncompleteReadNotice(await this.readArtifact(job), summary);
 		if (mode === "full") {
 			const truncated = truncateText(output || job.details.text || "(no text output)", maxChars);
 			const artifactNotice = job.artifactPath ? `\n\nFull output artifact: ${job.artifactPath}` : "";
@@ -231,19 +259,30 @@ export class MastraAsyncAgentManager {
 		return { text: tailText(text, maxChars), summary };
 	}
 
-	cancel(jobId: string, reason = "cancelled"): MastraAgentAsyncJobSummary | undefined {
+	async cancel(jobId: string, reason = "cancelled"): Promise<MastraAgentAsyncJobSummary | undefined> {
 		const job = this.jobs.get(jobId);
 		if (!job) return undefined;
-		if (job.details.status === "running") {
+		if (job.lifecycleStatus === "working" || job.details.status === "running") {
 			job.details.errors.push(reason);
 			job.controller.abort(new Error(reason));
+			if (job.usesWorkflow && job.workflowId && job.runId && this.hasClientMethod("cancelWorkflowRun")) {
+				await this.client.cancelWorkflowRun(job.workflowId, job.runId).catch((error) => {
+					job.details.errors.push(error instanceof Error ? error.message : String(error));
+				});
+			}
+			job.details.status = "aborted";
+			job.details.updatedAt = Date.now();
+			job.details.completedAt = job.details.updatedAt;
+			job.details.terminalReason = "abort";
 		}
+		this.markEnded(jobId);
 		return this.summary(job);
 	}
 
 	cancelAll(reason = "session shutdown", options: { suppressCompletionMessage?: boolean } = {}): void {
+		if (options.suppressCompletionMessage === true) this.suppressCompletionMessages = true;
 		for (const job of this.jobs.values()) {
-			job.suppressCompletionMessage = options.suppressCompletionMessage ?? job.suppressCompletionMessage;
+			if (options.suppressCompletionMessage === true) job.suppressCompletionMessage = true;
 			if (job.details.status === "running") {
 				job.details.errors.push(reason);
 				job.controller.abort(new Error(reason));
@@ -251,7 +290,69 @@ export class MastraAsyncAgentManager {
 		}
 	}
 
-	private async run(job: MastraAsyncAgentJob, request: MastraStreamRequest): Promise<void> {
+	detachAll(reason = "session shutdown"): void {
+		for (const job of this.jobs.values()) {
+			if (job.usesWorkflow && job.lifecycleStatus === "working") {
+				job.controller.abort(new Error(reason));
+			}
+		}
+		this.options.activitySink?.reset?.();
+	}
+
+	markEnded(jobId: string): MastraAgentAsyncJobSummary | undefined {
+		const job = this.jobs.get(jobId);
+		if (!job) return undefined;
+		job.lifecycleStatus = "ended";
+		this.options.activitySink?.end?.(jobId);
+		return this.summary(job);
+	}
+
+	async restoreSessionJobs(): Promise<MastraAgentAsyncJobSummary[]> {
+		if (!this.canUseWorkflowJobs() || !this.piSessionId) return [];
+		const resourceId = defaultResourceId(this.cwd);
+		let runs: MastraWorkflowRun[];
+		try {
+			runs = await this.client.listWorkflowRuns(MASTRA_PI_AGENT_JOB_WORKFLOW_ID, { resourceId });
+		} catch {
+			return [];
+		}
+
+		const restored: MastraAgentAsyncJobSummary[] = [];
+		for (const run of runs.filter((candidate) => this.isSessionRun(candidate.runId))) {
+			const job = this.jobFromWorkflowRun(run);
+			if (!job) continue;
+			restored.push(this.summary(job));
+
+			if (isActiveWorkflowStatus(run.status) && !job.controller.signal.aborted) {
+				void this.observeWorkflowJob(job);
+				continue;
+			}
+
+			await this.refreshWorkflowRun(job).catch(() => undefined);
+			if (this.options.isCompletionAcknowledged?.(job.jobId)) {
+				this.markEnded(job.jobId);
+			} else if (isTerminalWorkflowStatus(run.status)) {
+				await this.completeJob(job);
+			}
+		}
+		return restored;
+	}
+
+	inspectJobs(): MastraAgentInspectJob[] {
+		return this.list().map((summary) => ({
+			jobId: summary.jobId,
+			jobName: summary.jobName,
+			agentId: summary.agentId,
+			status: summary.lifecycleStatus ?? "working",
+			threadId: summary.threadId,
+			resourceId: summary.resourceId,
+			runId: summary.runId,
+			workflowId: summary.workflowId,
+			updatedAt: summary.updatedAt,
+		}));
+	}
+
+	private async runDirect(job: MastraAsyncAgentJob, request: MastraStreamRequest): Promise<void> {
 		try {
 			const timeoutMs = job.params.timeoutMs ?? DEFAULT_ASYNC_AGENT_TIMEOUT_MS;
 			for await (const chunk of this.client.streamAgent(job.params.agentId, request, { signal: job.controller.signal, timeoutMs })) {
@@ -261,21 +362,164 @@ export class MastraAsyncAgentManager {
 				this.options.activitySink?.update(job.jobId, job.details);
 			}
 
-			if (job.details.status === "running") job.details.status = "done";
-			job.details.updatedAt = Date.now();
-			job.details.completedAt = job.details.completedAt ?? job.details.updatedAt;
+			markStreamEofIncomplete(job.details);
 		} catch (error) {
-			job.details.status = job.controller.signal.aborted ? "aborted" : "error";
+			markStreamError(job.details, error, job.controller.signal.aborted);
+		} finally {
+			await this.completeJob(job);
+		}
+	}
+
+	private async startWorkflowJob(job: MastraAsyncAgentJob): Promise<void> {
+		if (!job.workflowId || !job.runId) throw new Error("Workflow job is missing workflow/run id");
+		await this.client.startWorkflowAsync(job.workflowId, job.runId, {
+			resourceId: job.details.resourceId,
+			inputData: {
+				jobId: job.jobId,
+				jobName: job.jobName,
+				piSessionId: job.piSessionId,
+				agentId: job.params.agentId,
+				message: job.params.message,
+				threadId: job.details.threadId,
+				resourceId: job.details.resourceId,
+				requestContext: job.params.requestContext,
+				includeToolResults: job.params.includeToolResults,
+				includeReasoning: job.params.includeReasoning ?? false,
+				input_args: job.params.input_args,
+				timeoutMs: job.params.timeoutMs,
+			},
+			requestContext: job.params.requestContext,
+		}, { signal: job.controller.signal });
+		job.usesWorkflow = true;
+	}
+
+	private async observeWorkflowJob(job: MastraAsyncAgentJob): Promise<void> {
+		if (!job.workflowId || !job.runId) return;
+		try {
+			const timeoutMs = job.params.timeoutMs ?? DEFAULT_ASYNC_AGENT_TIMEOUT_MS;
+			for await (const chunk of this.client.observeWorkflow(job.workflowId, job.runId, { resourceId: job.details.resourceId }, { signal: job.controller.signal, timeoutMs })) {
+				const agentChunk = unwrapWorkflowAgentChunk(chunk);
+				if (agentChunk !== undefined) {
+					const normalized = normalizeMastraChunk(agentChunk);
+					await this.persistChunk(job, agentChunk, normalized);
+					applyNormalizedEvent(job.details, normalized);
+					this.options.activitySink?.update(job.jobId, job.details);
+					continue;
+				}
+				applyWorkflowLifecycleChunk(job.details, chunk);
+				this.options.activitySink?.update(job.jobId, job.details);
+			}
+			await this.refreshWorkflowRun(job);
+			if (job.details.status === "running") markStreamEofIncomplete(job.details);
+		} catch (error) {
+			markStreamError(job.details, error, job.controller.signal.aborted);
+		} finally {
+			await this.completeJob(job);
+		}
+	}
+
+	private async refreshWorkflowRun(job: MastraAsyncAgentJob): Promise<void> {
+		if (!job.workflowId || !job.runId || !this.hasClientMethod("getWorkflowRun")) return;
+		const run = await this.client.getWorkflowRun(job.workflowId, job.runId, { fields: ["result", "error", "status"] });
+		const output = workflowJobOutput(run.result);
+		if (output.artifactPath) job.artifactPath = output.artifactPath;
+		if (output.eventsPath) job.eventsPath = output.eventsPath;
+		if (output.text && !job.details.text) job.details.text = output.text;
+
+		if (run.status === "success" && job.details.status === "running") {
+			job.details.status = "done";
 			job.details.updatedAt = Date.now();
 			job.details.completedAt = job.details.updatedAt;
-			const message = error instanceof Error ? error.message : String(error);
-			if (!job.details.errors.includes(message)) job.details.errors.push(message);
-		} finally {
-			this.options.activitySink?.finish(job.jobId, job.details);
-			if (job.finalMessage && !job.suppressCompletionMessage) {
-				await this.options.onComplete?.(this.summary(job));
-			}
+			job.details.terminalReason = "finish";
+		} else if (run.status === "canceled" && job.details.status === "running") {
+			markStreamError(job.details, "Workflow run canceled", true);
+		} else if (isFailedWorkflowStatus(run.status) && job.details.status === "running") {
+			markStreamError(job.details, run.error ?? `Workflow run failed with status ${run.status}`, false);
 		}
+	}
+
+	private async completeJob(job: MastraAsyncAgentJob): Promise<void> {
+		if (job.lifecycleStatus === "ended") return;
+		job.lifecycleStatus = "agent_response_queued";
+		this.options.activitySink?.finish(job.jobId, job.details);
+		if (job.finalMessage && !job.suppressCompletionMessage && !this.options.isCompletionAcknowledged?.(job.jobId)) {
+			await this.options.onComplete?.(this.summary(job));
+		}
+	}
+
+	private jobFromWorkflowRun(run: MastraWorkflowRun): MastraAsyncAgentJob | undefined {
+		const input = workflowRunInput(run);
+		const jobId = stringField(input, "jobId") ?? jobIdFromRunId(run.runId);
+		const agentId = stringField(input, "agentId") ?? "unknown-agent";
+		const jobName = normalizeJobName(stringField(input, "jobName") ?? jobId);
+		const resourceId = run.resourceId ?? stringField(input, "resourceId") ?? defaultResourceId(this.cwd);
+		const piSessionId = stringField(input, "piSessionId") ?? this.piSessionId;
+		const threadId = stringField(input, "threadId") ?? defaultPiSessionThreadId({
+			piSessionId: piSessionId ?? "local-session",
+			jobName,
+			agentName: agentId,
+			resourceId,
+		});
+		const existing = this.jobs.get(jobId);
+		if (existing) return existing;
+
+		const params: MastraAgentStartInput = {
+			agentId,
+			message: stringField(input, "message") ?? "",
+			jobId,
+			jobName,
+			piSessionId,
+			threadId,
+			resourceId,
+			requestContext: recordField(input, "requestContext"),
+			includeReasoning: booleanField(input, "includeReasoning"),
+			includeToolResults: booleanField(input, "includeToolResults"),
+			input_args: recordStringField(input, "input_args"),
+			timeoutMs: numberField(input, "timeoutMs"),
+			finalMessage: true,
+		};
+		const details = createInitialDetails(params);
+		details.status = isActiveWorkflowStatus(run.status) ? "running" : run.status === "success" ? "done" : isFailedWorkflowStatus(run.status) ? "error" : "aborted";
+		if (details.status !== "running") {
+			details.updatedAt = Date.now();
+			details.completedAt = details.updatedAt;
+			details.terminalReason = details.status === "done" ? "finish" : details.status === "aborted" ? "abort" : "error";
+		}
+
+		const output = workflowJobOutput(run.result);
+		if (output.text) details.text = output.text;
+		const job: MastraAsyncAgentJob = {
+			jobId,
+			jobName,
+			piSessionId,
+			runId: run.runId,
+			workflowId: MASTRA_PI_AGENT_JOB_WORKFLOW_ID,
+			params,
+			details,
+			controller: new AbortController(),
+			artifactPath: output.artifactPath,
+			eventsPath: output.eventsPath,
+			finalMessage: true,
+			lifecycleStatus: isActiveWorkflowStatus(run.status) ? "working" : "agent_response_queued",
+			usesWorkflow: true,
+		};
+		this.jobs.set(jobId, job);
+		this.options.activitySink?.start(jobId, params, details);
+		if (job.lifecycleStatus !== "working") this.options.activitySink?.finish(jobId, details);
+		return job;
+	}
+
+	private canUseWorkflowJobs(): boolean {
+		return this.options.useWorkflowJobs !== false && this.hasClientMethod("startWorkflowAsync") && this.hasClientMethod("observeWorkflow");
+	}
+
+	private hasClientMethod(name: keyof MastraHttpClient): boolean {
+		return typeof this.client[name] === "function";
+	}
+
+	private isSessionRun(runId: string): boolean {
+		if (!this.piSessionId) return false;
+		return runId.includes(`-${safeIdPart(this.piSessionId)}-`);
 	}
 
 	private async persistChunk(job: MastraAsyncAgentJob, chunk: unknown, normalized: ReturnType<typeof normalizeMastraChunk>): Promise<void> {
@@ -319,6 +563,13 @@ export class MastraAsyncAgentManager {
 			rawChunkCount: details.rawChunkCount,
 			chunksTruncated: details.chunksTruncated,
 			errors: [...details.errors],
+			terminalReason: details.terminalReason,
+			incomplete: details.incomplete,
+			jobName: job.jobName,
+			piSessionId: job.piSessionId,
+			runId: job.runId,
+			workflowId: job.workflowId,
+			lifecycleStatus: job.lifecycleStatus,
 			artifactPath: job.artifactPath,
 			eventsPath: job.eventsPath,
 		};
@@ -340,133 +591,13 @@ export function createMastraTools(client = new MastraHttpClient(), options: Mast
 		});
 	return [
 		createMastraAgentQueryTool(asyncAgentManager, client, options.agentActivitySink),
-		createMastraAgentTool(client, options.agentActivitySink),
-		createMastraAgentStartTool(asyncAgentManager),
-		createMastraAgentAsyncStatusTool(asyncAgentManager),
 		createMastraAgentReadTool(asyncAgentManager),
 		createMastraAgentCancelTool(asyncAgentManager),
-		createMastraAgentListTool(client),
-		createMastraAgentInspectTool(client),
-		createMastraAgentStatusTool(client),
+		createMastraAgentInspectTool(client, asyncAgentManager),
 		createMastraWorkflowCallTool(client),
 		createMastraWorkflowListTool(client),
 		createMastraWorkflowStatusTool(client),
 	];
-}
-
-export function createMastraAgentTool(client = new MastraHttpClient(), activitySink?: MastraAgentActivitySink) {
-	return {
-		name: MASTRA_AGENT_CALL_TOOL_NAME,
-		label: "Mastra Agent",
-		description: "Call a Mastra agent through the HTTP streaming API and return streamed text plus structured run details.",
-		promptSnippet: "Call a Mastra agent by id when specialist Mastra execution is needed.",
-		promptGuidelines: [
-			"Use agent_call when the user asks to route work through a Mastra agent and you need the final output before continuing.",
-			"Prefer agent_start for long-running Mastra agent delegation so live progress can stream to the Pi TUI while the parent turn continues.",
-		],
-		parameters: MASTRA_AGENT_CALL_PARAMETERS,
-		async execute(
-			toolCallId: string,
-			params: MastraAgentCallInput,
-			signal?: AbortSignal,
-			onUpdate?: AgentToolUpdateCallback<MastraAgentCallDetails>,
-		): Promise<AgentToolResult<MastraAgentCallDetails>> {
-			const details = createInitialDetails(params);
-			const request = createStreamRequest(params, details.threadId, details.resourceId);
-			const emitUpdate = () => {
-				details.updatedAt = Date.now();
-				activitySink?.update(toolCallId, details);
-				onUpdate?.(makeToolResult(details, params));
-			};
-
-			activitySink?.start(toolCallId, params, details);
-			emitUpdate();
-
-			try {
-				for await (const chunk of client.streamAgent(params.agentId, request, { signal, timeoutMs: params.timeoutMs })) {
-					applyNormalizedEvent(details, normalizeMastraChunk(chunk));
-					emitUpdate();
-				}
-
-				if (details.status === "running") details.status = "done";
-				details.updatedAt = Date.now();
-				details.completedAt = details.completedAt ?? details.updatedAt;
-				activitySink?.finish(toolCallId, details);
-				return makeToolResult(details, params);
-			} catch (error) {
-				details.status = signal?.aborted ? "aborted" : "error";
-				details.updatedAt = Date.now();
-				details.completedAt = details.updatedAt;
-				details.errors.push(error instanceof Error ? error.message : String(error));
-				activitySink?.finish(toolCallId, details);
-				return makeToolResult(details, params);
-			}
-		},
-		renderCall(args: MastraAgentCallInput, theme: any) {
-			const mode = args.modeId ? theme.fg("dim", ` mode=${args.modeId}`) : "";
-			return new Text(`${theme.fg("toolTitle", theme.bold("mastra "))}${theme.fg("accent", args.agentId)}${mode}`, 0, 0);
-		},
-		renderResult(result: AgentToolResult<MastraAgentCallDetails>, options: { expanded?: boolean; isPartial?: boolean }, theme: any) {
-			return new MastraAgentCard(result.details, options, theme);
-		},
-	};
-}
-
-export function createMastraAgentStartTool(manager: MastraAsyncAgentManager) {
-	return {
-		name: MASTRA_AGENT_START_TOOL_NAME,
-		label: "Mastra Agent Start",
-		description: "Start a Mastra agent call asynchronously. Returns a job id immediately while live output streams to the Pi TUI widget; after completion, read the job output by default unless the initial user prompt explicitly opted out.",
-		promptSnippet: "Start a Mastra agent in the background, stream progress to the Pi TUI, and read completed output by default.",
-		promptGuidelines: [
-			"Use agent_start for long-running Mastra agent delegation when live TUI progress is useful and the final answer can be fetched later.",
-			"After agent_start returns a jobId, use agent_async_status to check progress and agent_read to retrieve output without rerunning the agent.",
-			"When an async job completes, call agent_read before finalizing so you can incorporate the output, unless the user's initial prompt explicitly opted out with wording like \"pass the output\" or \"don't read the output\".",
-		],
-		parameters: MASTRA_AGENT_START_PARAMETERS,
-		// The async starter returns a model-visible receipt, but live progress is
-		// rendered by MastraAgentsWidget. Self-rendering an empty component prevents
-		// a duplicate static `mastra async` card from competing with the live card.
-		renderShell: "self" as const,
-		async execute(_toolCallId: string, params: MastraAgentStartInput, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
-			if (signal?.aborted) {
-				return {
-					content: [{ type: "text", text: "Async Mastra agent start was aborted before launch." }],
-					details: {
-						jobId: params.jobId ?? "",
-						agentId: params.agentId,
-						modeId: params.modeId,
-						threadId: params.threadId ?? defaultThreadId(params.agentId),
-						resourceId: params.resourceId ?? defaultResourceId(),
-						status: "aborted",
-						prompt: params.message,
-						textPreview: "",
-						toolCalls: 0,
-						toolResults: 0,
-						rawChunkCount: 0,
-						chunksTruncated: false,
-						errors: ["aborted before launch"],
-					} as Record<string, unknown>,
-				};
-			}
-
-			try {
-				const summary = await manager.start(params);
-				return {
-					content: [{ type: "text", text: formatAsyncStartResult(summary) }],
-					details: summary as unknown as Record<string, unknown>,
-				};
-			} catch (error) {
-				return errorResult(error, { jobId: params.jobId ?? "", agentId: params.agentId, status: "error" });
-			}
-		},
-		renderCall() {
-			return emptyComponent();
-		},
-		renderResult() {
-			return emptyComponent();
-		},
-	};
 }
 
 export function createMastraAgentQueryTool(
@@ -478,7 +609,7 @@ export function createMastraAgentQueryTool(
 		name: MASTRA_AGENT_QUERY_TOOL_NAME,
 		label: "Mastra Agent Query",
 		description: "Call a Mastra agent with async-by-default execution. Returns a job id immediately unless synchronous=true. Supports input_args, includeToolResults, and includeReasoning (default: false). Does not expose maxSteps or activeTools.",
-		promptSnippet: "Query a Mastra agent with async-by-default execution, using a narrower schema than agent_call.",
+		promptSnippet: "Query a Mastra agent with async-by-default execution.",
 		promptGuidelines: [
 			"Use agent_query for Mastra agent delegation when async-by-default behavior is preferred and maxSteps/activeTools are not needed.",
 			"After agent_query returns a jobId (async mode), use agent_read to retrieve output unless the initial prompt explicitly opts out.",
@@ -510,6 +641,8 @@ export function createMastraAgentQueryTool(
 							rawChunkCount: 0,
 							chunksTruncated: false,
 							errors: ["aborted before launch"],
+							terminalReason: "abort",
+							incomplete: false,
 						} as unknown as Record<string, unknown>,
 					};
 				}
@@ -517,6 +650,7 @@ export function createMastraAgentQueryTool(
 					const summary = await manager.start({
 						agentId: params.agentId,
 						message: params.message,
+						jobName: params.jobName,
 						threadId: params.threadId,
 						resourceId: params.resourceId,
 						requestContext: params.requestContext,
@@ -524,6 +658,7 @@ export function createMastraAgentQueryTool(
 						includeReasoning: params.includeReasoning ?? false,
 						timeoutMs: params.timeoutMs,
 						input_args: params.input_args,
+						finalMessage: true,
 					});
 					return {
 						content: [{ type: "text", text: formatAsyncStartResult(summary) }],
@@ -534,10 +669,11 @@ export function createMastraAgentQueryTool(
 				}
 			}
 
-			// Synchronous path: stream via client.streamAgent (same pattern as agent_call)
+			// Synchronous path: stream via client.streamAgent and return final details.
 			const details = createInitialDetails({
 				agentId: params.agentId,
 				message: params.message,
+				jobName: params.jobName,
 				threadId: params.threadId,
 				resourceId: params.resourceId,
 				requestContext: params.requestContext,
@@ -562,17 +698,14 @@ export function createMastraAgentQueryTool(
 					emitUpdate();
 				}
 
-				if (details.status === "running") details.status = "done";
-				details.updatedAt = Date.now();
-				details.completedAt = details.completedAt ?? details.updatedAt;
+				markStreamEofIncomplete(details);
 				activitySink?.finish(_toolCallId, details);
+				activitySink?.end?.(_toolCallId);
 				return makeToolResult(details, params);
 			} catch (error) {
-				details.status = signal?.aborted ? "aborted" : "error";
-				details.updatedAt = Date.now();
-				details.completedAt = details.updatedAt;
-				details.errors.push(error instanceof Error ? error.message : String(error));
+				markStreamError(details, error, signal?.aborted === true);
 				activitySink?.finish(_toolCallId, details);
+				activitySink?.end?.(_toolCallId);
 				return makeToolResult(details, params);
 			}
 		},
@@ -624,7 +757,7 @@ export function createMastraAgentReadTool(manager: MastraAsyncAgentManager) {
 		label: "Mastra Agent Read",
 		description: "Read output from an async Mastra agent job by jobId. Supports summary, tail, or bounded full output.",
 		promptSnippet: "Read summary, tail, or output from a background Mastra agent job.",
-		promptGuidelines: ["Use agent_read with a jobId from agent_start to retrieve async Mastra agent output without rerunning the job."],
+		promptGuidelines: ["Use agent_read with a jobId from agent_query to retrieve async Mastra agent output without rerunning the job."],
 		parameters: MASTRA_AGENT_READ_PARAMETERS,
 		async execute(_toolCallId: string, params: MastraAgentReadInput): Promise<AgentToolResult<Record<string, unknown>>> {
 			try {
@@ -655,7 +788,7 @@ export function createMastraAgentCancelTool(manager: MastraAsyncAgentManager) {
 		promptGuidelines: ["Use agent_cancel when the user asks to stop a background Mastra agent job."],
 		parameters: MASTRA_AGENT_CANCEL_PARAMETERS,
 		async execute(_toolCallId: string, params: MastraAgentCancelInput): Promise<AgentToolResult<Record<string, unknown>>> {
-			const summary = manager.cancel(params.jobId, params.reason);
+			const summary = await manager.cancel(params.jobId, params.reason);
 			if (!summary) return errorResult(new Error(`Unknown async Mastra agent job: ${params.jobId}`), { jobId: params.jobId, status: "missing" });
 			return { content: [{ type: "text", text: `Cancelled async Mastra agent job ${params.jobId}: ${summary.status}` }], details: summary as unknown as Record<string, unknown> };
 		},
@@ -669,23 +802,35 @@ export function createMastraAgentCancelTool(manager: MastraAsyncAgentManager) {
 	};
 }
 
-export function createMastraAgentInspectTool(client = new MastraHttpClient()) {
+export function createMastraAgentInspectTool(client = new MastraHttpClient(), manager?: MastraAsyncAgentManager) {
 	return {
 		name: MASTRA_AGENT_INSPECT_TOOL_NAME,
 		label: "Mastra Agent Inspect",
-		description: "Inspect one or more Mastra agents and return instructions, available tools, and modes metadata.",
-		promptSnippet: "Inspect Mastra agent instructions, tool schemas, and modes by agent id.",
+		description: "Inspect Mastra agent availability and current-session background jobs, or inspect one or more agents by id.",
+		promptSnippet: "Inspect available Mastra agents and current background job status.",
 		promptGuidelines: [
-			"Use agent_inspect when the user asks for Mastra agent instructions, available tools, modes, or deeper agent capabilities.",
+			"Use agent_inspect with no arguments to list available agents plus working, queued, and ended jobs for this Pi session.",
+			"Pass agentId or agents when the user asks for instructions, tools, modes, or deeper agent capabilities.",
 		],
 		parameters: MASTRA_AGENT_INSPECT_PARAMETERS,
 		async execute(_toolCallId: string, params: MastraAgentInspectInput, signal?: AbortSignal): Promise<AgentToolResult<MastraAgentInspectDetails>> {
 			const agentIds = normalizeInspectAgentIds(params);
 			if (agentIds.length === 0) {
-				return {
-					content: [{ type: "text", text: "Error: provide agentId, agentIds, or comma-separated agents" }],
-					details: { agents: [], count: 0, errors: [{ agentId: "", error: "No agent ids provided" }] },
-				};
+				try {
+					const agents = await client.listAgents(signal);
+					const jobs = manager?.inspectJobs() ?? [];
+					const calledAgentIds = new Set(jobs.filter((job) => job.jobId || job.threadId || job.runId).map((job) => job.agentId));
+					const availableAgents = Object.entries(agents)
+						.filter(([agentId]) => !calledAgentIds.has(agentId))
+						.map(([agentId]) => ({ agentId, status: "available" as const }));
+					const details: MastraAgentInspectDetails = { agents: [], count: availableAgents.length, errors: [], availableAgents, jobs };
+					return {
+						content: [{ type: "text", text: truncateText(formatAgentInspectSessionResult(details), DEFAULT_MODEL_CONTENT_LIMIT).text }],
+						details,
+					};
+				} catch (error) {
+					return errorResult(error, { agents: [], count: 0, errors: [] }) as AgentToolResult<MastraAgentInspectDetails>;
+				}
 			}
 
 			const inspections: MastraAgentInspection[] = [];
@@ -1000,6 +1145,34 @@ function createInitialDetails(params: MastraAgentCallInput): MastraAgentCallDeta
 	};
 }
 
+const INCOMPLETE_STREAM_MESSAGE = "Mastra agent stream ended before a terminal finish event.";
+
+function markStreamEofIncomplete(details: MastraAgentCallDetails): void {
+	if (details.status !== "running") return;
+	details.status = "error";
+	details.updatedAt = Date.now();
+	details.completedAt = details.updatedAt;
+	details.terminalReason = "stream_eof";
+	details.incomplete = true;
+	if (!details.errors.includes(INCOMPLETE_STREAM_MESSAGE)) details.errors.push(INCOMPLETE_STREAM_MESSAGE);
+}
+
+function markStreamError(details: MastraAgentCallDetails, error: unknown, aborted: boolean): void {
+	details.status = aborted ? "aborted" : "error";
+	details.updatedAt = Date.now();
+	details.completedAt = details.updatedAt;
+	details.terminalReason = aborted ? "abort" : "error";
+	details.incomplete = false;
+	const message = error instanceof Error ? error.message : String(error);
+	if (!details.errors.includes(message)) details.errors.push(message);
+}
+
+function appendIncompleteReadNotice(text: string, summary: MastraAgentAsyncJobSummary): string {
+	if (!summary.incomplete) return text;
+	const reason = summary.errors[summary.errors.length - 1] ?? INCOMPLETE_STREAM_MESSAGE;
+	return `${text || "(no text output)"}\n\n[async job incomplete: ${reason}]`;
+}
+
 function createWorkflowDetails(params: MastraWorkflowCallInput): MastraWorkflowCallDetails {
 	return {
 		workflowId: params.workflowId,
@@ -1162,6 +1335,14 @@ function formatAgentInspectResult(details: MastraAgentInspectDetails): string {
 	});
 }
 
+function formatAgentInspectSessionResult(details: MastraAgentInspectDetails): string {
+	return safeJson({
+		availableAgents: details.availableAgents ?? [],
+		jobs: details.jobs ?? [],
+		errors: details.errors,
+	});
+}
+
 function omitRecordKeys<T extends Record<string, unknown>>(record: T, keys: string[]): T {
 	const copy = { ...record };
 	for (const key of keys) delete copy[key];
@@ -1198,10 +1379,12 @@ function formatWorkflowRun(run: MastraWorkflowRun): string {
 function formatAsyncStartResult(summary: MastraAgentAsyncJobSummary): string {
 	return [
 		`Started async Mastra agent job: ${summary.jobId}`,
+		summary.jobName ? `jobName: ${summary.jobName}` : undefined,
 		`agentId: ${summary.agentId}`,
 		summary.modeId ? `modeId: ${summary.modeId}` : undefined,
 		`threadId: ${summary.threadId}`,
 		`resourceId: ${summary.resourceId}`,
+		summary.runId ? `runId: ${summary.runId}` : undefined,
 		summary.artifactPath ? `artifactPath: ${summary.artifactPath}` : undefined,
 		"Live progress is shown in the Mastra Agents widget above the editor.",
 		`When complete, use agent_read with jobId=${summary.jobId} before finalizing unless the initial user prompt explicitly said "pass the output" or "don't read the output".`,
@@ -1212,7 +1395,9 @@ function formatAsyncStartResult(summary: MastraAgentAsyncJobSummary): string {
 
 function formatAsyncJobHeadline(summary: MastraAgentAsyncJobSummary): string {
 	const parts = [
+		summary.lifecycleStatus ?? summary.status,
 		summary.status,
+		summary.incomplete ? "incomplete" : undefined,
 		summary.agentId,
 		summary.elapsedMs === undefined ? undefined : formatDuration(summary.elapsedMs),
 		summary.toolCalls + summary.toolResults > 0 ? `${summary.toolCalls + summary.toolResults} tools` : undefined,
@@ -1224,12 +1409,19 @@ function formatAsyncJobHeadline(summary: MastraAgentAsyncJobSummary): string {
 function formatAsyncJobSummary(summary: MastraAgentAsyncJobSummary): string {
 	const lines = [
 		`jobId: ${summary.jobId}`,
+		summary.jobName ? `jobName: ${summary.jobName}` : undefined,
 		`agentId: ${summary.agentId}`,
 		summary.modeId ? `modeId: ${summary.modeId}` : undefined,
+		summary.lifecycleStatus ? `lifecycleStatus: ${summary.lifecycleStatus}` : undefined,
 		`status: ${summary.status}`,
+		summary.terminalReason ? `terminalReason: ${summary.terminalReason}` : undefined,
+		summary.incomplete ? "incomplete: true" : undefined,
 		summary.elapsedMs === undefined ? undefined : `elapsed: ${formatDuration(summary.elapsedMs)}`,
 		`threadId: ${summary.threadId}`,
 		`resourceId: ${summary.resourceId}`,
+		summary.piSessionId ? `piSessionId: ${summary.piSessionId}` : undefined,
+		summary.runId ? `runId: ${summary.runId}` : undefined,
+		summary.workflowId ? `workflowId: ${summary.workflowId}` : undefined,
 		`events: ${summary.rawChunkCount}`,
 		`tools: ${summary.toolCalls + summary.toolResults}`,
 		summary.artifactPath ? `artifactPath: ${summary.artifactPath}` : undefined,
@@ -1247,8 +1439,140 @@ function normalizeJobId(value?: string): string {
 	return `mastra-agent-${Date.now()}-${randomUUID().slice(0, 8)}`;
 }
 
-function defaultAsyncThreadId(agentId: string, jobId: string): string {
-	return `${defaultThreadId(agentId)}:${jobId}`;
+function normalizeJobName(value?: string): string {
+	const trimmed = value?.trim();
+	if (!trimmed) return "agent-job";
+	const source = trimmed.length > 64 ? trimmed.slice(0, 64) : trimmed;
+	return safeIdPart(source.toLowerCase().replace(/[^a-z0-9._-]+/g, "-"));
+}
+
+function unwrapWorkflowAgentChunk(chunk: unknown): unknown | undefined {
+	if (!isRecord(chunk)) return undefined;
+	if (chunk.type === "workflow-step-output" && isRecord(chunk.payload)) {
+		return unwrapWorkflowAgentChunk(chunk.payload.output);
+	}
+	if (chunk.type === "pi-agent-stream-chunk" && isRecord(chunk.payload)) {
+		return chunk.payload.chunk;
+	}
+	if (chunk.type === "data-pi-agent-stream-chunk" && isRecord(chunk.data)) {
+		return chunk.data.chunk;
+	}
+	const type = typeof chunk.type === "string" ? chunk.type : "";
+	return isMastraAgentChunkType(type) ? chunk : undefined;
+}
+
+function isMastraAgentChunkType(type: string): boolean {
+	return [
+		"text-delta",
+		"reasoning-delta",
+		"tool-call",
+		"tool-result",
+		"tool-error",
+		"tool-call-input-streaming-start",
+		"tool-call-delta",
+		"tool-call-input-streaming-end",
+		"finish",
+		"error",
+	].includes(type);
+}
+
+function applyWorkflowLifecycleChunk(details: MastraAgentCallDetails, chunk: unknown): void {
+	if (!isRecord(chunk)) return;
+	if (chunk.type === "workflow-finish" && isRecord(chunk.payload)) {
+		const status = typeof chunk.payload.workflowStatus === "string" ? chunk.payload.workflowStatus : undefined;
+		if (status === "success" && details.status === "running") {
+			details.status = "done";
+			details.updatedAt = Date.now();
+			details.completedAt = details.updatedAt;
+			details.terminalReason = "finish";
+		}
+		if (status && isFailedWorkflowStatus(status) && details.status === "running") {
+			markStreamError(details, `Workflow run failed with status ${status}`, false);
+		}
+	}
+	if (chunk.type === "workflow-canceled" && details.status === "running") {
+		markStreamError(details, "Workflow run canceled", true);
+	}
+}
+
+function workflowJobOutput(value: unknown): { text?: string; artifactPath?: string; eventsPath?: string } {
+	const candidates = objectCandidates(value);
+	for (const candidate of candidates) {
+		const artifactPath = stringField(candidate, "artifactPath");
+		const eventsPath = stringField(candidate, "eventsPath");
+		const text = stringField(candidate, "text") ?? stringField(candidate, "output") ?? stringField(candidate, "textPreview");
+		if (artifactPath || eventsPath || text) return { artifactPath, eventsPath, text };
+	}
+	return {};
+}
+
+function workflowRunInput(run: MastraWorkflowRun): Record<string, unknown> {
+	const candidates = objectCandidates(run);
+	for (const candidate of candidates) {
+		const inputData = recordField(candidate, "inputData");
+		if (inputData) return inputData;
+		const payload = recordField(candidate, "payload");
+		if (payload) return payload;
+		const input = recordField(candidate, "input");
+		if (input) return input;
+	}
+	return {};
+}
+
+function objectCandidates(value: unknown): Record<string, unknown>[] {
+	if (!isRecord(value)) return [];
+	const candidates: Record<string, unknown>[] = [value];
+	for (const key of ["result", "output", "payload", "data"]) {
+		const nested = value[key];
+		if (isRecord(nested)) candidates.push(...objectCandidates(nested));
+	}
+	return candidates;
+}
+
+function jobIdFromRunId(runId: string): string {
+	const match = runId.match(/-mastra-agent-[^-]+-[^-]+$/);
+	if (match) return match[0].slice(1);
+	const parts = runId.split("-");
+	return parts.slice(-2).join("-") || runId;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+	const value = record[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+	const value = record[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanField(record: Record<string, unknown>, key: string): boolean | undefined {
+	const value = record[key];
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function recordField(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+	const value = record[key];
+	return isRecord(value) ? value : undefined;
+}
+
+function recordStringField(record: Record<string, unknown>, key: string): Record<string, string> | undefined {
+	const value = record[key];
+	if (!isRecord(value)) return undefined;
+	const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+	return entries.length === Object.keys(value).length ? Object.fromEntries(entries) : undefined;
+}
+
+function isActiveWorkflowStatus(status: string): boolean {
+	return ["running", "waiting", "pending", "paused", "suspended"].includes(status);
+}
+
+function isTerminalWorkflowStatus(status: string): boolean {
+	return ["success", "failed", "canceled", "bailed", "tripwire"].includes(status);
+}
+
+function isFailedWorkflowStatus(status: string): boolean {
+	return ["failed", "bailed", "tripwire"].includes(status);
 }
 
 function clampMaxChars(value?: number): number {

--- a/pi/src/mastra/types.ts
+++ b/pi/src/mastra/types.ts
@@ -10,6 +10,7 @@ export type MastraAgentsResponse = Record<string, MastraAgentInfo>;
 export interface MastraAgentCallInput {
 	agentId: string;
 	message: string;
+	jobName?: string;
 	modeId?: string;
 	threadId?: string;
 	resourceId?: string;
@@ -61,10 +62,26 @@ export interface MastraAgentInspection {
 	raw: MastraAgentInfo;
 }
 
+export type MastraAgentLifecycleStatus = "available" | "working" | "agent_response_queued" | "ended";
+
+export interface MastraAgentInspectJob {
+	jobId?: string;
+	jobName?: string;
+	agentId: string;
+	status: MastraAgentLifecycleStatus;
+	threadId?: string;
+	resourceId?: string;
+	runId?: string;
+	workflowId?: string;
+	updatedAt?: number;
+}
+
 export interface MastraAgentInspectDetails {
 	agents: MastraAgentInspection[];
 	count: number;
 	errors: Array<{ agentId: string; error: string }>;
+	availableAgents?: MastraAgentInspectJob[];
+	jobs?: MastraAgentInspectJob[];
 }
 
 export interface MastraStreamRequest {
@@ -124,6 +141,15 @@ export interface MastraWorkflowStreamRequest {
 	closeOnSuspend?: boolean;
 }
 
+export interface MastraWorkflowAsyncStartRequest extends MastraWorkflowStreamRequest {}
+
+export interface MastraWorkflowRunsListInput {
+	resourceId?: string;
+	status?: string;
+	page?: number;
+	perPage?: number;
+}
+
 export interface MastraWorkflowStatusInput {
 	workflowId: string;
 	runId: string;
@@ -177,6 +203,7 @@ export interface MastraWorkflowCallDetails {
 }
 
 export type MastraStreamStatus = "running" | "done" | "error" | "aborted";
+export type MastraTerminalReason = "finish" | "error" | "abort" | "stream_eof";
 
 export interface MastraToolEvent {
 	id?: string;
@@ -214,16 +241,20 @@ export interface MastraAgentCallDetails {
 	chunksTruncated: boolean;
 	errors: string[];
 	rawChunkCount: number;
+	terminalReason?: MastraTerminalReason;
+	incomplete?: boolean;
 }
 
 export interface MastraAgentStartInput extends MastraAgentCallInput {
 	jobId?: string;
+	piSessionId?: string;
 	finalMessage?: boolean;
 }
 
 export interface MastraAgentQueryInput {
 	agentId: string;
 	message: string;
+	jobName?: string;
 	synchronous?: boolean;
 	threadId?: string;
 	resourceId?: string;
@@ -251,10 +282,15 @@ export interface MastraAgentCancelInput {
 
 export interface MastraAgentAsyncJobSummary {
 	jobId: string;
+	jobName?: string;
 	agentId: string;
 	modeId?: string;
 	threadId: string;
 	resourceId: string;
+	piSessionId?: string;
+	runId?: string;
+	workflowId?: string;
+	lifecycleStatus?: MastraAgentLifecycleStatus;
 	status: MastraStreamStatus;
 	startedAt?: number;
 	updatedAt?: number;
@@ -269,6 +305,8 @@ export interface MastraAgentAsyncJobSummary {
 	rawChunkCount: number;
 	chunksTruncated: boolean;
 	errors: string[];
+	terminalReason?: MastraTerminalReason;
+	incomplete?: boolean;
 	artifactPath?: string;
 	eventsPath?: string;
 }

--- a/pi/src/mastra/types.ts
+++ b/pi/src/mastra/types.ts
@@ -221,6 +221,19 @@ export interface MastraAgentStartInput extends MastraAgentCallInput {
 	finalMessage?: boolean;
 }
 
+export interface MastraAgentQueryInput {
+	agentId: string;
+	message: string;
+	synchronous?: boolean;
+	threadId?: string;
+	resourceId?: string;
+	requestContext?: Record<string, unknown>;
+	includeToolResults?: boolean;
+	includeReasoning?: boolean;
+	timeoutMs?: number;
+	input_args?: MastraAgentInputArgs;
+}
+
 export interface MastraAgentAsyncStatusInput {
 	jobId?: string;
 }

--- a/pi/src/mastra/types.ts
+++ b/pi/src/mastra/types.ts
@@ -141,8 +141,6 @@ export interface MastraWorkflowStreamRequest {
 	closeOnSuspend?: boolean;
 }
 
-export interface MastraWorkflowAsyncStartRequest extends MastraWorkflowStreamRequest {}
-
 export interface MastraWorkflowRunsListInput {
 	resourceId?: string;
 	status?: string;
@@ -176,7 +174,8 @@ export interface MastraWorkflowRun {
 	resourceId?: string;
 	createdAt?: string;
 	updatedAt?: string;
-	status: MastraWorkflowRunStatus;
+	status?: MastraWorkflowRunStatus;
+	snapshot?: unknown;
 	initialState?: unknown;
 	result?: unknown;
 	error?: unknown;

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -148,7 +148,7 @@ test("MastraAgentsWidget render uses full live width with no artificial cap", ()
 	assert.notEqual(lines120.join(""), lines80.join(""));
 });
 
-test("MastraAgentsWidget keeps lingering done card slots stable", () => {
+test("MastraAgentsWidget keeps queued response card slots stable until explicit end", () => {
 	const store = new MastraAgentActivityStore(60_000);
 	for (let i = 1; i <= 4; i++) {
 		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
@@ -162,10 +162,15 @@ test("MastraAgentsWidget keeps lingering done card slots stable", () => {
 	const before = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
 	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
 	const after = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
-	widget.dispose();
 
 	assert.deepEqual(after.map(agentLabel), before.map(agentLabel));
 	assert.ok(after[0].includes("done"));
+
+	store.end("call-1");
+	const ended = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
+	widget.dispose();
+
+	assert.deepEqual(ended.map(agentLabel), ["agent-2", "agent-3", "agent-4"]);
 });
 
 test("MastraAgentsWidget keeps newest jobs visible with newest at the bottom", () => {
@@ -181,6 +186,32 @@ test("MastraAgentsWidget keeps newest jobs visible with newest at the bottom", (
 	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4 });
 	widget.render(100);
 	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
+	store.start("call-5", { agentId: "agent-5", message: "task 5" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-5",
+		status: "running",
+		text: "output 5",
+	}));
+	const labels = widget.render(100).filter((line) => line.includes("Mastra: agent-")).map(agentLabel);
+	widget.dispose();
+
+	assert.deepEqual(labels, ["agent-2", "agent-3", "agent-4", "agent-5"]);
+});
+
+test("MastraAgentsWidget appends new cards from the bottom after ended cards collapse", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 4; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4 });
+	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
+	assert.deepEqual(widget.render(100).filter((line) => line.includes("Mastra: agent-")).map(agentLabel), ["agent-1", "agent-2", "agent-3", "agent-4"]);
+
+	store.end("call-1");
 	store.start("call-5", { agentId: "agent-5", message: "task 5" } as MastraAgentCallInput, makeDetails({
 		agentId: "agent-5",
 		status: "running",
@@ -224,6 +255,52 @@ test("MastraAgentsWidget lets a single card use the total line budget", () => {
 
 	assert.ok(lines.length > 20, `single card should expand into budget, got ${lines.length}`);
 	assert.ok(lines.length <= 30, `expected maxLines cap, got ${lines.length}`);
+});
+
+test("MastraAgentsWidget divides total height budget across multiple long cards", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 3; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: Array.from({ length: 80 }, (_, index) => `agent ${i} line ${index + 1}`).join("\n"),
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4, maxLines: 30 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.filter((line) => line.includes("Mastra: agent-")).length, 3);
+	assert.ok(lines.length <= 30, `expected aggregate maxLines cap, got ${lines.length}`);
+	for (const label of ["agent-1", "agent-2", "agent-3"]) {
+		assert.ok(lines.some((line) => line.includes(`Mastra: ${label}`)), `${label} should stay visible`);
+	}
+	for (let i = 1; i <= 3; i++) {
+		assert.ok(lines.some((line) => line.includes(`agent ${i} line 80`)), `agent-${i} should retain body output within shared budget`);
+	}
+});
+
+test("MastraAgentsWidget preserves whole newest cards under tight height budget", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 5; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: Array.from({ length: 20 }, (_, index) => `agent ${i} line ${index + 1}`).join("\n"),
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4, maxLines: 12 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.ok(lines.length <= 12, `expected tight maxLines cap, got ${lines.length}`);
+	assert.match(lines[0], /\+3 more/);
+	assert.deepEqual(lines.filter((line) => line.includes("Mastra: agent-")).map(agentLabel), ["agent-4", "agent-5"]);
+	assert.equal(lines.filter((line) => line.startsWith("╭")).length, 2);
+	assert.equal(lines.filter((line) => line.startsWith("╰")).length, 2);
+	assert.equal(lines.at(-1)?.startsWith("╰"), true, "render should end at a whole-card bottom border");
 });
 
 function agentLabel(line: string): string {

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -319,6 +319,21 @@ test("MastraAgentsWidget keeps queued response card slots stable until explicit 
 	assert.deepEqual(ended.map(agentLabel), ["agent-2", "agent-3", "agent-4"]);
 });
 
+test("MastraAgentActivityStore ignores late updates after explicit end", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "running",
+	}));
+
+	store.end("call-1");
+	store.update("call-1", makeDetails({ agentId: "agent-1", status: "aborted", text: "late update" }));
+	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "aborted", text: "late finish" }));
+
+	assert.deepEqual(store.snapshot(), []);
+});
+
 test("MastraAgentsWidget keeps newest jobs visible with newest at the bottom", () => {
 	const store = new MastraAgentActivityStore(60_000);
 	for (let i = 1; i <= 4; i++) {

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@mariozechner/pi-tui";
-import { filterPromptScaffolding, MastraAgentActivityStore, MastraAgentCard, MastraAgentsWidget } from "./index.js";
+import {
+	filterPromptScaffolding,
+	MastraAgentActivityStore,
+	MastraAgentCard,
+	MastraAgentsListWidget,
+	MastraAgentsWidget,
+	MastraAgentsWidgetViewController,
+} from "./index.js";
 import type { MastraAgentCallDetails, MastraAgentCallInput } from "../mastra/types.js";
 
 // Stub theme matching the real Theme interface surface used by MastraAgentCard
@@ -126,6 +136,142 @@ test("MastraAgentsWidget uses default 4-card and 60-line budget", () => {
 
 	assert.equal(lines.filter((line) => line.includes("Mastra: agent-")).length, 4);
 	assert.ok(lines.length <= 60, `expected widget lines to honor default maxLines=60, got ${lines.length}`);
+});
+
+test("MastraAgentsWidget clamps configured maxLines to terminal viewport rows", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: Array.from({ length: 80 }, (_, index) => `line ${index + 1}`).join("\n"),
+	}));
+
+	const widget = new MastraAgentsWidget(makeTui(24), stubTheme as any, store, { maxLines: 60 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.ok(lines.length <= 14, `expected terminal-aware budget of 14 lines, got ${lines.length}`);
+	assert.ok(lines.length > 1, "card should still use available viewport budget");
+});
+
+test("MastraAgentsWidget falls back to compact rendering when viewport cannot fit a whole card", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "streaming output",
+	}));
+
+	const widget = new MastraAgentsWidget(makeTui(11), stubTheme as any, store, { maxLines: 60 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.ok(lines.length <= 1, `expected tiny viewport clamp, got ${lines.length}`);
+	assert.equal(lines.filter((line) => line.includes("Mastra: agent-")).length, 0);
+});
+
+test("MastraAgentsWidget emits viewport budget metrics when debug logging is enabled", async () => {
+	const previousDebug = process.env.MASTRA_WIDGET_DEBUG;
+	const previousDebugPath = process.env.MASTRA_WIDGET_DEBUG_PATH;
+	const dir = await mkdtemp(join(tmpdir(), "mastra-widget-debug-"));
+	const logPath = join(dir, "widget.log");
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "streaming output",
+	}));
+
+	try {
+		process.env.MASTRA_WIDGET_DEBUG = "1";
+		process.env.MASTRA_WIDGET_DEBUG_PATH = logPath;
+		const widget = new MastraAgentsWidget(makeTui(24), stubTheme as any, store, { maxLines: 60 });
+		widget.render(100);
+		widget.dispose();
+
+		const log = await readFile(logPath, "utf8");
+		assert.match(log, /terminalRows=24/);
+		assert.match(log, /configuredMaxLines=60/);
+		assert.match(log, /effectiveMaxLines=14/);
+		assert.match(log, /clamped=true/);
+		assert.match(log, /renderedLines=/);
+	} finally {
+		if (previousDebug === undefined) delete process.env.MASTRA_WIDGET_DEBUG;
+		else process.env.MASTRA_WIDGET_DEBUG = previousDebug;
+		if (previousDebugPath === undefined) delete process.env.MASTRA_WIDGET_DEBUG_PATH;
+		else process.env.MASTRA_WIDGET_DEBUG_PATH = previousDebugPath;
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("MastraAgentsListWidget renders compact default list above the editor", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 3; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+			toolCalls: [{ id: `tool-${i}`, name: "workspaceReadFile", type: "call", args: { path: `file-${i}.ts` }, timestamp: i, raw: {} }],
+		}));
+	}
+
+	const viewController = new MastraAgentsWidgetViewController("list");
+	const widget = new MastraAgentsListWidget(makeTui(24), stubTheme as any, store, { viewController, listMaxLines: 10 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.ok(lines[0].includes("Mastra Agents"));
+	assert.ok(lines.length <= 10);
+	assert.ok(lines.some((line) => line.includes("agent-3")));
+	assert.equal(lines.filter((line) => line.includes("├ tools")).length, 3);
+	assert.equal(lines.filter((line) => line.includes("└ now")).length, 3);
+	assert.ok(lines.some((line) => line.includes("read_file")), "list mode should stream tool events");
+	assert.equal(lines.some((line) => line.includes("Mastra: agent-")), false, "list mode should not render full cards");
+});
+
+test("MastraAgentsWidget hides in list mode and uses a fixed region in card mode", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "output",
+	}));
+
+	const viewController = new MastraAgentsWidgetViewController("list");
+	const widget = new MastraAgentsWidget(makeTui(24), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 10 });
+	assert.deepEqual(widget.render(100), []);
+
+	viewController.setMode("cards");
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.length, 10);
+	assert.ok(lines.some((line) => line.includes("Mastra: agent-1")));
+});
+
+test("MastraAgentsWidget detail mode dedicates the region to the focused agent", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 2; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: Array.from({ length: 20 }, (_, index) => `agent ${i} line ${index + 1}`).join("\n"),
+		}));
+	}
+
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	viewController.focusNext(store.snapshot({ includeFinished: false }), 1);
+	const widget = new MastraAgentsWidget(makeTui(30), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 12 });
+	const firstFocus = widget.render(100);
+	viewController.focusNext(store.snapshot({ includeFinished: false }), 1);
+	const secondFocus = widget.render(100);
+	widget.dispose();
+
+	assert.equal(firstFocus.length, 12);
+	assert.ok(firstFocus.some((line) => line.includes("Mastra: agent-1")));
+	assert.equal(secondFocus.length, 12);
+	assert.ok(secondFocus.some((line) => line.includes("Mastra: agent-2")));
+	assert.equal(secondFocus.filter((line) => line.includes("Mastra: agent-")).length, 1);
 });
 
 test("MastraAgentsWidget render uses full live width with no artificial cap", () => {
@@ -306,6 +452,10 @@ test("MastraAgentsWidget preserves whole newest cards under tight height budget"
 function agentLabel(line: string): string {
 	const match = line.match(/Mastra: (agent-\d+)/);
 	return match?.[1] ?? line;
+}
+
+function makeTui(rows?: number): { requestRender(): void; terminal?: { rows: number } } {
+	return rows === undefined ? { requestRender() {} } : { requestRender() {}, terminal: { rows } };
 }
 
 function makeDetails(overrides: Partial<MastraAgentCallDetails> = {}): MastraAgentCallDetails {

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -150,7 +150,8 @@ test("MastraAgentsWidget clamps configured maxLines to terminal viewport rows", 
 	const lines = widget.render(100);
 	widget.dispose();
 
-	assert.ok(lines.length <= 14, `expected terminal-aware budget of 14 lines, got ${lines.length}`);
+	assert.ok(lines.length <= 13, `expected terminal-aware content budget of 13 lines, got ${lines.length}`);
+	assert.ok(lines.length + 1 <= 14, `expected content plus spacer to fit 14-row viewport budget, got ${lines.length + 1}`);
 	assert.ok(lines.length > 1, "card should still use available viewport budget");
 });
 
@@ -192,7 +193,11 @@ test("MastraAgentsWidget emits viewport budget metrics when debug logging is ena
 		const log = await readFile(logPath, "utf8");
 		assert.match(log, /terminalRows=24/);
 		assert.match(log, /configuredMaxLines=60/);
-		assert.match(log, /effectiveMaxLines=14/);
+		assert.match(log, /effectiveMaxLines=13/);
+		assert.match(log, /spacerRows=1/);
+		assert.match(log, /occupiedRows=/);
+		assert.match(log, /workingActivities=1/);
+		assert.match(log, /hiddenQueuedActivities=0/);
 		assert.match(log, /clamped=true/);
 		assert.match(log, /renderedLines=/);
 	} finally {
@@ -204,9 +209,9 @@ test("MastraAgentsWidget emits viewport budget metrics when debug logging is ena
 	}
 });
 
-test("MastraAgentsListWidget renders compact default list above the editor", () => {
+test("MastraAgentsListWidget renders compact default list within spacer-aware budget", () => {
 	const store = new MastraAgentActivityStore(60_000);
-	for (let i = 1; i <= 3; i++) {
+	for (let i = 1; i <= 4; i++) {
 		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
 			agentId: `agent-${i}`,
 			status: "running",
@@ -216,20 +221,46 @@ test("MastraAgentsListWidget renders compact default list above the editor", () 
 	}
 
 	const viewController = new MastraAgentsWidgetViewController("list");
-	const widget = new MastraAgentsListWidget(makeTui(24), stubTheme as any, store, { viewController, listMaxLines: 10 });
+	const widget = new MastraAgentsListWidget(makeTui(24), stubTheme as any, store, { viewController, listMaxLines: 11 });
 	const lines = widget.render(100);
 	widget.dispose();
 
 	assert.ok(lines[0].includes("Mastra Agents"));
-	assert.ok(lines.length <= 10);
-	assert.ok(lines.some((line) => line.includes("agent-3")));
-	assert.equal(lines.filter((line) => line.includes("├ tools")).length, 3);
-	assert.equal(lines.filter((line) => line.includes("└ now")).length, 3);
+	assert.ok(lines.length + 1 <= 11);
+	assert.ok(lines.some((line) => line.includes("+2 more")));
+	assert.ok(lines.some((line) => line.includes("agent-4")));
+	assert.equal(lines.filter((line) => line.includes("├ tools")).length, 2);
+	assert.equal(lines.filter((line) => line.includes("└ now")).length, 2);
 	assert.ok(lines.some((line) => line.includes("read_file")), "list mode should stream tool events");
 	assert.equal(lines.some((line) => line.includes("Mastra: agent-")), false, "list mode should not render full cards");
 });
 
-test("MastraAgentsWidget hides in list mode and uses a fixed region in card mode", () => {
+test("MastraAgentsWidget list mode preselects five newest agents before rendering rows", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 6; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+			toolCalls: [{ id: `tool-${i}`, name: "workspaceReadFile", type: "call", args: { path: `file-${i}.ts` }, timestamp: i, raw: {} }],
+		}));
+	}
+
+	const viewController = new MastraAgentsWidgetViewController("list");
+	const widget = new MastraAgentsWidget(makeTui(60), stubTheme as any, store, { viewController, listMaxLines: 18, listMaxAgents: 5 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.length, 17);
+	assert.ok(lines.some((line) => line.includes("+1 more")));
+	assert.equal(lines.some((line) => line.includes("agent-1")), false);
+	assert.deepEqual(lines.map(listAgentLabel).filter(Boolean), ["agent-2", "agent-3", "agent-4", "agent-5", "agent-6"]);
+	assert.equal(lines.filter((line) => line.includes("├ tools")).length, 5);
+	assert.equal(lines.filter((line) => line.includes("└ now")).length, 5);
+	assert.equal(lines.some((line) => line.includes("Mastra: agent-")), false);
+});
+
+test("MastraAgentsWidget renders list mode and uses a fixed total card region", () => {
 	const store = new MastraAgentActivityStore(60_000);
 	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
 		agentId: "agent-1",
@@ -239,14 +270,41 @@ test("MastraAgentsWidget hides in list mode and uses a fixed region in card mode
 
 	const viewController = new MastraAgentsWidgetViewController("list");
 	const widget = new MastraAgentsWidget(makeTui(24), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 10 });
-	assert.deepEqual(widget.render(100), []);
+	const listLines = widget.render(100);
+	assert.ok(listLines.some((line) => line.includes("agent-1")));
+	assert.equal(listLines.some((line) => line.includes("Mastra: agent-")), false, "list mode should not render full cards");
 
 	viewController.setMode("cards");
 	const lines = widget.render(100);
 	widget.dispose();
 
-	assert.equal(lines.length, 10);
+	assert.equal(lines.length, 9);
+	assert.ok(lines.length + 1 <= 10);
 	assert.ok(lines.some((line) => line.includes("Mastra: agent-1")));
+});
+
+test("MastraAgentsWidget list mode does not retain detail region height", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 2; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: Array.from({ length: 20 }, (_, index) => `agent ${i} line ${index + 1}`).join("\n"),
+		}));
+	}
+
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	const widget = new MastraAgentsWidget(makeTui(60), stubTheme as any, store, { viewController, maxLines: 30, listMaxLines: 18, listMaxAgents: 5 });
+	const detailLines = widget.render(100);
+	viewController.setMode("list");
+	const listLines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(detailLines.length, 29);
+	assert.equal(detailLines.at(-1)?.startsWith("╰"), true);
+	assert.equal(listLines.length, 7);
+	assert.notEqual(listLines.at(-1), "", "list render should not end with old blank region padding");
+	assert.equal(listLines.some((line) => line.includes("Mastra: agent-")), false);
 });
 
 test("MastraAgentsWidget detail mode dedicates the region to the focused agent", () => {
@@ -267,9 +325,11 @@ test("MastraAgentsWidget detail mode dedicates the region to the focused agent",
 	const secondFocus = widget.render(100);
 	widget.dispose();
 
-	assert.equal(firstFocus.length, 12);
+	assert.equal(firstFocus.length, 11);
+	assert.ok(firstFocus.length + 1 <= 12);
 	assert.ok(firstFocus.some((line) => line.includes("Mastra: agent-1")));
-	assert.equal(secondFocus.length, 12);
+	assert.equal(secondFocus.length, 11);
+	assert.ok(secondFocus.length + 1 <= 12);
 	assert.ok(secondFocus.some((line) => line.includes("Mastra: agent-2")));
 	assert.equal(secondFocus.filter((line) => line.includes("Mastra: agent-")).length, 1);
 });
@@ -294,7 +354,7 @@ test("MastraAgentsWidget render uses full live width with no artificial cap", ()
 	assert.notEqual(lines120.join(""), lines80.join(""));
 });
 
-test("MastraAgentsWidget keeps queued response card slots stable until explicit end", () => {
+test("MastraAgentsWidget removes completed jobs from visible cards immediately", () => {
 	const store = new MastraAgentActivityStore(60_000);
 	for (let i = 1; i <= 4; i++) {
 		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
@@ -309,14 +369,49 @@ test("MastraAgentsWidget keeps queued response card slots stable until explicit 
 	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
 	const after = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
 
-	assert.deepEqual(after.map(agentLabel), before.map(agentLabel));
-	assert.ok(after[0].includes("done"));
-
-	store.end("call-1");
-	const ended = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
 	widget.dispose();
 
-	assert.deepEqual(ended.map(agentLabel), ["agent-2", "agent-3", "agent-4"]);
+	assert.deepEqual(before.map(agentLabel), ["agent-1", "agent-2", "agent-3", "agent-4"]);
+	assert.deepEqual(after.map(agentLabel), ["agent-2", "agent-3", "agent-4"]);
+	assert.equal(after.some((line) => line.includes("done")), false);
+	assert.equal(store.snapshot().some((activity) => activity.toolCallId === "call-1" && activity.lifecycleStatus === "agent_response_queued"), true);
+});
+
+test("MastraAgentsWidget keeps queued completion hidden after late updates", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "running",
+	}));
+	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
+	store.update("call-1", makeDetails({ agentId: "agent-1", status: "running", text: "late running update" }));
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store);
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.deepEqual(lines, []);
+	assert.equal(store.snapshot()[0]?.lifecycleStatus, "agent_response_queued");
+});
+
+test("MastraAgentActivityStore keeps queued completions until explicit end", async () => {
+	const store = new MastraAgentActivityStore(0);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "running",
+	}));
+	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
+
+	await new Promise((resolve) => setTimeout(resolve, 5));
+	assert.equal(store.snapshot()[0]?.lifecycleStatus, "agent_response_queued");
+
+	store.update("call-1", makeDetails({ agentId: "agent-1", status: "running", text: "late running update" }));
+	assert.equal(store.snapshot()[0]?.lifecycleStatus, "agent_response_queued");
+
+	store.end("call-1");
+	assert.deepEqual(store.snapshot(), []);
 });
 
 test("MastraAgentActivityStore ignores late updates after explicit end", () => {
@@ -332,6 +427,35 @@ test("MastraAgentActivityStore ignores late updates after explicit end", () => {
 	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "aborted", text: "late finish" }));
 
 	assert.deepEqual(store.snapshot(), []);
+});
+
+test("MastraAgentsWidget treats a later same-agent dispatch as newest active work", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 4; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			threadId: "thread-shared",
+			status: "running",
+			text: `output ${i}`,
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 5 });
+	store.finish("call-1", makeDetails({ agentId: "agent-1", threadId: "thread-shared", status: "done", text: "complete" }));
+	store.start("call-5", { agentId: "agent-1", message: "retry task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		threadId: "thread-shared",
+		status: "running",
+		text: "new output",
+	}));
+	const lines = widget.render(100);
+	const labels = lines.filter((line) => line.includes("Mastra: agent-")).map(agentLabel);
+	widget.dispose();
+
+	assert.deepEqual(labels, ["agent-2", "agent-3", "agent-4", "agent-1"]);
+	assert.equal(labels.filter((label) => label === "agent-1").length, 1);
+	assert.ok(lines.some((line) => line.includes("new output")));
+	assert.equal(lines.some((line) => line.includes("complete")), false);
 });
 
 test("MastraAgentsWidget keeps newest jobs visible with newest at the bottom", () => {
@@ -370,7 +494,7 @@ test("MastraAgentsWidget appends new cards from the bottom after ended cards col
 
 	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4 });
 	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
-	assert.deepEqual(widget.render(100).filter((line) => line.includes("Mastra: agent-")).map(agentLabel), ["agent-1", "agent-2", "agent-3", "agent-4"]);
+	assert.deepEqual(widget.render(100).filter((line) => line.includes("Mastra: agent-")).map(agentLabel), ["agent-2", "agent-3", "agent-4"]);
 
 	store.end("call-1");
 	store.start("call-5", { agentId: "agent-5", message: "task 5" } as MastraAgentCallInput, makeDetails({
@@ -415,7 +539,24 @@ test("MastraAgentsWidget lets a single card use the total line budget", () => {
 	widget.dispose();
 
 	assert.ok(lines.length > 20, `single card should expand into budget, got ${lines.length}`);
-	assert.ok(lines.length <= 30, `expected maxLines cap, got ${lines.length}`);
+	assert.ok(lines.length + 1 <= 30, `expected total maxLines cap including spacer, got ${lines.length + 1}`);
+});
+
+test("MastraAgentsWidget pads short single-card content inside the frame", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "short output",
+	}));
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4, maxLines: 30 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.length, 29);
+	assert.equal(lines.at(-1)?.startsWith("╰"), true);
+	assert.equal(lines.some((line) => line === ""), false, "fixed card region should not use trailing blank lines outside the frame");
 });
 
 test("MastraAgentsWidget divides total height budget across multiple long cards", () => {
@@ -434,6 +575,7 @@ test("MastraAgentsWidget divides total height budget across multiple long cards"
 
 	assert.equal(lines.filter((line) => line.includes("Mastra: agent-")).length, 3);
 	assert.ok(lines.length <= 30, `expected aggregate maxLines cap, got ${lines.length}`);
+	assert.notEqual(lines.at(-1), "", "shared card region should not end with blank padding");
 	for (const label of ["agent-1", "agent-2", "agent-3"]) {
 		assert.ok(lines.some((line) => line.includes(`Mastra: ${label}`)), `${label} should stay visible`);
 	}
@@ -452,21 +594,26 @@ test("MastraAgentsWidget preserves whole newest cards under tight height budget"
 		}));
 	}
 
-	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4, maxLines: 12 });
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4, maxLines: 13 });
 	const lines = widget.render(100);
 	widget.dispose();
 
-	assert.ok(lines.length <= 12, `expected tight maxLines cap, got ${lines.length}`);
+	assert.ok(lines.length + 1 <= 13, `expected tight total maxLines cap, got ${lines.length + 1}`);
 	assert.match(lines[0], /\+3 more/);
 	assert.deepEqual(lines.filter((line) => line.includes("Mastra: agent-")).map(agentLabel), ["agent-4", "agent-5"]);
 	assert.equal(lines.filter((line) => line.startsWith("╭")).length, 2);
 	assert.equal(lines.filter((line) => line.startsWith("╰")).length, 2);
 	assert.equal(lines.at(-1)?.startsWith("╰"), true, "render should end at a whole-card bottom border");
+	assert.notEqual(lines.at(-1), "", "tight card region should not end with blank padding");
 });
 
 function agentLabel(line: string): string {
 	const match = line.match(/Mastra: (agent-\d+)/);
 	return match?.[1] ?? line;
+}
+
+function listAgentLabel(line: string): string | undefined {
+	return line.match(/\b(agent-\d+)\b/)?.[1];
 }
 
 function makeTui(rows?: number): { requestRender(): void; terminal?: { rows: number } } {

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { filterPromptScaffolding, MastraAgentCard } from "./index.js";
-import type { MastraAgentCallDetails } from "../mastra/types.js";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { filterPromptScaffolding, MastraAgentActivityStore, MastraAgentCard, MastraAgentsWidget } from "./index.js";
+import type { MastraAgentCallDetails, MastraAgentCallInput } from "../mastra/types.js";
 
 // Stub theme matching the real Theme interface surface used by MastraAgentCard
 const stubTheme: Record<string, (...args: string[]) => string> = {
@@ -108,6 +109,127 @@ test("MastraAgentCard with partial streaming state shows correct status", () => 
 	// Border color for running status should be "accent" — verify card renders
 	assert.ok(lines.some((l) => l.includes("│")), "card should have frame borders");
 });
+
+test("MastraAgentsWidget uses default 4-card and 60-line budget", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 4; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store);
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.filter((line) => line.includes("Mastra: agent-")).length, 4);
+	assert.ok(lines.length <= 60, `expected widget lines to honor default maxLines=60, got ${lines.length}`);
+});
+
+test("MastraAgentsWidget render uses full live width with no artificial cap", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-wide", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-wide",
+		status: "running",
+		text: "Working on the task.",
+	}));
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store);
+	const lines120 = widget.render(120);
+	const lines80 = widget.render(80);
+	widget.dispose();
+
+	const topBorder = lines120.find((line) => line.includes("Mastra: agent-wide"));
+	assert.ok(topBorder, "top border line should be present");
+	assert.equal(visibleWidth(topBorder), 120);
+	assert.ok(lines80.every((line) => visibleWidth(line) <= 80));
+	assert.notEqual(lines120.join(""), lines80.join(""));
+});
+
+test("MastraAgentsWidget keeps lingering done card slots stable", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 4; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store);
+	const before = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
+	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
+	const after = widget.render(100).filter((line) => line.includes("Mastra: agent-"));
+	widget.dispose();
+
+	assert.deepEqual(after.map(agentLabel), before.map(agentLabel));
+	assert.ok(after[0].includes("done"));
+});
+
+test("MastraAgentsWidget keeps newest jobs visible with newest at the bottom", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 4; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4 });
+	widget.render(100);
+	store.finish("call-1", makeDetails({ agentId: "agent-1", status: "done", text: "complete" }));
+	store.start("call-5", { agentId: "agent-5", message: "task 5" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-5",
+		status: "running",
+		text: "output 5",
+	}));
+	const labels = widget.render(100).filter((line) => line.includes("Mastra: agent-")).map(agentLabel);
+	widget.dispose();
+
+	assert.deepEqual(labels, ["agent-2", "agent-3", "agent-4", "agent-5"]);
+});
+
+test("MastraAgentsWidget puts overflow marker at the top", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	for (let i = 1; i <= 5; i++) {
+		store.start(`call-${i}`, { agentId: `agent-${i}`, message: `task ${i}` } as MastraAgentCallInput, makeDetails({
+			agentId: `agent-${i}`,
+			status: "running",
+			text: `output ${i}`,
+		}));
+	}
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.match(lines[0], /\+1 more/);
+	assert.deepEqual(lines.filter((line) => line.includes("Mastra: agent-")).map(agentLabel), ["agent-2", "agent-3", "agent-4", "agent-5"]);
+});
+
+test("MastraAgentsWidget lets a single card use the total line budget", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: Array.from({ length: 80 }, (_, index) => `line ${index + 1}`).join("\n"),
+	}));
+
+	const widget = new MastraAgentsWidget({ requestRender() {} }, stubTheme as any, store, { maxCards: 4, maxLines: 30 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.ok(lines.length > 20, `single card should expand into budget, got ${lines.length}`);
+	assert.ok(lines.length <= 30, `expected maxLines cap, got ${lines.length}`);
+});
+
+function agentLabel(line: string): string {
+	const match = line.match(/Mastra: (agent-\d+)/);
+	return match?.[1] ?? line;
+}
 
 function makeDetails(overrides: Partial<MastraAgentCallDetails> = {}): MastraAgentCallDetails {
 	return {

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -98,27 +98,32 @@ export interface MastraAgentActivitySink {
 
 export class MastraAgentActivityStore implements MastraAgentActivitySink {
 	private readonly activities = new Map<string, MastraAgentActivity>();
+	private readonly endedToolCallIds = new Set<string>();
 	private readonly listeners = new Set<() => void>();
 	private nextOrder = 0;
 
 	constructor(private readonly lingerMs = DEFAULT_ACTIVITY_LINGER_MS) {}
 
 	start(toolCallId: string, params: MastraAgentCallInput, details: MastraAgentCallDetails): void {
+		this.endedToolCallIds.delete(toolCallId);
 		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, undefined, params.message, "working", this.nextOrder++));
 		this.notify();
 	}
 
 	update(toolCallId: string, details: MastraAgentCallDetails): void {
+		if (this.endedToolCallIds.has(toolCallId)) return;
 		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, this.activities.get(toolCallId)));
 		this.notify();
 	}
 
 	finish(toolCallId: string, details: MastraAgentCallDetails): void {
+		if (this.endedToolCallIds.has(toolCallId)) return;
 		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, this.activities.get(toolCallId), undefined, "agent_response_queued"));
 		this.notify();
 	}
 
 	end(toolCallId: string): void {
+		this.endedToolCallIds.add(toolCallId);
 		if (!this.activities.delete(toolCallId)) return;
 		this.notify();
 	}
@@ -146,6 +151,7 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 
 	reset(): void {
 		this.activities.clear();
+		this.endedToolCallIds.clear();
 		this.nextOrder = 0;
 		this.notify();
 	}

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -1,15 +1,10 @@
 import { getMarkdownTheme, type Theme, type ThemeColor } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI as PiTUI } from "@mariozechner/pi-tui";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
-import type { MastraAgentCallDetails, MastraAgentCallInput, MastraToolEvent, MastraUsage } from "../mastra/types.js";
+import type { MastraAgentCallDetails, MastraAgentCallInput, MastraAgentLifecycleStatus, MastraToolEvent, MastraUsage } from "../mastra/types.js";
 
-// Pi only gives extensions above/below-editor widget slots. The Mastra
-// activity surface uses the above-editor slot, so this line budget keeps live
-// async cards visible without pushing the prompt editor off screen.
-const DEFAULT_WIDGET_MAX_LINES = 28;
-// Show the two most relevant jobs directly. Extra jobs stay discoverable via
-// the overflow row and status/read tools instead of rendering partial cards.
-const DEFAULT_WIDGET_MAX_CARDS = 2;
+const DEFAULT_WIDGET_MAX_LINES = 60;
+const DEFAULT_WIDGET_MAX_CARDS = 4;
 const COLLAPSED_CARD_BODY_LINES = 18;
 const EXPANDED_CARD_BODY_LINES = 48; // 50 total lines including top/bottom borders.
 const COLLAPSED_PROMPT_LINES = 3;
@@ -66,6 +61,8 @@ export interface MastraAgentActivity {
 	threadId: string;
 	resourceId: string;
 	status: MastraAgentCallDetails["status"];
+	lifecycleStatus: Exclude<MastraAgentLifecycleStatus, "available">;
+	order: number;
 	startedAt: number;
 	updatedAt: number;
 	completedAt?: number;
@@ -81,7 +78,7 @@ export interface MastraAgentActivity {
 	 *
 	 * The summary fields above keep status/footer rendering cheap, while this
 	 * snapshot carries the text/tool arrays needed to reuse the same rich card
-	 * renderer used by synchronous `agent_call` results.
+	 * renderer used by synchronous `agent_query` results.
 	 */
 	details: MastraAgentCallDetails;
 }
@@ -90,16 +87,19 @@ export interface MastraAgentActivitySink {
 	start(toolCallId: string, params: MastraAgentCallInput, details: MastraAgentCallDetails): void;
 	update(toolCallId: string, details: MastraAgentCallDetails): void;
 	finish(toolCallId: string, details: MastraAgentCallDetails): void;
+	end?(toolCallId: string): void;
+	reset?(): void;
 }
 
 export class MastraAgentActivityStore implements MastraAgentActivitySink {
 	private readonly activities = new Map<string, MastraAgentActivity>();
 	private readonly listeners = new Set<() => void>();
+	private nextOrder = 0;
 
 	constructor(private readonly lingerMs = DEFAULT_ACTIVITY_LINGER_MS) {}
 
 	start(toolCallId: string, params: MastraAgentCallInput, details: MastraAgentCallDetails): void {
-		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, undefined, params.message));
+		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, undefined, params.message, "working", this.nextOrder++));
 		this.notify();
 	}
 
@@ -109,19 +109,24 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 	}
 
 	finish(toolCallId: string, details: MastraAgentCallDetails): void {
-		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, this.activities.get(toolCallId)));
+		this.activities.set(toolCallId, activityFromDetails(toolCallId, details, this.activities.get(toolCallId), undefined, "agent_response_queued"));
+		this.notify();
+	}
+
+	end(toolCallId: string): void {
+		if (!this.activities.delete(toolCallId)) return;
 		this.notify();
 	}
 
 	snapshot(options: { includeFinished?: boolean } = {}): MastraAgentActivity[] {
 		this.cleanupExpired();
 		const includeFinished = options.includeFinished ?? true;
-		const values = Array.from(this.activities.values()).filter((activity) => includeFinished || activity.status === "running");
+		const values = Array.from(this.activities.values()).filter((activity) => includeFinished || activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued");
 		return values.sort((a, b) => {
-			const aRunning = a.status === "running" ? 0 : 1;
-			const bRunning = b.status === "running" ? 0 : 1;
+			const aRunning = a.lifecycleStatus === "working" ? 0 : 1;
+			const bRunning = b.lifecycleStatus === "working" ? 0 : 1;
 			if (aRunning !== bRunning) return aRunning - bRunning;
-			return a.startedAt - b.startedAt;
+			return a.order - b.order;
 		});
 	}
 
@@ -136,13 +141,14 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 
 	reset(): void {
 		this.activities.clear();
+		this.nextOrder = 0;
 		this.notify();
 	}
 
 	private cleanupExpired(now = Date.now()): void {
 		let changed = false;
 		for (const [id, activity] of this.activities) {
-			if (activity.status === "running") continue;
+			if (activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued") continue;
 			const linger = activity.status === "error" || activity.status === "aborted" ? ERROR_ACTIVITY_LINGER_MS : this.lingerMs;
 			const completedAt = activity.completedAt ?? activity.updatedAt;
 			if (now - completedAt > linger) {
@@ -163,8 +169,6 @@ export interface MastraAgentsWidgetOptions {
 	maxLines?: number;
 	/** Number of live/lingering async jobs rendered as full cards. */
 	maxCards?: number;
-	/** Card width before right-padding; controls the bottom-right visual anchor. */
-	cardWidth?: number;
 	/** Optional fixed body height per card; otherwise derived from maxLines. */
 	cardBodyLines?: number;
 }
@@ -172,6 +176,7 @@ export interface MastraAgentsWidgetOptions {
 export class MastraAgentsWidget implements Component {
 	private readonly unsubscribe: () => void;
 	private readonly timer: ReturnType<typeof setInterval>;
+	private visibleToolCallIds: string[] = [];
 
 	constructor(
 		private readonly tui: Pick<PiTUI, "requestRender">,
@@ -183,55 +188,51 @@ export class MastraAgentsWidget implements Component {
 		this.timer = setInterval(() => {
 			if (this.store.hasVisibleActivity()) this.tui.requestRender();
 		}, 160);
+		(this.timer as { unref?: () => void }).unref?.();
 	}
 
 	render(width: number): string[] {
 		if (width < 12) return [];
 		const activities = this.store.snapshot();
-		if (activities.length === 0) return [];
+		if (activities.length === 0) {
+			this.visibleToolCallIds = [];
+			return [];
+		}
 
 		const maxLines = Math.max(8, this.options.maxLines ?? DEFAULT_WIDGET_MAX_LINES);
-		const running = activities.filter((activity) => activity.status === "running");
+		const running = activities.filter((activity) => activity.lifecycleStatus === "working");
 		const th = this.theme;
 
-		// Running jobs are the actionable surface; completed jobs linger briefly as
-		// confirmation. This order makes multiple concurrent async agents visible
-		// instead of letting an older finished card hide an active stream.
-		const orderedActivities = [...running, ...activities.filter((a) => a.status !== "running")];
+		const orderedActivities = activities
+			.filter((activity) => activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued")
+			.sort((a, b) => a.order - b.order);
 		const maxCards = Math.max(1, Math.floor(this.options.maxCards ?? DEFAULT_WIDGET_MAX_CARDS));
-		const visibleCards = orderedActivities.slice(0, maxCards);
+		const visibleCards = this.selectVisibleCards(orderedActivities, maxCards);
 		if (visibleCards.length > 0) {
-			// Split the available widget height across cards so launching two async
-			// agents yields two complete, bounded cards rather than half of one tall
-			// card. MastraAgentCard receives maxBodyLines as its per-card scroll budget.
-			const extra = Math.max(0, activities.length - visibleCards.length);
+			const extra = Math.max(0, orderedActivities.length - visibleCards.length);
 			const gapLines = Math.max(0, visibleCards.length - 1);
 			const overflowLines = extra > 0 ? 1 : 0;
 			const availableForCards = Math.max(5, maxLines - gapLines - overflowLines);
 			const perCardTotalLines = Math.max(5, Math.floor(availableForCards / visibleCards.length));
 			const maxBodyLines = Math.max(3, this.options.cardBodyLines ?? perCardTotalLines - 2);
-			// Cards align to the left gutter. Pi widget slot placement (aboveEditor /
-			// belowEditor) anchors to the content edge, so no horizontal offset is
-			// applied. cardWidth can optionally limit the card content width; by
-			// default, async cards use the full available widget width.
-			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? width));
 			const lines: string[] = [];
+
+			if (extra > 0) lines.push(truncateToWidth(th.fg("dim", `+${extra} more`), width));
 
 			for (let i = 0; i < visibleCards.length; i++) {
 				const activity = visibleCards[i];
 				const cardLines = new MastraAgentCard(
 					activity.details,
-					{ isPartial: activity.status === "running", expanded: false, maxBodyLines },
+					{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: false, maxBodyLines },
 					th,
-				).render(cardWidth);
+				).render(width);
 				if (cardLines.length === 0) continue;
 				if (lines.length > 0) lines.push("");
 				lines.push(...cardLines);
 			}
 
 			if (lines.length > 0) {
-				if (extra > 0) lines.push(truncateToWidth(th.fg("dim", `└─ +${extra} more`), width));
-				return lines;
+				return lines.slice(0, maxLines);
 			}
 		}
 
@@ -257,8 +258,8 @@ export class MastraAgentsWidget implements Component {
 			lines.push(truncateToWidth(`${th.fg("dim", child + "⎿ ")}${th.fg(activity.errors.length > 0 ? "error" : "muted", tail)}`, width));
 		}
 
-		if (activities.length > visibleActivities.length) {
-			lines.push(truncateToWidth(th.fg("dim", `└─ +${activities.length - visibleActivities.length} more`), width));
+		if (orderedActivities.length > visibleActivities.length) {
+			lines.unshift(truncateToWidth(th.fg("dim", `+${orderedActivities.length - visibleActivities.length} more`), width));
 		}
 
 		return lines.slice(0, maxLines);
@@ -271,6 +272,12 @@ export class MastraAgentsWidget implements Component {
 	dispose(): void {
 		this.unsubscribe();
 		clearInterval(this.timer);
+	}
+
+	private selectVisibleCards(orderedActivities: MastraAgentActivity[], maxCards: number): MastraAgentActivity[] {
+		const visibleCards = orderedActivities.slice(-maxCards);
+		this.visibleToolCallIds = visibleCards.map((activity) => activity.toolCallId);
+		return visibleCards;
 	}
 }
 
@@ -346,6 +353,8 @@ export class MastraAgentCard implements Component {
 		const footerParts = [
 			this.details.threadId ? `thread ${shortId(this.details.threadId)}` : undefined,
 			this.details.rawChunkCount ? `${this.details.rawChunkCount} chunks` : undefined,
+			this.details.terminalReason ? `terminal ${this.details.terminalReason}` : undefined,
+			this.details.incomplete ? "incomplete" : undefined,
 			this.details.chunksTruncated ? "truncated" : undefined,
 		].filter(Boolean);
 		if (footerParts.length > 0) {
@@ -404,6 +413,8 @@ function activityFromDetails(
 	details: MastraAgentCallDetails,
 	previous?: MastraAgentActivity,
 	promptOverride?: string,
+	lifecycleStatus?: Exclude<MastraAgentLifecycleStatus, "available">,
+	orderOverride?: number,
 ): MastraAgentActivity {
 	const now = Date.now();
 	const mostRecentTool = recentToolEvents(details, 1)[0];
@@ -418,6 +429,8 @@ function activityFromDetails(
 		threadId: details.threadId,
 		resourceId: details.resourceId,
 		status: details.status,
+		lifecycleStatus: lifecycleStatus ?? previous?.lifecycleStatus ?? (details.status === "running" ? "working" : "agent_response_queued"),
+		order: previous?.order ?? orderOverride ?? now,
 		startedAt,
 		updatedAt,
 		completedAt,

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -207,14 +207,14 @@ export class MastraAgentsWidget implements Component {
 			.filter((activity) => activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued")
 			.sort((a, b) => a.order - b.order);
 		const maxCards = Math.max(1, Math.floor(this.options.maxCards ?? DEFAULT_WIDGET_MAX_CARDS));
-		const visibleCards = this.selectVisibleCards(orderedActivities, maxCards);
+		const visibleCards = this.selectVisibleCards(orderedActivities, maxCards, maxLines);
 		if (visibleCards.length > 0) {
 			const extra = Math.max(0, orderedActivities.length - visibleCards.length);
 			const gapLines = Math.max(0, visibleCards.length - 1);
 			const overflowLines = extra > 0 ? 1 : 0;
 			const availableForCards = Math.max(5, maxLines - gapLines - overflowLines);
 			const perCardTotalLines = Math.max(5, Math.floor(availableForCards / visibleCards.length));
-			const maxBodyLines = Math.max(3, this.options.cardBodyLines ?? perCardTotalLines - 2);
+			const maxBodyLines = Math.max(3, Math.min(this.options.cardBodyLines ?? perCardTotalLines - 2, perCardTotalLines - 2));
 			const lines: string[] = [];
 
 			if (extra > 0) lines.push(truncateToWidth(th.fg("dim", `+${extra} more`), width));
@@ -227,12 +227,12 @@ export class MastraAgentsWidget implements Component {
 					th,
 				).render(width);
 				if (cardLines.length === 0) continue;
-				if (lines.length > 0) lines.push("");
+				if (lines.length > 0 && !(extra > 0 && i === 0)) lines.push("");
 				lines.push(...cardLines);
 			}
 
 			if (lines.length > 0) {
-				return lines.slice(0, maxLines);
+				return lines;
 			}
 		}
 
@@ -274,8 +274,17 @@ export class MastraAgentsWidget implements Component {
 		clearInterval(this.timer);
 	}
 
-	private selectVisibleCards(orderedActivities: MastraAgentActivity[], maxCards: number): MastraAgentActivity[] {
-		const visibleCards = orderedActivities.slice(-maxCards);
+	private selectVisibleCards(orderedActivities: MastraAgentActivity[], maxCards: number, maxLines: number): MastraAgentActivity[] {
+		const minCardLines = 5;
+		let visibleCount = Math.min(maxCards, orderedActivities.length);
+		while (visibleCount > 1) {
+			const hiddenCount = orderedActivities.length - visibleCount;
+			const overflowLines = hiddenCount > 0 ? 1 : 0;
+			const gapLines = visibleCount - 1;
+			if (visibleCount * minCardLines + gapLines + overflowLines <= maxLines) break;
+			visibleCount -= 1;
+		}
+		const visibleCards = orderedActivities.slice(-visibleCount);
 		this.visibleToolCallIds = visibleCards.map((activity) => activity.toolCallId);
 		return visibleCards;
 	}

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -1,17 +1,22 @@
 import { getMarkdownTheme, type Theme, type ThemeColor } from "@mariozechner/pi-coding-agent";
 import type { Component, TUI as PiTUI } from "@mariozechner/pi-tui";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import type { MastraAgentCallDetails, MastraAgentCallInput, MastraAgentLifecycleStatus, MastraToolEvent, MastraUsage } from "../mastra/types.js";
 
 const DEFAULT_WIDGET_MAX_LINES = 60;
 const DEFAULT_WIDGET_MAX_CARDS = 4;
+const DEFAULT_WIDGET_LIST_MAX_LINES = 12;
+const DEFAULT_WIDGET_RESERVED_ROWS = 10;
+const MIN_WIDGET_LINES = 1;
 const COLLAPSED_CARD_BODY_LINES = 18;
 const EXPANDED_CARD_BODY_LINES = 48; // 50 total lines including top/bottom borders.
 const COLLAPSED_PROMPT_LINES = 3;
 const EXPANDED_PROMPT_LINES = 8;
 const DEFAULT_ACTIVITY_LINGER_MS = 12_000;
 const ERROR_ACTIVITY_LINGER_MS = 30_000;
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const TOOL_NAME_ALIASES: Record<string, string> = {
 	mastra_workspace_list_files: "list_files",
 	mastra_workspace_read_file: "read_file",
@@ -165,50 +170,177 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 }
 
 export interface MastraAgentsWidgetOptions {
-	/** Overall widget height budget in Pi's above-editor slot. */
+	/** Overall widget height budget for the full card/detail region. */
 	maxLines?: number;
+	/** Height budget for the compact list widget above the editor. */
+	listMaxLines?: number;
 	/** Number of live/lingering async jobs rendered as full cards. */
 	maxCards?: number;
 	/** Optional fixed body height per card; otherwise derived from maxLines. */
 	cardBodyLines?: number;
+	/** Rows reserved for Pi chat/editor/status/footer chrome when adapting to terminal height. */
+	reservedRows?: number;
+	/** Keep the card/detail region height stable while activities are visible. */
+	fixedRegion?: boolean;
+	/** Shared view state for list/card/detail mode switching. */
+	viewController?: MastraAgentsWidgetViewController;
+	/** Emit Mastra widget viewport metrics. Can also be enabled with MASTRA_WIDGET_DEBUG=1. */
+	debug?: boolean;
+	/** Optional log path for widget metrics. Defaults to ~/.pi/agent/mastra-widget-debug.log. */
+	debugLogPath?: string;
+}
+
+export type MastraAgentsViewMode = "list" | "cards" | "detail";
+
+export class MastraAgentsWidgetViewController {
+	private mode: MastraAgentsViewMode;
+	private focusedToolCallId: string | undefined;
+	private readonly listeners = new Set<() => void>();
+
+	constructor(initialMode: MastraAgentsViewMode = "list") {
+		this.mode = initialMode;
+	}
+
+	getMode(): MastraAgentsViewMode {
+		return this.mode;
+	}
+
+	setMode(mode: MastraAgentsViewMode): void {
+		if (this.mode === mode) return;
+		this.mode = mode;
+		this.notify();
+	}
+
+	cycleMode(): MastraAgentsViewMode {
+		const nextMode: MastraAgentsViewMode = this.mode === "list" ? "cards" : this.mode === "cards" ? "detail" : "list";
+		this.setMode(nextMode);
+		return nextMode;
+	}
+
+	focusNext(activities: MastraAgentActivity[], direction = 1): MastraAgentActivity | undefined {
+		const focusable = visibleWidgetActivities(activities);
+		if (focusable.length === 0) {
+			if (this.focusedToolCallId !== undefined) {
+				this.focusedToolCallId = undefined;
+				this.notify();
+			}
+			return undefined;
+		}
+
+		const currentIndex = focusable.findIndex((activity) => activity.toolCallId === this.focusedToolCallId);
+		const startIndex = currentIndex >= 0 ? currentIndex : direction >= 0 ? focusable.length - 1 : 0;
+		const nextIndex = (startIndex + direction + focusable.length) % focusable.length;
+		const nextActivity = focusable[nextIndex];
+		if (this.focusedToolCallId !== nextActivity.toolCallId) {
+			this.focusedToolCallId = nextActivity.toolCallId;
+			this.notify();
+		}
+		return nextActivity;
+	}
+
+	getFocusedActivity(activities: MastraAgentActivity[]): MastraAgentActivity | undefined {
+		const focusable = visibleWidgetActivities(activities);
+		return focusable.find((activity) => activity.toolCallId === this.focusedToolCallId) ?? focusable.at(-1);
+	}
+
+	subscribe(listener: () => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	private notify(): void {
+		for (const listener of this.listeners) listener();
+	}
+}
+
+type MastraWidgetRenderReason = "external" | "store";
+type MastraWidgetRenderMode = "empty" | "list" | "cards" | "detail" | "compact";
+type MastraWidgetTUI = Pick<PiTUI, "requestRender"> & {
+	terminal?: {
+		rows?: number;
+	};
+};
+
+interface MastraWidgetLineBudget {
+	configuredMaxLines: number;
+	effectiveMaxLines: number;
+	terminalRows?: number;
+	reservedRows: number;
+	viewportBudget?: number;
+}
+
+interface MastraWidgetRenderMetrics {
+	renderMode: MastraWidgetRenderMode;
+	totalActivities: number;
+	visibleCards: number;
+	overflowCards: number;
+}
+
+interface MastraWidgetDebugEntry extends MastraWidgetLineBudget, MastraWidgetRenderMetrics {
+	renderReason: MastraWidgetRenderReason;
+	renderedLines: number;
+	clamped: boolean;
 }
 
 export class MastraAgentsWidget implements Component {
-	private readonly unsubscribe: () => void;
-	private readonly timer: ReturnType<typeof setInterval>;
+	private readonly unsubscribeStore: () => void;
+	private readonly unsubscribeViewController: () => void;
 	private visibleToolCallIds: string[] = [];
+	private renderReason: MastraWidgetRenderReason = "external";
 
 	constructor(
-		private readonly tui: Pick<PiTUI, "requestRender">,
+		private readonly tui: MastraWidgetTUI,
 		private readonly theme: Theme,
 		private readonly store: MastraAgentActivityStore,
 		private readonly options: MastraAgentsWidgetOptions = {},
 	) {
-		this.unsubscribe = this.store.subscribe(() => this.tui.requestRender());
-		this.timer = setInterval(() => {
-			if (this.store.hasVisibleActivity()) this.tui.requestRender();
-		}, 160);
-		(this.timer as { unref?: () => void }).unref?.();
+		this.unsubscribeStore = this.store.subscribe(() => this.requestRender("store"));
+		this.unsubscribeViewController = this.options.viewController?.subscribe(() => this.requestRender("store")) ?? (() => undefined);
 	}
 
 	render(width: number): string[] {
 		if (width < 12) return [];
 		const activities = this.store.snapshot();
+		const lineBudget = resolveWidgetLineBudget(this.options, this.tui.terminal?.rows);
+		const viewMode = this.options.viewController?.getMode() ?? "cards";
+		if (viewMode === "list") {
+			this.visibleToolCallIds = [];
+			return this.finishRender([], lineBudget, {
+				renderMode: "empty",
+				totalActivities: activities.length,
+				visibleCards: 0,
+				overflowCards: 0,
+			});
+		}
 		if (activities.length === 0) {
 			this.visibleToolCallIds = [];
-			return [];
+			return this.finishRender([], lineBudget, {
+				renderMode: "empty",
+				totalActivities: 0,
+				visibleCards: 0,
+				overflowCards: 0,
+			});
 		}
 
-		const maxLines = Math.max(8, this.options.maxLines ?? DEFAULT_WIDGET_MAX_LINES);
-		const running = activities.filter((activity) => activity.lifecycleStatus === "working");
+		const maxLines = lineBudget.effectiveMaxLines;
 		const th = this.theme;
 
-		const orderedActivities = activities
-			.filter((activity) => activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued")
-			.sort((a, b) => a.order - b.order);
+		const orderedActivities = visibleWidgetActivities(activities);
+		if (orderedActivities.length === 0) {
+			this.visibleToolCallIds = [];
+			return this.finishRender([], lineBudget, {
+				renderMode: "empty",
+				totalActivities: activities.length,
+				visibleCards: 0,
+				overflowCards: 0,
+			});
+		}
+		if (viewMode === "detail") return this.renderDetail(orderedActivities, maxLines, width, lineBudget);
+
+		const running = orderedActivities.filter((activity) => activity.lifecycleStatus === "working");
 		const maxCards = Math.max(1, Math.floor(this.options.maxCards ?? DEFAULT_WIDGET_MAX_CARDS));
 		const visibleCards = this.selectVisibleCards(orderedActivities, maxCards, maxLines);
-		if (visibleCards.length > 0) {
+		if (visibleCards.length > 0 && maxLines >= 5) {
 			const extra = Math.max(0, orderedActivities.length - visibleCards.length);
 			const gapLines = Math.max(0, visibleCards.length - 1);
 			const overflowLines = extra > 0 ? 1 : 0;
@@ -232,7 +364,12 @@ export class MastraAgentsWidget implements Component {
 			}
 
 			if (lines.length > 0) {
-				return lines;
+				return this.finishRender(this.finishRegion(lines.slice(0, maxLines), maxLines), lineBudget, {
+					renderMode: "cards",
+					totalActivities: orderedActivities.length,
+					visibleCards: visibleCards.length,
+					overflowCards: extra,
+				});
 			}
 		}
 
@@ -262,7 +399,12 @@ export class MastraAgentsWidget implements Component {
 			lines.unshift(truncateToWidth(th.fg("dim", `+${orderedActivities.length - visibleActivities.length} more`), width));
 		}
 
-		return lines.slice(0, maxLines);
+		return this.finishRender(this.finishRegion(lines.slice(0, maxLines), maxLines), lineBudget, {
+			renderMode: "compact",
+			totalActivities: orderedActivities.length,
+			visibleCards: 0,
+			overflowCards: Math.max(0, orderedActivities.length - visibleActivities.length),
+		});
 	}
 
 	invalidate(): void {
@@ -270,8 +412,8 @@ export class MastraAgentsWidget implements Component {
 	}
 
 	dispose(): void {
-		this.unsubscribe();
-		clearInterval(this.timer);
+		this.unsubscribeStore();
+		this.unsubscribeViewController();
 	}
 
 	private selectVisibleCards(orderedActivities: MastraAgentActivity[], maxCards: number, maxLines: number): MastraAgentActivity[] {
@@ -287,6 +429,252 @@ export class MastraAgentsWidget implements Component {
 		const visibleCards = orderedActivities.slice(-visibleCount);
 		this.visibleToolCallIds = visibleCards.map((activity) => activity.toolCallId);
 		return visibleCards;
+	}
+
+	private renderDetail(orderedActivities: MastraAgentActivity[], maxLines: number, width: number, lineBudget: MastraWidgetLineBudget): string[] {
+		const th = this.theme;
+		const activity = this.options.viewController?.getFocusedActivity(orderedActivities) ?? orderedActivities.at(-1);
+		if (!activity) {
+			this.visibleToolCallIds = [];
+			return this.finishRender([], lineBudget, {
+				renderMode: "empty",
+				totalActivities: orderedActivities.length,
+				visibleCards: 0,
+				overflowCards: 0,
+			});
+		}
+
+		this.visibleToolCallIds = [activity.toolCallId];
+		const position = Math.max(0, orderedActivities.findIndex((candidate) => candidate.toolCallId === activity.toolCallId)) + 1;
+		const headerParts = [
+			`${position}/${orderedActivities.length}`,
+			formatActivityStatusLabel(activity),
+			activity.modeId ? `mode=${activity.modeId}` : undefined,
+		].filter(Boolean);
+		const header = truncateToWidth(
+			`${activityIcon(activity, th)} ${th.bold("Mastra Agent")} ${th.fg("accent", activity.agentId)} ${th.fg("dim", headerParts.join(" · "))}`,
+			width,
+		);
+		const maxBodyLines = Math.max(1, maxLines - 3);
+		const cardLines = new MastraAgentCard(
+			activity.details,
+			{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: true, maxBodyLines },
+			th,
+		).render(width);
+		return this.finishRender(this.finishRegion([header, ...cardLines].slice(0, maxLines), maxLines), lineBudget, {
+			renderMode: "detail",
+			totalActivities: orderedActivities.length,
+			visibleCards: 1,
+			overflowCards: Math.max(0, orderedActivities.length - 1),
+		});
+	}
+
+	private finishRegion(lines: string[], maxLines: number): string[] {
+		if (this.options.fixedRegion !== true || lines.length === 0 || lines.length >= maxLines) return lines;
+		return [...lines, ...Array.from({ length: maxLines - lines.length }, () => "")];
+	}
+
+	private requestRender(reason: MastraWidgetRenderReason): void {
+		this.renderReason = reason;
+		this.tui.requestRender();
+	}
+
+	private finishRender(lines: string[], lineBudget: MastraWidgetLineBudget, metrics: MastraWidgetRenderMetrics): string[] {
+		logWidgetDebug(
+			{
+				...lineBudget,
+				...metrics,
+				renderReason: this.renderReason,
+				renderedLines: lines.length,
+				clamped: lineBudget.effectiveMaxLines < lineBudget.configuredMaxLines,
+			},
+			this.options,
+		);
+		this.renderReason = "external";
+		return lines;
+	}
+}
+
+export class MastraAgentsListWidget implements Component {
+	private readonly unsubscribeStore: () => void;
+	private readonly unsubscribeViewController: () => void;
+	private renderReason: MastraWidgetRenderReason = "external";
+
+	constructor(
+		private readonly tui: MastraWidgetTUI,
+		private readonly theme: Theme,
+		private readonly store: MastraAgentActivityStore,
+		private readonly options: MastraAgentsWidgetOptions = {},
+	) {
+		this.unsubscribeStore = this.store.subscribe(() => this.requestRender("store"));
+		this.unsubscribeViewController = this.options.viewController?.subscribe(() => this.requestRender("store")) ?? (() => undefined);
+	}
+
+	render(width: number): string[] {
+		if (width < 12) return [];
+		const listOptions = { ...this.options, maxLines: this.options.listMaxLines ?? DEFAULT_WIDGET_LIST_MAX_LINES };
+		const lineBudget = resolveWidgetLineBudget(listOptions, this.tui.terminal?.rows);
+		const viewMode = this.options.viewController?.getMode() ?? "list";
+		const activities = visibleWidgetActivities(this.store.snapshot());
+		if (viewMode !== "list" || activities.length === 0) {
+			return this.finishRender([], lineBudget, {
+				renderMode: "empty",
+				totalActivities: activities.length,
+				visibleCards: 0,
+				overflowCards: 0,
+			});
+		}
+
+		const result = renderCompactActivityList(activities, lineBudget.effectiveMaxLines, width, this.theme);
+		return this.finishRender(result.lines, lineBudget, {
+			renderMode: "list",
+			totalActivities: activities.length,
+			visibleCards: result.visibleCount,
+			overflowCards: result.hiddenCount,
+		});
+	}
+
+	invalidate(): void {
+		// No cached rendering state.
+	}
+
+	dispose(): void {
+		this.unsubscribeStore();
+		this.unsubscribeViewController();
+	}
+
+	private requestRender(reason: MastraWidgetRenderReason): void {
+		this.renderReason = reason;
+		this.tui.requestRender();
+	}
+
+	private finishRender(lines: string[], lineBudget: MastraWidgetLineBudget, metrics: MastraWidgetRenderMetrics): string[] {
+		logWidgetDebug(
+			{
+				...lineBudget,
+				...metrics,
+				renderReason: this.renderReason,
+				renderedLines: lines.length,
+				clamped: lineBudget.effectiveMaxLines < lineBudget.configuredMaxLines,
+			},
+			this.options,
+		);
+		this.renderReason = "external";
+		return lines;
+	}
+}
+
+function resolveWidgetLineBudget(options: MastraAgentsWidgetOptions, terminalRows?: number): MastraWidgetLineBudget {
+	const configuredMaxLines = Math.max(MIN_WIDGET_LINES, positiveInteger(options.maxLines) ?? DEFAULT_WIDGET_MAX_LINES);
+	const reservedRows = Math.max(0, nonNegativeInteger(options.reservedRows) ?? DEFAULT_WIDGET_RESERVED_ROWS);
+	const rows = positiveInteger(terminalRows);
+	if (rows === undefined) {
+		return {
+			configuredMaxLines,
+			effectiveMaxLines: configuredMaxLines,
+			reservedRows,
+		};
+	}
+
+	const viewportBudget = Math.max(MIN_WIDGET_LINES, rows - reservedRows);
+	return {
+		configuredMaxLines,
+		effectiveMaxLines: Math.min(configuredMaxLines, viewportBudget),
+		terminalRows: rows,
+		reservedRows,
+		viewportBudget,
+	};
+}
+
+function visibleWidgetActivities(activities: MastraAgentActivity[]): MastraAgentActivity[] {
+	return activities
+		.filter((activity) => activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued")
+		.sort((a, b) => a.order - b.order);
+}
+
+function renderCompactActivityList(
+	activities: MastraAgentActivity[],
+	maxLines: number,
+	width: number,
+	theme: Theme,
+): { lines: string[]; visibleCount: number; hiddenCount: number } {
+	const running = activities.filter((activity) => activity.lifecycleStatus === "working");
+	const queued = activities.filter((activity) => activity.lifecycleStatus === "agent_response_queued");
+	const titleIcon = running.length > 0 ? theme.fg("accent", "●") : theme.fg("success", "✓");
+	const titleMeta = compactParts([
+		running.length > 0 ? `${running.length} working` : undefined,
+		queued.length > 0 ? `${queued.length} queued` : undefined,
+	]);
+	const lines = [truncateToWidth(`${titleIcon} ${theme.bold("Mastra Agents")} ${theme.fg("dim", titleMeta || `${activities.length} visible`)}`, width)];
+	if (maxLines <= 1) return { lines: lines.slice(0, maxLines), visibleCount: 0, hiddenCount: activities.length };
+
+	let bodyBudget = maxLines - 1;
+	let visibleCount = Math.min(activities.length, Math.floor(bodyBudget / 3));
+	let hiddenCount = activities.length - visibleCount;
+	if (hiddenCount > 0 && bodyBudget > 1) {
+		bodyBudget -= 1;
+		visibleCount = Math.min(activities.length, Math.floor(bodyBudget / 3));
+		hiddenCount = activities.length - visibleCount;
+		lines.push(truncateToWidth(theme.fg("dim", `├─ +${hiddenCount} more`), width));
+	}
+
+	const visibleActivities = visibleCount > 0 ? activities.slice(-visibleCount) : [];
+	for (let i = 0; i < visibleActivities.length; i++) {
+		const activity = visibleActivities[i];
+		const isLast = i === visibleActivities.length - 1;
+		const branch = isLast ? "└─" : "├─";
+		const child = isLast ? "   " : "│  ";
+		lines.push(truncateToWidth(`${theme.fg("dim", branch)} ${formatActivityHeadline(activity, theme)}`, width));
+		lines.push(truncateToWidth(`${theme.fg("dim", child + "├ tools ")}${theme.fg("muted", formatActivityToolStream(activity, theme, width))}`, width));
+		const output = activity.errors[0]
+			? `error: ${activity.errors[activity.errors.length - 1]}`
+			: textTail(activity.text, 110) || (activity.prompt ? `prompt: ${textHead(activity.prompt, 90)}` : formatActivityStatusLabel(activity));
+		lines.push(truncateToWidth(`${theme.fg("dim", child + "└ now ")}${theme.fg(activity.errors.length > 0 ? "error" : "muted", output)}`, width));
+	}
+
+	return { lines: lines.slice(0, maxLines), visibleCount, hiddenCount };
+}
+
+function formatActivityToolStream(activity: MastraAgentActivity, theme: Theme, width: number): string {
+	const events = compactToolEvents(recentToolEvents(activity.details, 3));
+	if (events.length === 0) return activity.lastEvent || "waiting for tool events";
+	const previewWidth = Math.max(24, Math.floor(width / 2));
+	return events.map((event) => formatToolEvent(event, theme, previewWidth)).join(theme.fg("dim", " · "));
+}
+
+function positiveInteger(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : undefined;
+}
+
+function logWidgetDebug(entry: MastraWidgetDebugEntry, options: MastraAgentsWidgetOptions): void {
+	const enabled = options.debug === true || process.env.MASTRA_WIDGET_DEBUG === "1" || process.env.MASTRA_WIDGET_DEBUG === "true";
+	if (!enabled) return;
+	const logPath = options.debugLogPath ?? process.env.MASTRA_WIDGET_DEBUG_PATH ?? join(homedir(), ".pi", "agent", "mastra-widget-debug.log");
+	const fields = [
+		`ts=${new Date().toISOString()}`,
+		`reason=${entry.renderReason}`,
+		`mode=${entry.renderMode}`,
+		`terminalRows=${entry.terminalRows ?? "unknown"}`,
+		`reservedRows=${entry.reservedRows}`,
+		`configuredMaxLines=${entry.configuredMaxLines}`,
+		`effectiveMaxLines=${entry.effectiveMaxLines}`,
+		`viewportBudget=${entry.viewportBudget ?? "unknown"}`,
+		`renderedLines=${entry.renderedLines}`,
+		`totalActivities=${entry.totalActivities}`,
+		`visibleCards=${entry.visibleCards}`,
+		`overflowCards=${entry.overflowCards}`,
+		`clamped=${entry.clamped}`,
+	];
+
+	try {
+		mkdirSync(dirname(logPath), { recursive: true });
+		appendFileSync(logPath, `${fields.join(" ")}\n`, "utf8");
+	} catch {
+		// Debug logging must not break the interactive terminal.
 	}
 }
 
@@ -312,9 +700,10 @@ export class MastraAgentCard implements Component {
 		const lines: string[] = [];
 		const border = (s: string) => th.fg(borderColor, s);
 		const topLabel = ` Mastra: ${this.details.agentId} `;
+		const elapsed = this.details.completedAt ? formatElapsed(this.details.startedAt, this.details.completedAt) : undefined;
 		const meta = [
 			this.options.isPartial ? "running" : this.details.status,
-			formatElapsed(this.details.startedAt, this.details.completedAt),
+			elapsed,
 			`${this.details.toolCalls.length + this.details.toolResults.length} tools`,
 			formatUsage(this.details.usage),
 		]
@@ -461,9 +850,10 @@ function activityFromDetails(
 
 function formatActivityHeadline(activity: MastraAgentActivity, theme: Theme): string {
 	const icon = activityIcon(activity, theme);
+	const elapsed = activity.completedAt ? formatElapsed(activity.startedAt, activity.completedAt) : undefined;
 	const meta = [
 		activity.status,
-		formatElapsed(activity.startedAt, activity.completedAt),
+		elapsed,
 		activity.toolCalls + activity.toolResults > 0 ? `${activity.toolCalls + activity.toolResults} tools` : undefined,
 		formatUsage(activity.usage),
 		activity.modeId ? `mode=${activity.modeId}` : undefined,
@@ -473,11 +863,14 @@ function formatActivityHeadline(activity: MastraAgentActivity, theme: Theme): st
 	return `${icon} ${theme.fg("accent", activity.agentId)} ${theme.fg("dim", meta)}`;
 }
 
+function formatActivityStatusLabel(activity: MastraAgentActivity): string {
+	if (activity.lifecycleStatus === "agent_response_queued") return "agent_response_queued";
+	if (activity.status === "running") return "working";
+	return activity.status;
+}
+
 function activityIcon(activity: MastraAgentActivity, theme: Theme): string {
-	if (activity.status === "running") {
-		const frame = SPINNER_FRAMES[Math.floor(Date.now() / 160) % SPINNER_FRAMES.length];
-		return theme.fg("accent", frame);
-	}
+	if (activity.status === "running") return theme.fg("accent", "●");
 	if (activity.status === "done") return theme.fg("success", "✓");
 	if (activity.status === "error" || activity.status === "aborted") return theme.fg("error", "✗");
 	return theme.fg("dim", "○");

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -8,9 +8,11 @@ import type { MastraAgentCallDetails, MastraAgentCallInput, MastraAgentLifecycle
 
 const DEFAULT_WIDGET_MAX_LINES = 60;
 const DEFAULT_WIDGET_MAX_CARDS = 4;
-const DEFAULT_WIDGET_LIST_MAX_LINES = 12;
+const DEFAULT_WIDGET_LIST_MAX_LINES = 18;
+const DEFAULT_WIDGET_LIST_MAX_AGENTS = 5;
 const DEFAULT_WIDGET_RESERVED_ROWS = 10;
 const MIN_WIDGET_LINES = 1;
+const ABOVE_EDITOR_WIDGET_SPACER_LINES = 1;
 const COLLAPSED_CARD_BODY_LINES = 18;
 const EXPANDED_CARD_BODY_LINES = 48; // 50 total lines including top/bottom borders.
 const COLLAPSED_PROMPT_LINES = 3;
@@ -131,7 +133,7 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 	snapshot(options: { includeFinished?: boolean } = {}): MastraAgentActivity[] {
 		this.cleanupExpired();
 		const includeFinished = options.includeFinished ?? true;
-		const values = Array.from(this.activities.values()).filter((activity) => includeFinished || activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued");
+		const values = Array.from(this.activities.values()).filter((activity) => includeFinished || activity.lifecycleStatus === "working");
 		return values.sort((a, b) => {
 			const aRunning = a.lifecycleStatus === "working" ? 0 : 1;
 			const bRunning = b.lifecycleStatus === "working" ? 0 : 1;
@@ -141,7 +143,7 @@ export class MastraAgentActivityStore implements MastraAgentActivitySink {
 	}
 
 	hasVisibleActivity(): boolean {
-		return this.snapshot().length > 0;
+		return this.snapshot({ includeFinished: false }).length > 0;
 	}
 
 	subscribe(listener: () => void): () => void {
@@ -180,13 +182,15 @@ export interface MastraAgentsWidgetOptions {
 	maxLines?: number;
 	/** Height budget for the compact list widget above the editor. */
 	listMaxLines?: number;
+	/** Maximum live async jobs rendered in compact list mode. */
+	listMaxAgents?: number;
 	/** Number of live/lingering async jobs rendered as full cards. */
 	maxCards?: number;
 	/** Optional fixed body height per card; otherwise derived from maxLines. */
 	cardBodyLines?: number;
 	/** Rows reserved for Pi chat/editor/status/footer chrome when adapting to terminal height. */
 	reservedRows?: number;
-	/** Keep the card/detail region height stable while activities are visible. */
+	/** Deprecated: card/detail fixed sizing is derived from maxLines. */
 	fixedRegion?: boolean;
 	/** Shared view state for list/card/detail mode switching. */
 	viewController?: MastraAgentsWidgetViewController;
@@ -272,12 +276,15 @@ interface MastraWidgetLineBudget {
 	effectiveMaxLines: number;
 	terminalRows?: number;
 	reservedRows: number;
+	spacerRows: number;
 	viewportBudget?: number;
 }
 
 interface MastraWidgetRenderMetrics {
 	renderMode: MastraWidgetRenderMode;
 	totalActivities: number;
+	workingActivities: number;
+	hiddenQueuedActivities: number;
 	visibleCards: number;
 	overflowCards: number;
 }
@@ -285,6 +292,7 @@ interface MastraWidgetRenderMetrics {
 interface MastraWidgetDebugEntry extends MastraWidgetLineBudget, MastraWidgetRenderMetrics {
 	renderReason: MastraWidgetRenderReason;
 	renderedLines: number;
+	occupiedRows: number;
 	clamped: boolean;
 }
 
@@ -307,41 +315,63 @@ export class MastraAgentsWidget implements Component {
 	render(width: number): string[] {
 		if (width < 12) return [];
 		const activities = this.store.snapshot();
-		const lineBudget = resolveWidgetLineBudget(this.options, this.tui.terminal?.rows);
+		const orderedActivities = visibleWidgetActivities(activities);
+		const hiddenQueuedActivities = activities.filter((activity) => activity.lifecycleStatus === "agent_response_queued").length;
 		const viewMode = this.options.viewController?.getMode() ?? "cards";
 		if (viewMode === "list") {
+			const listOptions = { ...this.options, maxLines: this.options.listMaxLines ?? DEFAULT_WIDGET_LIST_MAX_LINES };
+			const lineBudget = resolveWidgetLineBudget(listOptions, this.tui.terminal?.rows);
+			if (orderedActivities.length === 0) {
+				this.visibleToolCallIds = [];
+				return this.finishRender([], lineBudget, {
+					renderMode: "empty",
+					totalActivities: activities.length,
+					workingActivities: 0,
+					hiddenQueuedActivities,
+					visibleCards: 0,
+					overflowCards: 0,
+				});
+			}
+
+			const result = renderCompactActivityList(orderedActivities, lineBudget.effectiveMaxLines, width, this.theme, resolveListMaxAgents(this.options));
+			this.visibleToolCallIds = result.visibleCount > 0 ? orderedActivities.slice(-result.visibleCount).map((activity) => activity.toolCallId) : [];
+			return this.finishRender(result.lines, lineBudget, {
+				renderMode: "list",
+				totalActivities: activities.length,
+				workingActivities: orderedActivities.length,
+				hiddenQueuedActivities,
+				visibleCards: result.visibleCount,
+				overflowCards: result.hiddenCount,
+			});
+		}
+		const lineBudget = resolveWidgetLineBudget(this.options, this.tui.terminal?.rows);
+		if (orderedActivities.length === 0) {
 			this.visibleToolCallIds = [];
 			return this.finishRender([], lineBudget, {
 				renderMode: "empty",
 				totalActivities: activities.length,
-				visibleCards: 0,
-				overflowCards: 0,
-			});
-		}
-		if (activities.length === 0) {
-			this.visibleToolCallIds = [];
-			return this.finishRender([], lineBudget, {
-				renderMode: "empty",
-				totalActivities: 0,
+				workingActivities: 0,
+				hiddenQueuedActivities,
 				visibleCards: 0,
 				overflowCards: 0,
 			});
 		}
 
 		const maxLines = lineBudget.effectiveMaxLines;
-		const th = this.theme;
-
-		const orderedActivities = visibleWidgetActivities(activities);
-		if (orderedActivities.length === 0) {
+		if (maxLines <= 0) {
 			this.visibleToolCallIds = [];
 			return this.finishRender([], lineBudget, {
 				renderMode: "empty",
 				totalActivities: activities.length,
+				workingActivities: orderedActivities.length,
+				hiddenQueuedActivities,
 				visibleCards: 0,
 				overflowCards: 0,
 			});
 		}
-		if (viewMode === "detail") return this.renderDetail(orderedActivities, maxLines, width, lineBudget);
+		const th = this.theme;
+
+		if (viewMode === "detail") return this.renderDetail(orderedActivities, maxLines, width, lineBudget, activities.length, hiddenQueuedActivities);
 
 		const running = orderedActivities.filter((activity) => activity.lifecycleStatus === "working");
 		const maxCards = Math.max(1, Math.floor(this.options.maxCards ?? DEFAULT_WIDGET_MAX_CARDS));
@@ -349,30 +379,37 @@ export class MastraAgentsWidget implements Component {
 		if (visibleCards.length > 0 && maxLines >= 5) {
 			const extra = Math.max(0, orderedActivities.length - visibleCards.length);
 			const gapLines = Math.max(0, visibleCards.length - 1);
-			const overflowLines = extra > 0 ? 1 : 0;
-			const availableForCards = Math.max(5, maxLines - gapLines - overflowLines);
-			const perCardTotalLines = Math.max(5, Math.floor(availableForCards / visibleCards.length));
-			const maxBodyLines = Math.max(3, Math.min(this.options.cardBodyLines ?? perCardTotalLines - 2, perCardTotalLines - 2));
+			const minimumCardLines = visibleCards.length * 5 + gapLines;
+			const showOverflow = extra > 0 && minimumCardLines + 1 <= maxLines;
+			const overflowLines = showOverflow ? 1 : 0;
+			const availableForCards = Math.max(visibleCards.length * 5, maxLines - gapLines - overflowLines);
+			const baseCardTotalLines = Math.max(5, Math.floor(availableForCards / visibleCards.length));
+			const remainderLines = Math.max(0, availableForCards - baseCardTotalLines * visibleCards.length);
 			const lines: string[] = [];
 
-			if (extra > 0) lines.push(truncateToWidth(th.fg("dim", `+${extra} more`), width));
+			if (showOverflow) lines.push(truncateToWidth(th.fg("dim", `+${extra} more`), width));
 
 			for (let i = 0; i < visibleCards.length; i++) {
 				const activity = visibleCards[i];
+				const fixedTotalLines = baseCardTotalLines + (i >= visibleCards.length - remainderLines ? 1 : 0);
+				const bodyLines = Math.max(0, fixedTotalLines - 2);
+				const maxBodyLines = Math.max(0, Math.min(this.options.cardBodyLines ?? bodyLines, bodyLines));
 				const cardLines = new MastraAgentCard(
 					activity.details,
-					{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: false, maxBodyLines },
+					{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: false, fixedTotalLines, maxBodyLines },
 					th,
 				).render(width);
 				if (cardLines.length === 0) continue;
-				if (lines.length > 0 && !(extra > 0 && i === 0)) lines.push("");
+				if (lines.length > 0 && !(showOverflow && i === 0)) lines.push("");
 				lines.push(...cardLines);
 			}
 
 			if (lines.length > 0) {
-				return this.finishRender(this.finishRegion(lines.slice(0, maxLines), maxLines), lineBudget, {
+				return this.finishRender(lines.slice(0, maxLines), lineBudget, {
 					renderMode: "cards",
-					totalActivities: orderedActivities.length,
+					totalActivities: activities.length,
+					workingActivities: orderedActivities.length,
+					hiddenQueuedActivities,
 					visibleCards: visibleCards.length,
 					overflowCards: extra,
 				});
@@ -383,13 +420,13 @@ export class MastraAgentsWidget implements Component {
 		const allActivities = orderedActivities;
 		const lines: string[] = [];
 		const titleIcon = running.length > 0 ? th.fg("accent", "●") : th.fg("success", "✓");
-		const title = `${titleIcon} ${th.bold("Mastra Agents")} ${th.fg("dim", `${running.length} running · ${activities.length} visible`)}`;
+		const title = `${titleIcon} ${th.bold("Mastra Agents")} ${th.fg("dim", `${running.length} running · ${orderedActivities.length} visible`)}`;
 		lines.push(truncateToWidth(title, width));
 
 		const visibleActivities = allActivities.slice(0, Math.max(0, maxLines - 2));
 		for (let i = 0; i < visibleActivities.length; i++) {
 			const activity = visibleActivities[i];
-			const isLast = i === visibleActivities.length - 1 && activities.length <= visibleActivities.length;
+			const isLast = i === visibleActivities.length - 1 && orderedActivities.length <= visibleActivities.length;
 			const branch = isLast ? "└─" : "├─";
 			lines.push(truncateToWidth(`${th.fg("dim", branch)} ${formatActivityHeadline(activity, th)}`, width));
 			const progress = activity.lastEvent || textTail(activity.text, 90);
@@ -405,9 +442,11 @@ export class MastraAgentsWidget implements Component {
 			lines.unshift(truncateToWidth(th.fg("dim", `+${orderedActivities.length - visibleActivities.length} more`), width));
 		}
 
-		return this.finishRender(this.finishRegion(lines.slice(0, maxLines), maxLines), lineBudget, {
+		return this.finishRender(lines.slice(0, maxLines), lineBudget, {
 			renderMode: "compact",
-			totalActivities: orderedActivities.length,
+			totalActivities: activities.length,
+			workingActivities: orderedActivities.length,
+			hiddenQueuedActivities,
 			visibleCards: 0,
 			overflowCards: Math.max(0, orderedActivities.length - visibleActivities.length),
 		});
@@ -437,14 +476,23 @@ export class MastraAgentsWidget implements Component {
 		return visibleCards;
 	}
 
-	private renderDetail(orderedActivities: MastraAgentActivity[], maxLines: number, width: number, lineBudget: MastraWidgetLineBudget): string[] {
+	private renderDetail(
+		orderedActivities: MastraAgentActivity[],
+		maxLines: number,
+		width: number,
+		lineBudget: MastraWidgetLineBudget,
+		totalActivities: number,
+		hiddenQueuedActivities: number,
+	): string[] {
 		const th = this.theme;
 		const activity = this.options.viewController?.getFocusedActivity(orderedActivities) ?? orderedActivities.at(-1);
 		if (!activity) {
 			this.visibleToolCallIds = [];
 			return this.finishRender([], lineBudget, {
 				renderMode: "empty",
-				totalActivities: orderedActivities.length,
+				totalActivities,
+				workingActivities: 0,
+				hiddenQueuedActivities,
 				visibleCards: 0,
 				overflowCards: 0,
 			});
@@ -461,23 +509,31 @@ export class MastraAgentsWidget implements Component {
 			`${activityIcon(activity, th)} ${th.bold("Mastra Agent")} ${th.fg("accent", activity.agentId)} ${th.fg("dim", headerParts.join(" · "))}`,
 			width,
 		);
-		const maxBodyLines = Math.max(1, maxLines - 3);
+		if (maxLines <= 1) {
+			return this.finishRender([header].slice(0, maxLines), lineBudget, {
+				renderMode: "detail",
+				totalActivities,
+				workingActivities: orderedActivities.length,
+				hiddenQueuedActivities,
+				visibleCards: 1,
+				overflowCards: Math.max(0, orderedActivities.length - 1),
+			});
+		}
+		const fixedTotalLines = Math.max(2, maxLines - 1);
+		const maxBodyLines = Math.max(0, fixedTotalLines - 2);
 		const cardLines = new MastraAgentCard(
 			activity.details,
-			{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: true, maxBodyLines },
+			{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: true, fixedTotalLines, maxBodyLines },
 			th,
 		).render(width);
-		return this.finishRender(this.finishRegion([header, ...cardLines].slice(0, maxLines), maxLines), lineBudget, {
+		return this.finishRender([header, ...cardLines].slice(0, maxLines), lineBudget, {
 			renderMode: "detail",
-			totalActivities: orderedActivities.length,
+			totalActivities,
+			workingActivities: orderedActivities.length,
+			hiddenQueuedActivities,
 			visibleCards: 1,
 			overflowCards: Math.max(0, orderedActivities.length - 1),
 		});
-	}
-
-	private finishRegion(lines: string[], maxLines: number): string[] {
-		if (this.options.fixedRegion !== true || lines.length === 0 || lines.length >= maxLines) return lines;
-		return [...lines, ...Array.from({ length: maxLines - lines.length }, () => "")];
 	}
 
 	private requestRender(reason: MastraWidgetRenderReason): void {
@@ -492,7 +548,8 @@ export class MastraAgentsWidget implements Component {
 				...metrics,
 				renderReason: this.renderReason,
 				renderedLines: lines.length,
-				clamped: lineBudget.effectiveMaxLines < lineBudget.configuredMaxLines,
+				occupiedRows: lines.length + lineBudget.spacerRows,
+				clamped: lineBudget.viewportBudget !== undefined && lineBudget.viewportBudget < lineBudget.configuredMaxLines,
 			},
 			this.options,
 		);
@@ -521,20 +578,26 @@ export class MastraAgentsListWidget implements Component {
 		const listOptions = { ...this.options, maxLines: this.options.listMaxLines ?? DEFAULT_WIDGET_LIST_MAX_LINES };
 		const lineBudget = resolveWidgetLineBudget(listOptions, this.tui.terminal?.rows);
 		const viewMode = this.options.viewController?.getMode() ?? "list";
-		const activities = visibleWidgetActivities(this.store.snapshot());
+		const allActivities = this.store.snapshot();
+		const activities = visibleWidgetActivities(allActivities);
+		const hiddenQueuedActivities = allActivities.filter((activity) => activity.lifecycleStatus === "agent_response_queued").length;
 		if (viewMode !== "list" || activities.length === 0) {
 			return this.finishRender([], lineBudget, {
 				renderMode: "empty",
-				totalActivities: activities.length,
+				totalActivities: allActivities.length,
+				workingActivities: activities.length,
+				hiddenQueuedActivities,
 				visibleCards: 0,
 				overflowCards: 0,
 			});
 		}
 
-		const result = renderCompactActivityList(activities, lineBudget.effectiveMaxLines, width, this.theme);
+		const result = renderCompactActivityList(activities, lineBudget.effectiveMaxLines, width, this.theme, resolveListMaxAgents(this.options));
 		return this.finishRender(result.lines, lineBudget, {
 			renderMode: "list",
-			totalActivities: activities.length,
+			totalActivities: allActivities.length,
+			workingActivities: activities.length,
+			hiddenQueuedActivities,
 			visibleCards: result.visibleCount,
 			overflowCards: result.hiddenCount,
 		});
@@ -561,7 +624,8 @@ export class MastraAgentsListWidget implements Component {
 				...metrics,
 				renderReason: this.renderReason,
 				renderedLines: lines.length,
-				clamped: lineBudget.effectiveMaxLines < lineBudget.configuredMaxLines,
+				occupiedRows: lines.length + lineBudget.spacerRows,
+				clamped: lineBudget.viewportBudget !== undefined && lineBudget.viewportBudget < lineBudget.configuredMaxLines,
 			},
 			this.options,
 		);
@@ -574,27 +638,31 @@ function resolveWidgetLineBudget(options: MastraAgentsWidgetOptions, terminalRow
 	const configuredMaxLines = Math.max(MIN_WIDGET_LINES, positiveInteger(options.maxLines) ?? DEFAULT_WIDGET_MAX_LINES);
 	const reservedRows = Math.max(0, nonNegativeInteger(options.reservedRows) ?? DEFAULT_WIDGET_RESERVED_ROWS);
 	const rows = positiveInteger(terminalRows);
+	const contentLinesForTotal = (totalLines: number) => Math.max(0, totalLines - ABOVE_EDITOR_WIDGET_SPACER_LINES);
 	if (rows === undefined) {
 		return {
 			configuredMaxLines,
-			effectiveMaxLines: configuredMaxLines,
+			effectiveMaxLines: contentLinesForTotal(configuredMaxLines),
 			reservedRows,
+			spacerRows: ABOVE_EDITOR_WIDGET_SPACER_LINES,
 		};
 	}
 
 	const viewportBudget = Math.max(MIN_WIDGET_LINES, rows - reservedRows);
+	const totalBudget = Math.min(configuredMaxLines, viewportBudget);
 	return {
 		configuredMaxLines,
-		effectiveMaxLines: Math.min(configuredMaxLines, viewportBudget),
+		effectiveMaxLines: contentLinesForTotal(totalBudget),
 		terminalRows: rows,
 		reservedRows,
+		spacerRows: ABOVE_EDITOR_WIDGET_SPACER_LINES,
 		viewportBudget,
 	};
 }
 
 function visibleWidgetActivities(activities: MastraAgentActivity[]): MastraAgentActivity[] {
 	return activities
-		.filter((activity) => activity.lifecycleStatus === "working" || activity.lifecycleStatus === "agent_response_queued")
+		.filter((activity) => activity.lifecycleStatus === "working")
 		.sort((a, b) => a.order - b.order);
 }
 
@@ -603,26 +671,24 @@ function renderCompactActivityList(
 	maxLines: number,
 	width: number,
 	theme: Theme,
+	maxAgents = DEFAULT_WIDGET_LIST_MAX_AGENTS,
 ): { lines: string[]; visibleCount: number; hiddenCount: number } {
 	const running = activities.filter((activity) => activity.lifecycleStatus === "working");
-	const queued = activities.filter((activity) => activity.lifecycleStatus === "agent_response_queued");
 	const titleIcon = running.length > 0 ? theme.fg("accent", "●") : theme.fg("success", "✓");
-	const titleMeta = compactParts([
-		running.length > 0 ? `${running.length} working` : undefined,
-		queued.length > 0 ? `${queued.length} queued` : undefined,
-	]);
+	const titleMeta = running.length > 0 ? `${running.length} working` : `${activities.length} visible`;
 	const lines = [truncateToWidth(`${titleIcon} ${theme.bold("Mastra Agents")} ${theme.fg("dim", titleMeta || `${activities.length} visible`)}`, width)];
 	if (maxLines <= 1) return { lines: lines.slice(0, maxLines), visibleCount: 0, hiddenCount: activities.length };
 
-	let bodyBudget = maxLines - 1;
-	let visibleCount = Math.min(activities.length, Math.floor(bodyBudget / 3));
+	let visibleCount = Math.min(activities.length, Math.max(1, Math.floor(maxAgents)));
 	let hiddenCount = activities.length - visibleCount;
-	if (hiddenCount > 0 && bodyBudget > 1) {
-		bodyBudget -= 1;
-		visibleCount = Math.min(activities.length, Math.floor(bodyBudget / 3));
+	while (visibleCount > 0) {
 		hiddenCount = activities.length - visibleCount;
-		lines.push(truncateToWidth(theme.fg("dim", `├─ +${hiddenCount} more`), width));
+		const requiredLines = 1 + (hiddenCount > 0 ? 1 : 0) + visibleCount * 3;
+		if (requiredLines <= maxLines) break;
+		visibleCount -= 1;
 	}
+	hiddenCount = activities.length - visibleCount;
+	if (hiddenCount > 0) lines.push(truncateToWidth(theme.fg("dim", `├─ +${hiddenCount} more`), width));
 
 	const visibleActivities = visibleCount > 0 ? activities.slice(-visibleCount) : [];
 	for (let i = 0; i < visibleActivities.length; i++) {
@@ -638,7 +704,11 @@ function renderCompactActivityList(
 		lines.push(truncateToWidth(`${theme.fg("dim", child + "└ now ")}${theme.fg(activity.errors.length > 0 ? "error" : "muted", output)}`, width));
 	}
 
-	return { lines: lines.slice(0, maxLines), visibleCount, hiddenCount };
+	return { lines, visibleCount, hiddenCount };
+}
+
+function resolveListMaxAgents(options: MastraAgentsWidgetOptions): number {
+	return Math.max(1, positiveInteger(options.listMaxAgents) ?? DEFAULT_WIDGET_LIST_MAX_AGENTS);
 }
 
 function formatActivityToolStream(activity: MastraAgentActivity, theme: Theme, width: number): string {
@@ -668,9 +738,13 @@ function logWidgetDebug(entry: MastraWidgetDebugEntry, options: MastraAgentsWidg
 		`reservedRows=${entry.reservedRows}`,
 		`configuredMaxLines=${entry.configuredMaxLines}`,
 		`effectiveMaxLines=${entry.effectiveMaxLines}`,
+		`spacerRows=${entry.spacerRows}`,
 		`viewportBudget=${entry.viewportBudget ?? "unknown"}`,
 		`renderedLines=${entry.renderedLines}`,
+		`occupiedRows=${entry.occupiedRows}`,
 		`totalActivities=${entry.totalActivities}`,
+		`workingActivities=${entry.workingActivities}`,
+		`hiddenQueuedActivities=${entry.hiddenQueuedActivities}`,
 		`visibleCards=${entry.visibleCards}`,
 		`overflowCards=${entry.overflowCards}`,
 		`clamped=${entry.clamped}`,
@@ -689,6 +763,8 @@ export interface MastraAgentCardOptions {
 	isPartial?: boolean;
 	/** Optional body budget used by the async widget to stack multiple cards. */
 	maxBodyLines?: number;
+	/** Optional total card height. Short content is padded inside the card frame. */
+	fixedTotalLines?: number;
 }
 
 export class MastraAgentCard implements Component {
@@ -766,10 +842,16 @@ export class MastraAgentCard implements Component {
 		}
 
 		if (pinnedBodyLines.length > 0 && bodyLines.length > 0) pinnedBodyLines.push("");
-		const bodyLimit = this.options.maxBodyLines ?? (this.options.expanded ? EXPANDED_CARD_BODY_LINES : COLLAPSED_CARD_BODY_LINES);
+		const fixedTotalLines = positiveInteger(this.options.fixedTotalLines);
+		const fixedBodyLines = fixedTotalLines !== undefined ? Math.max(0, fixedTotalLines - 2) : undefined;
+		const bodyLimit = fixedBodyLines ?? this.options.maxBodyLines ?? (this.options.expanded ? EXPANDED_CARD_BODY_LINES : COLLAPSED_CARD_BODY_LINES);
 		const remainingBodyLimit = Math.max(0, bodyLimit - pinnedBodyLines.length);
 		const scrolledBody = remainingBodyLimit > 0 ? [...pinnedBodyLines, ...tailLines(bodyLines, remainingBodyLimit, th)] : tailLines(pinnedBodyLines, bodyLimit, th);
-		for (const bodyLine of scrolledBody) {
+		const framedBody =
+			fixedBodyLines !== undefined && scrolledBody.length < fixedBodyLines
+				? [...scrolledBody, ...Array.from({ length: fixedBodyLines - scrolledBody.length }, () => "")]
+				: scrolledBody;
+		for (const bodyLine of framedBody) {
 			lines.push(renderFrameRow(bodyLine, width, border));
 		}
 		lines.push(border(`╰${"─".repeat(Math.max(0, width - 2))}╯`));

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -212,9 +212,9 @@ export class MastraAgentsWidget implements Component {
 			const maxBodyLines = Math.max(3, this.options.cardBodyLines ?? perCardTotalLines - 2);
 			// Cards align to the left gutter. Pi widget slot placement (aboveEditor /
 			// belowEditor) anchors to the content edge, so no horizontal offset is
-			// applied. cardWidth limits the card content width; overflow is truncated
-			// at the right rather than right-aligned.
-			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? 96));
+			// applied. cardWidth can optionally limit the card content width; by
+			// default, async cards use the full available widget width.
+			const cardWidth = Math.min(width, Math.max(12, this.options.cardWidth ?? width));
 			const lines: string[] = [];
 
 			for (let i = 0; i < visibleCards.length; i++) {


### PR DESCRIPTION
## Summary
- Stabilizes the Mastra agent live widget render lifecycle for issue 15.
- Adds `listMaxAgents` config and keeps list mode bounded to the newest working agents.
- Replaces old bottom-region padding with fixed framed card surfaces for card/detail modes.
- Keeps completed, queued, ended, and canceled jobs out of live list/card/detail surfaces.

## Verification
- `npm --workspace pi test`
- `npm run typecheck --workspaces --if-present`
- `git diff --check`

Closes #15
Closes #11
Closes #8
Closes #7
