### PR TITLE
Improve Pi agent TUI streaming controls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,8 +5,11 @@ mastra-agent-extension:
   listMaxAgents: 5
   reservedRows: 10
   defaultViewMode: list
-  viewModeShortcut: ctrl+h
+  viewModeShortcut: alt+h
   nextAgentShortcut: ctrl+down
   previousAgentShortcut: ctrl+up
+  detailScrollDownShortcut: alt+j
+  detailScrollUpShortcut: alt+k
+  detailStreamOnlyShortcut: alt+s
   debug: true
   debugPiRedraw: true

--- a/config.yaml
+++ b/config.yaml
@@ -11,5 +11,9 @@ mastra-agent-extension:
   detailScrollDownShortcut: alt+j
   detailScrollUpShortcut: alt+k
   detailStreamOnlyShortcut: alt+s
+  colors:
+    prompt: syntaxString
+    tool: syntaxString
+    reasoning: muted
   debug: true
   debugPiRedraw: true

--- a/pi/README.md
+++ b/pi/README.md
@@ -37,14 +37,19 @@ mastra-agent-extension:
   listMaxAgents: 5
   reservedRows: 10
   defaultViewMode: list
-  viewModeShortcut: ctrl+h
+  viewModeShortcut: alt+h
   nextAgentShortcut: ctrl+down
   previousAgentShortcut: ctrl+up
+  detailScrollDownShortcut: alt+j
+  detailScrollUpShortcut: alt+k
+  detailStreamOnlyShortcut: alt+s
   debug: true
   debugPiRedraw: true
 ```
 
 Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 18`, `listMaxAgents: 5`, `reservedRows: 10`, and `defaultViewMode: list`. List mode renders a compact above-editor job list with three lines per visible agent and a `+N more` marker when more than `listMaxAgents` jobs are working. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
+
+Detail mode supports keyboard scrolling with `detailScrollDownShortcut` and `detailScrollUpShortcut`, and `detailStreamOnlyShortcut` hides the submitted prompt and reasoning while keeping agent output and tool events visible. Widget hotkeys are installed from the active session `config.yaml`; scroll keys are consumed only when detail mode has visible running jobs. Raw Backspace and Enter-compatible terminal bytes are not consumed for `ctrl+h` or `ctrl+j`; terminals that disambiguate control keys can still use those shortcuts, and other environments can remap them in `config.yaml`.
 
 `debug: true` writes widget metrics to `~/.pi/agent/mastra-widget-debug.log`; `debugPiRedraw: true` also enables Pi's `~/.pi/agent/pi-debug.log` redraw reasons.
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -43,6 +43,10 @@ mastra-agent-extension:
   detailScrollDownShortcut: alt+j
   detailScrollUpShortcut: alt+k
   detailStreamOnlyShortcut: alt+s
+  colors:
+    prompt: syntaxString
+    tool: syntaxString
+    reasoning: muted
   debug: true
   debugPiRedraw: true
 ```
@@ -50,6 +54,20 @@ mastra-agent-extension:
 Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 18`, `listMaxAgents: 5`, `reservedRows: 10`, and `defaultViewMode: list`. List mode renders a compact above-editor job list with three lines per visible agent and a `+N more` marker when more than `listMaxAgents` jobs are working. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
 
 Detail mode supports keyboard scrolling with `detailScrollDownShortcut` and `detailScrollUpShortcut`, and `detailStreamOnlyShortcut` hides the submitted prompt and reasoning while keeping agent output and tool events visible. Widget hotkeys are installed from the active session `config.yaml`; scroll keys are consumed only when detail mode has visible running jobs. Raw Backspace and Enter-compatible terminal bytes are not consumed for `ctrl+h` or `ctrl+j`; terminals that disambiguate control keys can still use those shortcuts, and other environments can remap them in `config.yaml`.
+
+`colors` accepts Pi theme color keys. The defaults use `syntaxString` for submitted prompt/query detail text and `muted` for reasoning text; labels and tool names stay in normal foreground text.
+
+### Agent TUI Rendering Model
+
+The Mastra agent widget is intentionally bounded above the editor. `maxLines` defines the largest render region, then each view mode uses that same budget differently:
+
+- List mode shows a compact job list, capped by `listMaxAgents`, with three streaming rows per visible agent.
+- Card mode splits the fixed region across active cards so adding another job shrinks the shared slots instead of growing the terminal buffer.
+- Detail mode gives the whole region to one active agent, with keyboard scrolling for historical output and stream-only mode for focused live output.
+
+Completed or cancelled jobs are removed from the visible widget surface. That keeps stale cards from reappearing while preserving the session/job lifecycle in the Mastra side of the integration.
+
+The rendering surface uses Pi's Markdown renderer for agent output and expanded tool result bodies. Tool names and section labels remain plain foreground text, while prompt bodies and tool argument/result details use the configured highlight color. Reasoning is muted by default because it is supporting context rather than primary output.
 
 `debug: true` writes widget metrics to `~/.pi/agent/mastra-widget-debug.log`; `debugPiRedraw: true` also enables Pi's `~/.pi/agent/pi-debug.log` redraw reasons.
 

--- a/pi/src/extensions/config.test.ts
+++ b/pi/src/extensions/config.test.ts
@@ -25,7 +25,7 @@ test("loadMastraAgentExtensionConfig reads widget and debug values from config.y
 	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-valid-"));
 	await writeFile(
 		join(cwd, "config.yaml"),
-		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  listMaxAgents: 5\n  reservedRows: 12\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+h\n  nextAgentShortcut: ctrl+down\n  previousAgentShortcut: ctrl+up\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
+		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  listMaxAgents: 5\n  reservedRows: 12\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+]\n  nextAgentShortcut: alt+n\n  previousAgentShortcut: alt+p\n  detailScrollDownShortcut: alt+d\n  detailScrollUpShortcut: alt+u\n  detailStreamOnlyShortcut: alt+t\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
 		"utf8",
 	);
 
@@ -35,9 +35,12 @@ test("loadMastraAgentExtensionConfig reads widget and debug values from config.y
 	assert.equal(result.debugPiRedraw, true);
 	assert.equal(result.defaultViewMode, "cards");
 	assert.deepEqual(result.shortcuts, {
-		viewMode: "ctrl+h",
-		nextAgent: "ctrl+down",
-		previousAgent: "ctrl+up",
+		viewMode: "ctrl+]",
+		nextAgent: "alt+n",
+		previousAgent: "alt+p",
+		detailScrollDown: "alt+d",
+		detailScrollUp: "alt+u",
+		detailStreamOnly: "alt+t",
 	});
 	assert.equal(result.warning, undefined);
 });

--- a/pi/src/extensions/config.test.ts
+++ b/pi/src/extensions/config.test.ts
@@ -25,13 +25,22 @@ test("loadMastraAgentExtensionConfig reads widget and debug values from config.y
 	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-valid-"));
 	await writeFile(
 		join(cwd, "config.yaml"),
-		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  listMaxAgents: 5\n  reservedRows: 12\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+]\n  nextAgentShortcut: alt+n\n  previousAgentShortcut: alt+p\n  detailScrollDownShortcut: alt+d\n  detailScrollUpShortcut: alt+u\n  detailStreamOnlyShortcut: alt+t\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
+		"mastra-agent-extension:\n  maxCards: 4\n  maxLines: 60\n  listMaxLines: 10\n  listMaxAgents: 5\n  reservedRows: 12\n  colors:\n    prompt: syntaxString\n    tool: syntaxString\n    reasoning: muted\n  defaultViewMode: cards\n  viewModeShortcut: ctrl+]\n  nextAgentShortcut: alt+n\n  previousAgentShortcut: alt+p\n  detailScrollDownShortcut: alt+d\n  detailScrollUpShortcut: alt+u\n  detailStreamOnlyShortcut: alt+t\n  debug: true\n  debugPiRedraw: true\n  debugLogPath: /tmp/mastra-widget.log\n",
 		"utf8",
 	);
 
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
-	assert.deepEqual(result.options, { maxCards: 4, maxLines: 60, listMaxAgents: 5, listMaxLines: 10, reservedRows: 12, debug: true, debugLogPath: "/tmp/mastra-widget.log" });
+	assert.deepEqual(result.options, {
+		maxCards: 4,
+		maxLines: 60,
+		listMaxAgents: 5,
+		colors: { prompt: "syntaxString", tool: "syntaxString", reasoning: "muted" },
+		listMaxLines: 10,
+		reservedRows: 12,
+		debug: true,
+		debugLogPath: "/tmp/mastra-widget.log",
+	});
 	assert.equal(result.debugPiRedraw, true);
 	assert.equal(result.defaultViewMode, "cards");
 	assert.deepEqual(result.shortcuts, {
@@ -51,10 +60,25 @@ test("loadMastraAgentExtensionConfig ignores invalid values and keeps valid valu
 
 	const result = await loadMastraAgentExtensionConfig(cwd);
 	assert.equal(result.found, true);
-	assert.deepEqual(result.options, { maxCards: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards, maxLines: 60, listMaxAgents: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.listMaxAgents });
+	assert.deepEqual(result.options, {
+		maxCards: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards,
+		maxLines: 60,
+		listMaxAgents: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.listMaxAgents,
+		colors: DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.colors,
+	});
 	assert.equal(result.debugPiRedraw, false);
 	assert.match(result.warning ?? "", /maxCards/);
 	assert.match(result.warning ?? "", /listMaxAgents/);
+});
+
+test("loadMastraAgentExtensionConfig validates configurable widget colors", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-config-colors-"));
+	await writeFile(join(cwd, "config.yaml"), "mastra-agent-extension:\n  colors:\n    prompt: syntaxString\n    tool: nope\n    reasoning: muted\n", "utf8");
+
+	const result = await loadMastraAgentExtensionConfig(cwd);
+	assert.equal(result.found, true);
+	assert.deepEqual(result.options.colors, { prompt: "syntaxString", tool: "syntaxString", reasoning: "muted" });
+	assert.match(result.warning ?? "", /colors\.tool/);
 });
 
 test("loadMastraAgentExtensionConfig lets debug enable Pi redraw logging by default", async () => {

--- a/pi/src/extensions/config.ts
+++ b/pi/src/extensions/config.ts
@@ -12,15 +12,21 @@ export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidg
 };
 export const DEFAULT_MASTRA_AGENT_VIEW_MODE: MastraAgentsViewMode = "list";
 export const DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS: MastraAgentExtensionShortcuts = {
-	viewMode: "ctrl+h",
+	viewMode: "alt+h",
 	nextAgent: "ctrl+down",
 	previousAgent: "ctrl+up",
+	detailScrollDown: "alt+j",
+	detailScrollUp: "alt+k",
+	detailStreamOnly: "alt+s",
 };
 
 export interface MastraAgentExtensionShortcuts {
 	viewMode: string;
 	nextAgent: string;
 	previousAgent: string;
+	detailScrollDown: string;
+	detailScrollUp: string;
+	detailStreamOnly: string;
 }
 
 export interface MastraAgentExtensionConfigResult {
@@ -102,6 +108,9 @@ function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgent
 	const viewModeShortcut = readString(section.viewModeShortcut, "viewModeShortcut", warnings);
 	const nextAgentShortcut = readString(section.nextAgentShortcut, "nextAgentShortcut", warnings);
 	const previousAgentShortcut = readString(section.previousAgentShortcut, "previousAgentShortcut", warnings);
+	const detailScrollDownShortcut = readString(section.detailScrollDownShortcut, "detailScrollDownShortcut", warnings);
+	const detailScrollUpShortcut = readString(section.detailScrollUpShortcut, "detailScrollUpShortcut", warnings);
+	const detailStreamOnlyShortcut = readString(section.detailStreamOnlyShortcut, "detailStreamOnlyShortcut", warnings);
 	return {
 		options: {
 			maxCards: maxCards ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards,
@@ -118,6 +127,9 @@ function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgent
 			viewMode: viewModeShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.viewMode,
 			nextAgent: nextAgentShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.nextAgent,
 			previousAgent: previousAgentShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.previousAgent,
+			detailScrollDown: detailScrollDownShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.detailScrollDown,
+			detailScrollUp: detailScrollUpShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.detailScrollUp,
+			detailStreamOnly: detailStreamOnlyShortcut ?? DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS.detailStreamOnly,
 		},
 		path,
 		found: true,

--- a/pi/src/extensions/config.ts
+++ b/pi/src/extensions/config.ts
@@ -2,13 +2,15 @@ import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parse } from "yaml";
-import type { MastraAgentsViewMode, MastraAgentsWidgetOptions } from "../tui/index.js";
+import type { ThemeColor } from "@mariozechner/pi-coding-agent";
+import { DEFAULT_MASTRA_AGENT_WIDGET_COLORS, type MastraAgentWidgetColors, type MastraAgentsViewMode, type MastraAgentsWidgetOptions } from "../tui/index.js";
 
 export const MASTRA_AGENT_EXTENSION_CONFIG_KEY = "mastra-agent-extension";
-export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidgetOptions, "maxCards" | "maxLines" | "listMaxAgents">> = {
+export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidgetOptions, "maxCards" | "maxLines" | "listMaxAgents" | "colors">> = {
 	maxCards: 4,
 	maxLines: 60,
 	listMaxAgents: 5,
+	colors: { ...DEFAULT_MASTRA_AGENT_WIDGET_COLORS },
 };
 export const DEFAULT_MASTRA_AGENT_VIEW_MODE: MastraAgentsViewMode = "list";
 export const DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS: MastraAgentExtensionShortcuts = {
@@ -104,6 +106,7 @@ function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgent
 	const debug = readBoolean(section.debug, "debug", warnings);
 	const debugPiRedraw = readBoolean(section.debugPiRedraw, "debugPiRedraw", warnings);
 	const debugLogPath = readString(section.debugLogPath, "debugLogPath", warnings);
+	const colors = readWidgetColors(section.colors, "colors", warnings);
 	const defaultViewMode = readViewMode(section.defaultViewMode, "defaultViewMode", warnings);
 	const viewModeShortcut = readString(section.viewModeShortcut, "viewModeShortcut", warnings);
 	const nextAgentShortcut = readString(section.nextAgentShortcut, "nextAgentShortcut", warnings);
@@ -116,6 +119,7 @@ function parseMastraAgentExtensionConfig(raw: string, path: string): MastraAgent
 			maxCards: maxCards ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxCards,
 			maxLines: maxLines ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.maxLines,
 			listMaxAgents: listMaxAgents ?? DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS.listMaxAgents,
+			colors: { ...DEFAULT_MASTRA_AGENT_WIDGET_COLORS, ...(colors ?? {}) },
 			...(listMaxLines !== undefined ? { listMaxLines } : {}),
 			...(reservedRows !== undefined ? { reservedRows } : {}),
 			...(debug !== undefined ? { debug } : {}),
@@ -176,11 +180,86 @@ function readString(value: unknown, name: string, warnings: string[]): string | 
 	return undefined;
 }
 
+function readWidgetColors(value: unknown, name: string, warnings: string[]): MastraAgentWidgetColors | undefined {
+	if (value === undefined) return undefined;
+	if (!isRecord(value)) {
+		warnings.push(name);
+		return undefined;
+	}
+	const colors: MastraAgentWidgetColors = {};
+	const prompt = readThemeColor(value.prompt, `${name}.prompt`, warnings);
+	const tool = readThemeColor(value.tool, `${name}.tool`, warnings);
+	const reasoning = readThemeColor(value.reasoning, `${name}.reasoning`, warnings);
+	if (prompt !== undefined) colors.prompt = prompt;
+	if (tool !== undefined) colors.tool = tool;
+	if (reasoning !== undefined) colors.reasoning = reasoning;
+	return colors;
+}
+
+function readThemeColor(value: unknown, name: string, warnings: string[]): ThemeColor | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "string" && isThemeColor(value)) return value;
+	warnings.push(name);
+	return undefined;
+}
+
 function readViewMode(value: unknown, name: string, warnings: string[]): MastraAgentsViewMode | undefined {
 	if (value === undefined) return undefined;
 	if (value === "list" || value === "cards" || value === "detail") return value;
 	warnings.push(name);
 	return undefined;
+}
+
+const VALID_THEME_COLORS: readonly ThemeColor[] = [
+	"accent",
+	"border",
+	"borderAccent",
+	"borderMuted",
+	"success",
+	"error",
+	"warning",
+	"muted",
+	"dim",
+	"text",
+	"thinkingText",
+	"userMessageText",
+	"customMessageText",
+	"customMessageLabel",
+	"toolTitle",
+	"toolOutput",
+	"mdHeading",
+	"mdLink",
+	"mdLinkUrl",
+	"mdCode",
+	"mdCodeBlock",
+	"mdCodeBlockBorder",
+	"mdQuote",
+	"mdQuoteBorder",
+	"mdHr",
+	"mdListBullet",
+	"toolDiffAdded",
+	"toolDiffRemoved",
+	"toolDiffContext",
+	"syntaxComment",
+	"syntaxKeyword",
+	"syntaxFunction",
+	"syntaxVariable",
+	"syntaxString",
+	"syntaxNumber",
+	"syntaxType",
+	"syntaxOperator",
+	"syntaxPunctuation",
+	"thinkingOff",
+	"thinkingMinimal",
+	"thinkingLow",
+	"thinkingMedium",
+	"thinkingHigh",
+	"thinkingXhigh",
+	"bashMode",
+];
+
+function isThemeColor(value: string): value is ThemeColor {
+	return (VALID_THEME_COLORS as readonly string[]).includes(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/pi/src/extensions/index.test.ts
+++ b/pi/src/extensions/index.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { MASTRA_AGENT_QUERY_TOOL_NAME, MASTRA_AGENT_RESULT_MESSAGE_TYPE, MASTRA_PI_AGENT_JOB_WORKFLOW_ID, MASTRA_STATUS_KEY } from "../const.js";
 import type { MastraAgentAsyncJobSummary } from "../mastra/index.js";
-import mastraPiExtension, { completionJobIdFromMessageEnd, formatAsyncAgentCompletion, hasCompletionReminder } from "./index.js";
+import mastraPiExtension, { completionJobIdFromMessageEnd, formatAsyncAgentCompletion, hasCompletionReminder, matchesMastraWidgetShortcut } from "./index.js";
 
 const stubTheme: Record<string, (...args: string[]) => string> = {
 	fg: (_color: string, text: string) => text,
@@ -80,11 +83,39 @@ test("hasCompletionReminder matches persisted custom completion entries by job i
 	assert.equal(hasCompletionReminder(entries, "job-2"), true);
 });
 
+test("matchesMastraWidgetShortcut avoids raw editor-key ambiguities", () => {
+	assert.equal(matchesMastraWidgetShortcut("\b", "ctrl+h"), false, "raw backspace must not cycle the widget");
+	assert.equal(matchesMastraWidgetShortcut("\n", "ctrl+j"), false, "raw line feed must not scroll the widget");
+	assert.equal(matchesMastraWidgetShortcut("\x1b[104;5u", "ctrl+h"), true, "disambiguated ctrl+h should still work");
+	assert.equal(matchesMastraWidgetShortcut("\x1b[106;5u", "ctrl+j"), true, "disambiguated ctrl+j should still work");
+	assert.equal(matchesMastraWidgetShortcut("\x0b", "ctrl+k"), true);
+	assert.equal(matchesMastraWidgetShortcut("\x1bh", "alt+h"), true);
+	assert.equal(matchesMastraWidgetShortcut("\x1bj", "alt+j"), true);
+	assert.equal(matchesMastraWidgetShortcut("\x1bk", "alt+k"), true);
+	assert.equal(matchesMastraWidgetShortcut("\x1bs", "alt+s"), true);
+});
+
 test("extension queues async agent completion as steer reminder and message_end collapses activity", async () => {
 	const originalFetch = globalThis.fetch;
+	const cwd = await mkdtemp(join(tmpdir(), "mastra-extension-session-"));
+	await writeFile(
+		join(cwd, "config.yaml"),
+			[
+				"mastra-agent-extension:",
+				"  defaultViewMode: list",
+				"  viewModeShortcut: alt+h",
+				"  nextAgentShortcut: n",
+				"  previousAgentShortcut: p",
+				"  detailScrollDownShortcut: alt+j",
+				"  detailScrollUpShortcut: alt+k",
+				"  detailStreamOnlyShortcut: alt+s",
+			].join("\n"),
+			"utf8",
+	);
 	const registeredTools: any[] = [];
 	const handlers = new Map<string, (...args: any[]) => unknown>();
 	const shortcuts = new Map<string, { handler: (ctx: any) => unknown }>();
+	const terminalInputHandlers: Array<(data: string) => { consume?: boolean; data?: string } | undefined> = [];
 	const sentMessages: Array<{ message: any; options: any }> = [];
 	const statusCalls: Array<{ key: string; value: string }> = [];
 	const widgetFactories = new Map<string, (tui: any, theme: any) => any>();
@@ -124,11 +155,11 @@ test("extension queues async agent completion as steer reminder and message_end 
 			return new Response(
 				new ReadableStream<Uint8Array>({
 					start(controller) {
-						controller.enqueue(encoder.encode([
-							`data: ${JSON.stringify({ type: "tool-call", toolCallId: "tool-1", toolName: "read_file", args: { path: "src/index.ts" } })}\n\n`,
-							`data: ${JSON.stringify({ type: "tool-result", toolCallId: "tool-1", toolName: "read_file", result: "ok" })}\n\n`,
-							`data: ${JSON.stringify({ type: "text-delta", text: "extension result" })}\n\n`,
-						].join("")));
+							controller.enqueue(encoder.encode([
+								`data: ${JSON.stringify({ type: "tool-call", toolCallId: "tool-1", toolName: "read_file", args: { path: "src/index.ts" } })}\n\n`,
+								`data: ${JSON.stringify({ type: "tool-result", toolCallId: "tool-1", toolName: "read_file", result: "ok" })}\n\n`,
+								`data: ${JSON.stringify({ type: "text-delta", text: Array.from({ length: 80 }, (_, index) => `- extension result ${index + 1}`).join("\n") })}\n\n`,
+							].join("")));
 						releaseAgentFinish = () => {
 							controller.enqueue(encoder.encode([`data: ${JSON.stringify({ type: "finish" })}\n\n`, "data: [DONE]\n\n"].join("")));
 							controller.close();
@@ -176,7 +207,7 @@ test("extension queues async agent completion as steer reminder and message_end 
 		await sessionStart?.(
 			{},
 			{
-				cwd: "/workspace/project",
+				cwd,
 				hasUI: true,
 				sessionManager: {
 					getSessionId: () => "session-extension",
@@ -184,6 +215,13 @@ test("extension queues async agent completion as steer reminder and message_end 
 				},
 				ui: {
 					notify() {},
+					onTerminalInput(handler: (data: string) => { consume?: boolean; data?: string } | undefined) {
+						terminalInputHandlers.push(handler);
+						return () => {
+							const index = terminalInputHandlers.indexOf(handler);
+							if (index >= 0) terminalInputHandlers.splice(index, 1);
+						};
+					},
 					setWidget(id: string, factory: ((tui: any, theme: any) => any) | undefined, options?: { placement?: string }) {
 						widgetCalls.push({ id, hasFactory: typeof factory === "function", placement: options?.placement });
 						if (factory) widgetFactories.set(id, factory);
@@ -207,12 +245,32 @@ test("extension queues async agent completion as steer reminder and message_end 
 		assert.ok(queryTool, "agent_query tool should be registered by the extension");
 		const queryPromise = queryTool.execute("call", { agentId: "validator-agent", message: "prompt", jobName: "extension job" });
 		await waitFor(() => widgetFactories.has("mastra-agents"));
-		const widget = widgetFactories.get("mastra-agents")!({ requestRender() {}, terminal: { rows: 30 } }, stubTheme as any);
+		let renderRequests = 0;
+		const widget = widgetFactories.get("mastra-agents")!({ requestRender() { renderRequests += 1; }, terminal: { rows: 30 } }, stubTheme as any);
 		assert.ok(widget.render(100).some((line: string) => line.includes("validator-agent")), "running job should mount the compact list surface");
 		assert.equal(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), false, "default list mode should not render a card");
-		assert.ok(shortcuts.has("ctrl+h"), "view mode shortcut should be registered");
-		await shortcuts.get("ctrl+h")!.handler({ ui: { notify() {} } });
+		assert.equal(shortcuts.size, 0, "widget hotkeys should be session-scoped terminal listeners, not global extension shortcuts");
+		assert.equal(terminalInputHandlers.length, 1, "session should install one terminal shortcut listener");
+		assert.equal(terminalInputHandlers[0]?.("\x0b"), undefined, "detail scroll-up shortcut should not be consumed outside detail mode");
+		assert.equal(renderRequests, 0);
+		assert.equal(terminalInputHandlers[0]?.("\b"), undefined, "raw backspace should not be consumed as the view-mode shortcut");
+		assert.equal(terminalInputHandlers[0]?.("\x1bh")?.consume, true, "alt+h view-mode shortcut should be consumed");
+		assert.ok(renderRequests > 0, "view-mode shortcut should request a widget render");
 		assert.ok(widget.render(100).some((line: string) => line.includes("Mastra: validator-agent")), "card mode should render running work in fixed region");
+		await waitFor(() => widget.render(100).some((line: string) => line.includes("extension result 80")));
+		const renderRequestsBeforeStreamOnly = renderRequests;
+		assert.equal(terminalInputHandlers[0]?.("\x1bs")?.consume, true, "alt+s stream-only shortcut should be consumed");
+		assert.ok(renderRequests > renderRequestsBeforeStreamOnly, "stream-only shortcut should request a widget render");
+		assert.ok(widget.render(100).some((line: string) => line.includes("stream-only")), "stream-only shortcut should affect detail view state");
+		const renderRequestsBeforeScrollUp = renderRequests;
+		assert.equal(terminalInputHandlers[0]?.("\x1bk")?.consume, true, "alt+k scroll-up shortcut should be consumed in detail mode");
+		assert.ok(renderRequests > renderRequestsBeforeScrollUp, "scroll-up shortcut should request a widget render");
+		assert.ok(widget.render(100).some((line: string) => line.includes("scroll +")), "scroll-up shortcut should move away from live tail");
+		const renderRequestsBeforeScrollDown = renderRequests;
+		assert.equal(terminalInputHandlers[0]?.("\n"), undefined, "raw newline should not be consumed as the scroll-down shortcut");
+		assert.equal(terminalInputHandlers[0]?.("\x1bj")?.consume, true, "alt+j scroll-down shortcut should be consumed in detail mode");
+		assert.ok(renderRequests > renderRequestsBeforeScrollDown, "scroll-down shortcut should request a widget render");
+		assert.equal(widget.render(100).some((line: string) => line.includes("scroll +")), false, "scroll-down shortcut should return toward live tail");
 
 		await waitFor(() => typeof releaseAgentFinish === "function");
 		releaseAgentFinish?.();
@@ -239,6 +297,7 @@ test("extension queues async agent completion as steer reminder and message_end 
 		assert.equal(activeMounts[0]?.placement, "aboveEditor");
 		assert.equal(activeUnmountsAfterMount.length, 1, "completion should unmount the active widget once");
 		assert.deepEqual(widget.render(100), [], "queued completion should no longer occupy widget rows");
+		assert.equal(terminalInputHandlers[0]?.("\x0b"), undefined, "detail scroll-up shortcut should not be consumed after active work ends");
 
 		const messageEnd = handlers.get("message_end");
 		assert.equal(typeof messageEnd, "function");
@@ -265,6 +324,7 @@ test("extension queues async agent completion as steer reminder and message_end 
 		widget.dispose();
 	} finally {
 		globalThis.fetch = originalFetch;
+		await rm(cwd, { recursive: true, force: true });
 	}
 });
 

--- a/pi/src/extensions/index.ts
+++ b/pi/src/extensions/index.ts
@@ -1,10 +1,10 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { Text, type KeyId } from "@mariozechner/pi-tui";
+import { matchesKey, Text, type KeyId } from "@mariozechner/pi-tui";
 import { MASTRA_AGENT_RESULT_MESSAGE_TYPE, MASTRA_STATUS_KEY } from "../const.js";
 import { MastraAsyncAgentManager, MastraHttpClient, createMastraTools } from "../mastra/index.js";
 import { MastraAgentActivityStore, MastraAgentsWidget, MastraAgentsWidgetViewController, type MastraAgentsViewMode } from "../tui/index.js";
 import type { MastraAgentAsyncJobSummary, MastraAgentInfo, MastraWorkflowInfo, MastraWorkflowRun } from "../mastra/index.js";
-import { loadMastraAgentExtensionConfig, loadMastraAgentExtensionConfigSync, type MastraAgentExtensionShortcuts } from "./config.js";
+import { loadMastraAgentExtensionConfig, type MastraAgentExtensionShortcuts } from "./config.js";
 
 const MASTRA_AGENT_WIDGET_ID = "mastra-agents";
 const LEGACY_MASTRA_AGENT_WIDGET_IDS = [MASTRA_AGENT_WIDGET_ID, "mastra-agents-list", "mastra-agents-region"] as const;
@@ -12,8 +12,7 @@ const LEGACY_MASTRA_AGENT_WIDGET_IDS = [MASTRA_AGENT_WIDGET_ID, "mastra-agents-l
 export default function mastraPiExtension(pi: ExtensionAPI) {
 	const client = new MastraHttpClient();
 	const activityStore = new MastraAgentActivityStore();
-	const startupWidgetConfig = loadMastraAgentExtensionConfigSync(process.cwd());
-	const viewController = new MastraAgentsWidgetViewController(startupWidgetConfig.defaultViewMode);
+	const viewController = new MastraAgentsWidgetViewController();
 	const asyncAgentManager = new MastraAsyncAgentManager(client, {
 		activitySink: activityStore,
 		useWorkflowJobs: false,
@@ -35,9 +34,8 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 	});
 	let unsubscribeActivityStatus: (() => void) | undefined;
 	let unmountMastraWidget: (() => void) | undefined;
+	let uninstallMastraWidgetShortcuts: (() => void) | undefined;
 	let statusLabel = "offline";
-
-	registerMastraWidgetShortcuts(pi, startupWidgetConfig.shortcuts, viewController, activityStore);
 
 	for (const tool of createMastraTools(client, { agentActivitySink: activityStore, asyncAgentManager })) {
 		pi.registerTool(tool as any);
@@ -103,8 +101,10 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		unsubscribeActivityStatus?.();
+		uninstallMastraWidgetShortcuts?.();
 		unmountMastraWidget?.();
 		unmountMastraWidget = undefined;
+		uninstallMastraWidgetShortcuts = undefined;
 		const piSessionId = ctx.sessionManager.getSessionId();
 		asyncAgentManager.configureSession({
 			piSessionId,
@@ -114,7 +114,8 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 		let syncMastraWidget = () => undefined;
 		if (ctx.hasUI) {
 			const widgetConfig = await loadMastraAgentExtensionConfig(ctx.cwd);
-			viewController.setMode(widgetConfig.defaultViewMode);
+			viewController.reset(widgetConfig.defaultViewMode);
+			uninstallMastraWidgetShortcuts = installMastraWidgetTerminalShortcuts(ctx.ui, widgetConfig.shortcuts, viewController, activityStore);
 			if (widgetConfig.warning) ctx.ui.notify(widgetConfig.warning, "warning");
 			if (widgetConfig.debugPiRedraw && process.env.PI_DEBUG_REDRAW === undefined) process.env.PI_DEBUG_REDRAW = "1";
 			for (const widgetId of LEGACY_MASTRA_AGENT_WIDGET_IDS) ctx.ui.setWidget(widgetId, undefined);
@@ -141,7 +142,9 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 			syncMastraWidget();
 		}
 		unsubscribeActivityStatus = activityStore.subscribe(() => {
-			const running = activityStore.snapshot({ includeFinished: false }).length;
+			const runningActivities = activityStore.snapshot({ includeFinished: false });
+			viewController.syncActivities(runningActivities);
+			const running = runningActivities.length;
 			syncMastraWidget();
 			ctx.ui.setStatus(MASTRA_STATUS_KEY, running > 0 ? `mastra: ${running} running` : `mastra: ${statusLabel}`);
 		});
@@ -167,41 +170,85 @@ export default function mastraPiExtension(pi: ExtensionAPI) {
 		asyncAgentManager.detachAll("Pi session shutdown");
 		unmountMastraWidget?.();
 		unmountMastraWidget = undefined;
+		uninstallMastraWidgetShortcuts?.();
+		uninstallMastraWidgetShortcuts = undefined;
 		unsubscribeActivityStatus?.();
 		unsubscribeActivityStatus = undefined;
 	});
 }
 
-function registerMastraWidgetShortcuts(
-	pi: ExtensionAPI,
+function installMastraWidgetTerminalShortcuts(
+	ui: ExtensionCommandContext["ui"],
 	shortcuts: MastraAgentExtensionShortcuts,
 	viewController: MastraAgentsWidgetViewController,
 	activityStore: MastraAgentActivityStore,
-): void {
-	const registered = new Set<string>();
-	const register = (shortcut: string, description: string, handler: Parameters<ExtensionAPI["registerShortcut"]>[1]["handler"]) => {
-		if (registered.has(shortcut)) return;
-		registered.add(shortcut);
-		pi.registerShortcut(shortcut as KeyId, { description, handler });
-	};
+): () => void {
+	const workingActivities = () => activityStore.snapshot({ includeFinished: false });
+	return ui.onTerminalInput((data) => {
+		if (matchesMastraWidgetShortcut(data, shortcuts.viewMode)) {
+			const activities = workingActivities();
+			if (activities.length === 0) return undefined;
+			const mode = viewController.cycleMode();
+			if (mode === "detail") viewController.focusNext(activities, 0);
+			ui.notify(`Mastra agents: ${formatViewMode(mode)}`, "info");
+			return { consume: true };
+		}
 
-	register(shortcuts.viewMode, "Cycle Mastra agent widget view", (ctx) => {
-		const mode = viewController.cycleMode();
-		if (mode === "detail") viewController.focusNext(activityStore.snapshot({ includeFinished: false }), 0);
-		ctx.ui.notify(`Mastra agents: ${formatViewMode(mode)}`, "info");
-	});
+		if (matchesMastraWidgetShortcut(data, shortcuts.nextAgent)) {
+			const activities = workingActivities();
+			if (activities.length === 0) return undefined;
+			viewController.setMode("detail");
+			const activity = viewController.focusNext(activities, 1);
+			ui.notify(activity ? `Mastra detail: ${activity.agentId}` : "No Mastra agent jobs", "info");
+			return { consume: true };
+		}
 
-	register(shortcuts.nextAgent, "Focus next Mastra agent in detail view", (ctx) => {
-		viewController.setMode("detail");
-		const activity = viewController.focusNext(activityStore.snapshot({ includeFinished: false }), 1);
-		ctx.ui.notify(activity ? `Mastra detail: ${activity.agentId}` : "No Mastra agent jobs", "info");
-	});
+		if (matchesMastraWidgetShortcut(data, shortcuts.previousAgent)) {
+			const activities = workingActivities();
+			if (activities.length === 0) return undefined;
+			viewController.setMode("detail");
+			const activity = viewController.focusNext(activities, -1);
+			ui.notify(activity ? `Mastra detail: ${activity.agentId}` : "No Mastra agent jobs", "info");
+			return { consume: true };
+		}
 
-	register(shortcuts.previousAgent, "Focus previous Mastra agent in detail view", (ctx) => {
-		viewController.setMode("detail");
-		const activity = viewController.focusNext(activityStore.snapshot({ includeFinished: false }), -1);
-		ctx.ui.notify(activity ? `Mastra detail: ${activity.agentId}` : "No Mastra agent jobs", "info");
+		if (matchesMastraWidgetShortcut(data, shortcuts.detailScrollDown)) {
+			const activities = workingActivities();
+			if (viewController.getMode() !== "detail" || activities.length === 0) return undefined;
+			const activity = viewController.getFocusedActivity(activities);
+			const offset = viewController.scrollDetailDown(activity?.toolCallId);
+			ui.notify(activity ? `Mastra detail scroll: ${offset === 0 ? "live" : `+${offset}`}` : "No Mastra agent jobs", "info");
+			return { consume: true };
+		}
+
+		if (matchesMastraWidgetShortcut(data, shortcuts.detailScrollUp)) {
+			const activities = workingActivities();
+			if (viewController.getMode() !== "detail" || activities.length === 0) return undefined;
+			const activity = viewController.getFocusedActivity(activities);
+			const offset = viewController.scrollDetailUp(activity?.toolCallId);
+			ui.notify(activity ? `Mastra detail scroll: +${offset}` : "No Mastra agent jobs", "info");
+			return { consume: true };
+		}
+
+		if (matchesMastraWidgetShortcut(data, shortcuts.detailStreamOnly)) {
+			const activities = workingActivities();
+			if (activities.length === 0) return undefined;
+			viewController.setMode("detail");
+			viewController.focusNext(activities, 0);
+			const enabled = viewController.toggleDetailStreamOnly();
+			ui.notify(`Mastra detail: ${enabled ? "stream-only" : "full"}`, "info");
+			return { consume: true };
+		}
+
+		return undefined;
 	});
+}
+
+export function matchesMastraWidgetShortcut(data: string, shortcut: string): boolean {
+	const normalized = shortcut.trim().toLowerCase();
+	if (normalized === "ctrl+h" && (data === "\b" || data === "\x7f")) return false;
+	if (normalized === "ctrl+j" && data === "\n") return false;
+	return matchesKey(data, shortcut as KeyId);
 }
 
 function formatViewMode(mode: MastraAgentsViewMode): string {

--- a/pi/src/mastra/normalize.test.ts
+++ b/pi/src/mastra/normalize.test.ts
@@ -18,6 +18,15 @@ test("normalizes payload text deltas from current Mastra streams", () => {
 	assert.equal(details.reasoning, "why");
 });
 
+test("normalizes AI SDK textDelta reasoning stream variants", () => {
+	const details = makeDetails();
+	applyNormalizedEvent(details, normalizeMastraChunk({ type: "text-delta", textDelta: "hello" }));
+	applyNormalizedEvent(details, normalizeMastraChunk({ type: "reasoning", textDelta: "why" }));
+	applyNormalizedEvent(details, normalizeMastraChunk({ type: "reasoning-delta", payload: { textDelta: " now" } }));
+	assert.equal(details.text, "hello");
+	assert.equal(details.reasoning, "why now");
+});
+
 test("normalizes tool lifecycle events", () => {
 	const details = makeDetails();
 	applyNormalizedEvent(details, normalizeMastraChunk({ type: "tool-call", toolCallId: "1", toolName: "read", args: { path: "x" } }));

--- a/pi/src/mastra/normalize.ts
+++ b/pi/src/mastra/normalize.ts
@@ -17,9 +17,10 @@ export function normalizeMastraChunk(chunk: unknown): NormalizedMastraEvent {
 	const type = stringValue(chunk.type);
 	switch (type) {
 		case "text-delta":
-			return { kind: "text-delta", text: textFrom(chunk, "text", "delta"), raw: chunk };
+			return { kind: "text-delta", text: textFrom(chunk, "text", "delta", "textDelta"), raw: chunk };
 		case "reasoning-delta":
-			return { kind: "reasoning-delta", text: textFrom(chunk, "text", "delta", "reasoning"), raw: chunk };
+		case "reasoning":
+			return { kind: "reasoning-delta", text: textFrom(chunk, "text", "delta", "textDelta", "reasoning"), raw: chunk };
 		case "tool-call":
 			return { kind: "tool", event: makeToolEvent("call", chunk) };
 		case "tool-result":
@@ -118,7 +119,11 @@ function textFrom(chunk: Record<string, unknown>, ...keys: string[]): string {
 	for (const key of keys) {
 		const value = chunk[key];
 		if (typeof value === "string") return value;
-		if (isRecord(value) && typeof value.text === "string") return value.text;
+		if (isRecord(value)) {
+			if (typeof value.text === "string") return value.text;
+			if (typeof value.delta === "string") return value.delta;
+			if (typeof value.textDelta === "string") return value.textDelta;
+		}
 	}
 	if (isRecord(chunk.payload)) {
 		return textFrom(chunk.payload, ...keys);

--- a/pi/src/mastra/tool.test.ts
+++ b/pi/src/mastra/tool.test.ts
@@ -417,11 +417,13 @@ test("async agent manager drives workflow jobs through working to queued complet
 	const workflowRunReads: any[] = [];
 	const sinkEvents: string[] = [];
 	const completions: any[] = [];
+	let latestDetails: any;
 	const manager = new MastraAsyncAgentManager(
 		{
 			async *streamWorkflow(workflowId: string, runId: string, payload: unknown) {
 				workflowStarts.push({ workflowId, runId, payload });
 				yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "text-delta", text: "hello" } } };
+				yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "reasoning", textDelta: "workflow why" } } };
 				yield { type: "pi-agent-stream-chunk", payload: { chunk: { type: "finish", usage: { totalTokens: 7 } } } };
 			},
 			async *observeWorkflow(workflowId: string, runId: string, payload: unknown) {
@@ -442,7 +444,8 @@ test("async agent manager drives workflow jobs through working to queued complet
 				start() {
 					sinkEvents.push("start");
 				},
-				update() {
+				update(_toolCallId: string, details: any) {
+					latestDetails = details;
 					sinkEvents.push("update");
 				},
 				finish() {
@@ -488,6 +491,7 @@ test("async agent manager drives workflow jobs through working to queued complet
 	assert.equal(summary?.status, "done");
 	assert.equal(summary?.lifecycleStatus, "agent_response_queued");
 	assert.equal(summary?.textPreview, "hello");
+	assert.equal(latestDetails?.reasoning, "workflow why");
 	assert.equal(summary?.artifactPath, "/tmp/output.txt");
 	assert.equal(summary?.eventsPath, "/tmp/events.jsonl");
 	assert.ok(sinkEvents.filter((event) => event === "update").length >= 2, "workflow chunks should update the live activity card");

--- a/pi/src/mastra/tool.ts
+++ b/pi/src/mastra/tool.ts
@@ -1585,6 +1585,7 @@ function isMastraAgentChunkType(type: string): boolean {
 	return [
 		"text-delta",
 		"reasoning-delta",
+		"reasoning",
 		"tool-call",
 		"tool-result",
 		"tool-error",

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -20,6 +20,11 @@ const stubTheme: Record<string, (...args: string[]) => string> = {
 	bold: (text: string) => text,
 	dim: (text: string) => text,
 };
+const markerTheme: Record<string, (...args: string[]) => string> = {
+	fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+	bold: (text: string) => `<bold>${text}</bold>`,
+	dim: (text: string) => `<dim>${text}</dim>`,
+};
 
 test("filterPromptScaffolding removes Expected return status prefix", () => {
 	const result = filterPromptScaffolding("Expected return status: success. Here is my analysis.");
@@ -332,6 +337,177 @@ test("MastraAgentsWidget detail mode dedicates the region to the focused agent",
 	assert.ok(secondFocus.length + 1 <= 12);
 	assert.ok(secondFocus.some((line) => line.includes("Mastra: agent-2")));
 	assert.equal(secondFocus.filter((line) => line.includes("Mastra: agent-")).length, 1);
+});
+
+test("MastraAgentsWidget detail mode scrolls within fixed region", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join("\n"),
+	}));
+
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	const widget = new MastraAgentsWidget(makeTui(30), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 12 });
+	const liveLines = widget.render(100);
+	viewController.scrollDetailUp("call-1", 10);
+	const scrolledLines = widget.render(100);
+	viewController.scrollDetailDown("call-1", 10);
+	const returnedLines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(liveLines.length, 11);
+	assert.equal(scrolledLines.length, 11);
+	assert.equal(returnedLines.length, 11);
+	assert.ok(liveLines.join("\n").includes("line 40"), "live detail should follow newest output");
+	assert.ok(scrolledLines.join("\n").includes("later lines"), "scrolled detail should show hidden later marker");
+	assert.equal(scrolledLines.join("\n").includes("line 40"), false, "scrolling up should move away from live tail");
+	assert.ok(returnedLines.join("\n").includes("line 40"), "scrolling down should return to live tail");
+});
+
+test("MastraAgentsWidget detail mode clamps displayed scroll offset to rendered content", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "short output",
+	}));
+
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	viewController.scrollDetailUp("call-1", 100);
+	const widget = new MastraAgentsWidget(makeTui(30), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 12 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.some((line) => line.includes("scroll +")), false, "short output should not show an impossible scroll offset");
+	assert.equal(viewController.getDetailScrollOffset("call-1"), 0, "render should clear latent impossible scroll offsets");
+});
+
+test("MastraAgentsWidget detail mode avoids clipped card frames in tiny viewports", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "short output",
+	}));
+
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	const widget = new MastraAgentsWidget(makeTui(13), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 60, reservedRows: 10 });
+	const lines = widget.render(100);
+	widget.dispose();
+
+	assert.equal(lines.length, 2);
+	assert.equal(lines.some((line) => line.startsWith("╭")), false);
+	assert.equal(lines.some((line) => line.startsWith("╰")), false);
+	assert.ok(lines.some((line) => line.includes("short output")));
+});
+
+test("MastraAgentsWidgetViewController resets and prunes detail-only state", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "task" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		text: "output",
+	}));
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	viewController.focusNext(store.snapshot({ includeFinished: false }), 1);
+	viewController.toggleDetailStreamOnly();
+	viewController.scrollDetailUp("call-1", 10);
+
+	assert.equal(viewController.isDetailStreamOnly(), true);
+	assert.equal(viewController.getDetailScrollOffset("call-1"), 10);
+
+	viewController.syncActivities([]);
+	assert.equal(viewController.getDetailScrollOffset("call-1"), 0, "scroll offsets should be dropped for non-visible jobs");
+
+	viewController.reset("list");
+	assert.equal(viewController.getMode(), "list");
+	assert.equal(viewController.isDetailStreamOnly(), false, "new sessions should not inherit stream-only detail state");
+});
+
+test("MastraAgentsWidget detail stream-only mode hides prompt and reasoning", () => {
+	const store = new MastraAgentActivityStore(60_000);
+	store.start("call-1", { agentId: "agent-1", message: "submitted prompt" } as MastraAgentCallInput, makeDetails({
+		agentId: "agent-1",
+		status: "running",
+		prompt: "submitted prompt",
+		text: "streamed output",
+		reasoning: "private reasoning",
+		toolCalls: [{ id: "tool-1", name: "workspaceReadFile", type: "call", args: { path: "src/index.ts" }, timestamp: 1, raw: {} }],
+		toolResults: [{ id: "tool-1", name: "workspaceReadFile", type: "result", args: { path: "src/index.ts" }, result: "tool result body", timestamp: 2, raw: {} }],
+	}));
+
+	const viewController = new MastraAgentsWidgetViewController("detail");
+	const widget = new MastraAgentsWidget(makeTui(30), stubTheme as any, store, { viewController, fixedRegion: true, maxLines: 18 });
+	const fullLines = widget.render(100).join("\n");
+	viewController.toggleDetailStreamOnly();
+	const streamOnlyLines = widget.render(100).join("\n");
+	widget.dispose();
+
+	assert.ok(fullLines.includes("Prompt"));
+	assert.ok(fullLines.includes("Reasoning"));
+	assert.ok(streamOnlyLines.includes("stream-only"));
+	assert.ok(streamOnlyLines.includes("streamed output"));
+	assert.ok(streamOnlyLines.includes("read_file"), "stream-only detail should keep tool events visible");
+	assert.equal(streamOnlyLines.includes("submitted prompt"), false);
+	assert.equal(streamOnlyLines.includes("private reasoning"), false);
+});
+
+test("MastraAgentCard renders expanded tool output through markdown", () => {
+	const details = makeDetails({
+		text: "answer",
+		toolResults: [{
+			id: "tool-1",
+			name: "workspaceReadFile",
+			type: "result",
+			args: { path: "README.md" },
+			result: "Tool says **bold**\n\n- first\n- second",
+			timestamp: 1,
+			raw: {},
+		}],
+	});
+	const card = new MastraAgentCard(details, { expanded: true, fixedTotalLines: 28 }, stubTheme as any);
+	const joined = card.render(100).join("\n");
+
+	assert.ok(joined.includes("read_file"));
+	assert.ok(joined.includes("Tool says"));
+	assert.ok(joined.includes("bold"));
+	assert.equal(joined.includes("**bold**"), false);
+});
+
+test("MastraAgentCard stream-only tool output keeps markdown body at normal contrast", () => {
+	const details = makeDetails({
+		text: "answer",
+		toolResults: [{
+			id: "tool-1",
+			name: "workspaceReadFile",
+			type: "result",
+			args: { path: "README.md" },
+			result: "Tool says **bold**",
+			timestamp: 1,
+			raw: {},
+		}],
+	});
+	const card = new MastraAgentCard(details, { expanded: true, streamOnly: true, fixedTotalLines: 24 }, markerTheme as any);
+	const joined = card.render(120).join("\n");
+
+	assert.ok(joined.includes("Tool says"));
+	assert.ok(joined.includes("<dim>  ⎿ </dim>"), "tool-output prefix should remain secondary");
+	assert.equal(joined.includes("<dim>Tool says"), false, "tool-output body should not inherit dim styling");
+	assert.equal(joined.includes("**bold**"), false);
+});
+
+test("MastraAgentCard renders reasoning through markdown in expanded mode", () => {
+	const details = makeDetails({
+		text: "answer",
+		reasoning: "Reasoning says **bold**",
+	});
+	const card = new MastraAgentCard(details, { expanded: true, fixedTotalLines: 18 }, stubTheme as any);
+	const joined = card.render(100).join("\n");
+
+	assert.ok(joined.includes("Reasoning"));
+	assert.ok(joined.includes("bold"));
+	assert.equal(joined.includes("**bold**"), false);
 });
 
 test("MastraAgentsWidget render uses full live width with no artificial cap", () => {

--- a/pi/src/tui/index.test.ts
+++ b/pi/src/tui/index.test.ts
@@ -497,6 +497,40 @@ test("MastraAgentCard stream-only tool output keeps markdown body at normal cont
 	assert.equal(joined.includes("**bold**"), false);
 });
 
+test("MastraAgentCard renders prompt body with configured highlight color", () => {
+	const details = makeDetails({
+		prompt: "Inspect the failing test and explain the fix.",
+		text: "answer",
+	});
+	const card = new MastraAgentCard(details, { expanded: true, fixedTotalLines: 18 }, markerTheme as any);
+	const joined = card.render(120).join("\n");
+
+	assert.ok(joined.includes("<text>Prompt</text>"), "prompt label should use the normal foreground");
+	assert.ok(joined.includes("<syntaxString>Inspect the failing test and explain the fix.</syntaxString>"), "prompt body should use the prompt highlight");
+	assert.equal(joined.includes("<dim>Inspect the failing test"), false, "prompt body should not be tertiary grey");
+});
+
+test("MastraAgentCard applies configured tool and reasoning colors", () => {
+	const details = makeDetails({
+		text: "answer",
+		reasoning: "Reasoning says **bold**",
+		toolCalls: [{ id: "tool-1", name: "workspaceReadFile", type: "call", args: { path: "README.md" }, timestamp: 1, raw: {} }],
+		toolResults: [{ id: "tool-1", name: "workspaceReadFile", type: "result", args: { path: "README.md" }, result: "Tool says **bold**", timestamp: 2, raw: {} }],
+	});
+	const card = new MastraAgentCard(
+		details,
+		{ expanded: true, fixedTotalLines: 28, colors: { prompt: "error", tool: "warning", reasoning: "success" } },
+		markerTheme as any,
+	);
+	const joined = card.render(120).join("\n");
+
+	assert.ok(joined.includes("<text>read_file</text>"), "tool event names should use the normal foreground");
+	assert.ok(joined.includes("<text>→</text>"), "tool call marker should use the normal foreground");
+	assert.ok(joined.includes("<warning>path=README.md</warning>"), "tool details should use the configured tool color");
+	assert.ok(joined.includes("<text>Reasoning</text>"), "reasoning label should use the normal foreground");
+	assert.ok(joined.includes("<success>Reasoning says"), "reasoning body should use the configured reasoning color");
+});
+
 test("MastraAgentCard renders reasoning through markdown in expanded mode", () => {
 	const details = makeDetails({
 		text: "answer",

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -21,6 +21,18 @@ const DETAIL_SCROLL_STEP_ROWS = 5;
 const MAX_DETAIL_SCROLL_OFFSET_ROWS = 5_000;
 const DEFAULT_ACTIVITY_LINGER_MS = 12_000;
 const ERROR_ACTIVITY_LINGER_MS = 30_000;
+export interface MastraAgentWidgetColors {
+	prompt?: ThemeColor;
+	tool?: ThemeColor;
+	reasoning?: ThemeColor;
+}
+// These roles color payload/detail text only. Labels and tool names stay on the
+// normal foreground so the card hierarchy remains stable while streams update.
+export const DEFAULT_MASTRA_AGENT_WIDGET_COLORS: Required<MastraAgentWidgetColors> = {
+	prompt: "syntaxString",
+	tool: "syntaxString",
+	reasoning: "muted",
+};
 const TOOL_NAME_ALIASES: Record<string, string> = {
 	mastra_workspace_list_files: "list_files",
 	mastra_workspace_read_file: "read_file",
@@ -212,6 +224,8 @@ export interface MastraAgentsWidgetOptions {
 	fixedRegion?: boolean;
 	/** Shared view state for list/card/detail mode switching. */
 	viewController?: MastraAgentsWidgetViewController;
+	/** Theme color keys for highlighted card sections. */
+	colors?: MastraAgentWidgetColors;
 	/** Emit Mastra widget viewport metrics. Can also be enabled with MASTRA_WIDGET_DEBUG=1. */
 	debug?: boolean;
 	/** Optional log path for widget metrics. Defaults to ~/.pi/agent/mastra-widget-debug.log. */
@@ -424,7 +438,7 @@ export class MastraAgentsWidget implements Component {
 				});
 			}
 
-			const result = renderCompactActivityList(orderedActivities, lineBudget.effectiveMaxLines, width, this.theme, resolveListMaxAgents(this.options));
+			const result = renderCompactActivityList(orderedActivities, lineBudget.effectiveMaxLines, width, this.theme, resolveListMaxAgents(this.options), this.options.colors);
 			this.visibleToolCallIds = result.visibleCount > 0 ? orderedActivities.slice(-result.visibleCount).map((activity) => activity.toolCallId) : [];
 			return this.finishRender(result.lines, lineBudget, {
 				renderMode: "list",
@@ -487,7 +501,7 @@ export class MastraAgentsWidget implements Component {
 				const maxBodyLines = Math.max(0, Math.min(this.options.cardBodyLines ?? bodyLines, bodyLines));
 				const cardLines = new MastraAgentCard(
 					activity.details,
-					{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: false, fixedTotalLines, maxBodyLines },
+					{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: false, fixedTotalLines, maxBodyLines, colors: this.options.colors },
 					th,
 				).render(width);
 				if (cardLines.length === 0) continue;
@@ -640,6 +654,7 @@ export class MastraAgentsWidget implements Component {
 				maxBodyLines,
 				streamOnly,
 				scrollOffset,
+				colors: this.options.colors,
 				onScrollOffsetResolved: (offset) => {
 					resolvedScrollOffset = offset;
 					this.options.viewController?.resolveDetailScrollOffset(activity.toolCallId, offset);
@@ -713,7 +728,7 @@ export class MastraAgentsListWidget implements Component {
 			});
 		}
 
-		const result = renderCompactActivityList(activities, lineBudget.effectiveMaxLines, width, this.theme, resolveListMaxAgents(this.options));
+		const result = renderCompactActivityList(activities, lineBudget.effectiveMaxLines, width, this.theme, resolveListMaxAgents(this.options), this.options.colors);
 		return this.finishRender(result.lines, lineBudget, {
 			renderMode: "list",
 			totalActivities: allActivities.length,
@@ -793,7 +808,9 @@ function renderCompactActivityList(
 	width: number,
 	theme: Theme,
 	maxAgents = DEFAULT_WIDGET_LIST_MAX_AGENTS,
+	colors?: MastraAgentWidgetColors,
 ): { lines: string[]; visibleCount: number; hiddenCount: number } {
+	const resolvedColors = resolveWidgetColors(colors);
 	const running = activities.filter((activity) => activity.lifecycleStatus === "working");
 	const titleIcon = running.length > 0 ? theme.fg("accent", "●") : theme.fg("success", "✓");
 	const titleMeta = running.length > 0 ? `${running.length} working` : `${activities.length} visible`;
@@ -818,7 +835,7 @@ function renderCompactActivityList(
 		const branch = isLast ? "└─" : "├─";
 		const child = isLast ? "   " : "│  ";
 		lines.push(truncateToWidth(`${theme.fg("dim", branch)} ${formatActivityHeadline(activity, theme)}`, width));
-		lines.push(truncateToWidth(`${theme.fg("dim", child + "├ tools ")}${theme.fg("muted", formatActivityToolStream(activity, theme, width))}`, width));
+		lines.push(truncateToWidth(`${theme.fg("dim", child + "├ tools ")}${theme.fg("muted", formatActivityToolStream(activity, theme, width, resolvedColors))}`, width));
 		const output = activity.errors[0]
 			? `error: ${activity.errors[activity.errors.length - 1]}`
 			: textTail(activity.text, 110) || (activity.prompt ? `prompt: ${textHead(activity.prompt, 90)}` : formatActivityStatusLabel(activity));
@@ -832,11 +849,11 @@ function resolveListMaxAgents(options: MastraAgentsWidgetOptions): number {
 	return Math.max(1, positiveInteger(options.listMaxAgents) ?? DEFAULT_WIDGET_LIST_MAX_AGENTS);
 }
 
-function formatActivityToolStream(activity: MastraAgentActivity, theme: Theme, width: number): string {
+function formatActivityToolStream(activity: MastraAgentActivity, theme: Theme, width: number, colors: Required<MastraAgentWidgetColors>): string {
 	const events = compactToolEvents(recentToolEvents(activity.details, 3));
 	if (events.length === 0) return activity.lastEvent || "waiting for tool events";
 	const previewWidth = Math.max(24, Math.floor(width / 2));
-	return events.map((event) => formatToolEvent(event, theme, previewWidth)).join(theme.fg("dim", " · "));
+	return events.map((event) => formatToolEvent(event, theme, previewWidth, colors)).join(theme.fg("dim", " · "));
 }
 
 function positiveInteger(value: unknown): number | undefined {
@@ -882,6 +899,8 @@ function logWidgetDebug(entry: MastraWidgetDebugEntry, options: MastraAgentsWidg
 export interface MastraAgentCardOptions {
 	expanded?: boolean;
 	isPartial?: boolean;
+	/** Theme color keys for prompt/tool/reasoning emphasis. */
+	colors?: MastraAgentWidgetColors;
 	/** In expanded detail mode, hide prompt and reasoning so only live stream content remains. */
 	streamOnly?: boolean;
 	/** Number of rows to move upward from the live tail in expanded detail mode. */
@@ -906,6 +925,7 @@ export class MastraAgentCard implements Component {
 		const innerWidth = Math.max(1, width - 4);
 		const borderColor = statusColor(this.options.isPartial ? "running" : this.details.status);
 		const th = this.theme;
+		const colors = resolveWidgetColors(this.options.colors);
 		const lines: string[] = [];
 		const border = (s: string) => th.fg(borderColor, s);
 		const topLabel = ` Mastra: ${this.details.agentId} `;
@@ -923,8 +943,8 @@ export class MastraAgentCard implements Component {
 		const pinnedBodyLines: string[] = [];
 		const prompt = this.details.prompt?.trim();
 		if (prompt && !this.options.streamOnly) {
-			pinnedBodyLines.push(th.fg("muted", "Prompt"));
-			pinnedBodyLines.push(...renderPromptLines(prompt, innerWidth, this.options.expanded === true, th));
+			pinnedBodyLines.push(th.fg("text", "Prompt"));
+			pinnedBodyLines.push(...renderPromptLines(prompt, innerWidth, this.options.expanded === true, th, colors.prompt));
 		}
 
 		const bodyLines: string[] = [];
@@ -932,7 +952,7 @@ export class MastraAgentCard implements Component {
 		if (toolEvents.length > 0) {
 			bodyLines.push(th.fg("muted", "Tools"));
 			for (const event of toolEvents) {
-				bodyLines.push(...formatToolEventLines(event, th, innerWidth, this.options.expanded === true));
+				bodyLines.push(...formatToolEventLines(event, th, innerWidth, this.options.expanded === true, colors));
 			}
 		}
 
@@ -944,8 +964,8 @@ export class MastraAgentCard implements Component {
 
 		if (this.details.reasoning && this.options.expanded && !this.options.streamOnly) {
 			bodyLines.push("");
-			bodyLines.push(th.fg("muted", "Reasoning"));
-			bodyLines.push(...renderMarkdownLines(markdownTail(this.details.reasoning, 4_000), innerWidth, { color: (value) => th.fg("dim", value), italic: true }));
+			bodyLines.push(th.fg("text", "Reasoning"));
+			bodyLines.push(...renderMarkdownLines(markdownTail(this.details.reasoning, 4_000), innerWidth, { color: (value) => th.fg(colors.reasoning, value), italic: true }));
 		}
 
 		if (this.details.errors.length > 0) {
@@ -1088,6 +1108,14 @@ function formatActivityStatusLabel(activity: MastraAgentActivity): string {
 	return activity.status;
 }
 
+function resolveWidgetColors(colors?: MastraAgentWidgetColors): Required<MastraAgentWidgetColors> {
+	return {
+		prompt: colors?.prompt ?? DEFAULT_MASTRA_AGENT_WIDGET_COLORS.prompt,
+		tool: colors?.tool ?? DEFAULT_MASTRA_AGENT_WIDGET_COLORS.tool,
+		reasoning: colors?.reasoning ?? DEFAULT_MASTRA_AGENT_WIDGET_COLORS.reasoning,
+	};
+}
+
 function activityIcon(activity: MastraAgentActivity, theme: Theme): string {
 	if (activity.status === "running") return theme.fg("accent", "●");
 	if (activity.status === "done") return theme.fg("success", "✓");
@@ -1101,12 +1129,12 @@ function recentToolEvents(details: MastraAgentCallDetails, limit: number): Mastr
 		.slice(-limit);
 }
 
-function formatToolEvent(event: MastraToolEvent, theme: Theme, previewWidth: number): string {
+function formatToolEvent(event: MastraToolEvent, theme: Theme, previewWidth: number, colors: Required<MastraAgentWidgetColors>): string {
 	const icon = toolEventIcon(event, theme);
 	const rawName = event.name ?? event.id ?? "tool";
-	const name = theme.fg("accent", displayToolName(rawName));
+	const name = theme.fg("text", displayToolName(rawName));
 	const detail = event.type === "result" ? formatToolResultSummary(rawName, event.args, event.result, previewWidth) : formatToolArgs(rawName, event.args, previewWidth);
-	const preview = detail ? ` ${theme.fg("dim", detail)}` : "";
+	const preview = detail ? ` ${theme.fg(colors.tool, detail)}` : "";
 	return `${icon} ${name}${preview}`;
 }
 
@@ -1119,10 +1147,10 @@ function compactToolEvents(events: MastraToolEvent[]): MastraToolEvent[] {
 	});
 }
 
-function formatToolEventLines(event: MastraToolEvent, theme: Theme, width: number, expanded: boolean): string[] {
+function formatToolEventLines(event: MastraToolEvent, theme: Theme, width: number, expanded: boolean, colors: Required<MastraAgentWidgetColors>): string[] {
 	const icon = toolEventIcon(event, theme);
 	const rawName = event.name ?? event.id ?? "tool";
-	const name = theme.fg("accent", displayToolName(rawName));
+	const name = theme.fg("text", displayToolName(rawName));
 	const prefix = `${icon} ${name}`;
 	const detail = event.type === "result"
 		? formatToolResultSummary(rawName, event.args, event.result, width)
@@ -1130,10 +1158,10 @@ function formatToolEventLines(event: MastraToolEvent, theme: Theme, width: numbe
 	if (!detail) return [truncateToWidth(prefix, width)];
 
 	if (!expanded || event.type !== "result") {
-		return wrapTextWithAnsi(`${prefix} ${theme.fg("dim", detail)}`, width);
+		return wrapTextWithAnsi(`${prefix} ${theme.fg(colors.tool, detail)}`, width);
 	}
 
-	const lines = wrapTextWithAnsi(`${prefix} ${theme.fg("dim", detail)}`, width);
+	const lines = wrapTextWithAnsi(`${prefix} ${theme.fg(colors.tool, detail)}`, width);
 	const output = toolResultText(event.result);
 	if (!output || isShortSummary(detail, output)) return lines;
 	const renderedOutput = renderMarkdownLines(markdownTail(output, 3_000), Math.max(1, width - 4));
@@ -1288,7 +1316,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 function toolEventIcon(event: MastraToolEvent, theme: Theme): string {
 	if (event.type === "result") return theme.fg("success", "✓");
 	if (event.type === "error") return theme.fg("error", "✗");
-	if (event.type === "call") return theme.fg("accent", "→");
+	if (event.type === "call") return theme.fg("text", "→");
 	return theme.fg("muted", "…");
 }
 
@@ -1329,12 +1357,12 @@ function headLines(lines: string[], limit: number, theme: Theme): string[] {
 	return [...lines.slice(0, kept), theme.fg("dim", `… ${lines.length - kept} more prompt lines`)];
 }
 
-function renderPromptLines(prompt: string, width: number, expanded: boolean, theme: Theme): string[] {
+function renderPromptLines(prompt: string, width: number, expanded: boolean, theme: Theme, color: ThemeColor): string[] {
 	const maxChars = expanded ? 2_000 : 500;
 	const maxLines = expanded ? EXPANDED_PROMPT_LINES : COLLAPSED_PROMPT_LINES;
 	const trimmed = filterPromptScaffolding(prompt).trim();
 	const clipped = trimmed.length <= maxChars ? trimmed : `${trimmed.slice(0, Math.max(0, maxChars - 1))}…`;
-	const lines = clipped.split("\n").flatMap((line) => (line.length === 0 ? [""] : wrapTextWithAnsi(theme.fg("dim", line), width)));
+	const lines = clipped.split("\n").flatMap((line) => (line.length === 0 ? [""] : wrapTextWithAnsi(theme.fg(color, line), width)));
 	return headLines(lines, maxLines, theme);
 }
 

--- a/pi/src/tui/index.ts
+++ b/pi/src/tui/index.ts
@@ -1,5 +1,5 @@
 import { getMarkdownTheme, type Theme, type ThemeColor } from "@mariozechner/pi-coding-agent";
-import type { Component, TUI as PiTUI } from "@mariozechner/pi-tui";
+import type { Component, DefaultTextStyle, MarkdownTheme, TUI as PiTUI } from "@mariozechner/pi-tui";
 import { Markdown, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
@@ -17,6 +17,8 @@ const COLLAPSED_CARD_BODY_LINES = 18;
 const EXPANDED_CARD_BODY_LINES = 48; // 50 total lines including top/bottom borders.
 const COLLAPSED_PROMPT_LINES = 3;
 const EXPANDED_PROMPT_LINES = 8;
+const DETAIL_SCROLL_STEP_ROWS = 5;
+const MAX_DETAIL_SCROLL_OFFSET_ROWS = 5_000;
 const DEFAULT_ACTIVITY_LINGER_MS = 12_000;
 const ERROR_ACTIVITY_LINGER_MS = 30_000;
 const TOOL_NAME_ALIASES: Record<string, string> = {
@@ -30,6 +32,22 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 	workspaceReadFile: "read_file",
 	workspaceWriteFile: "write_file",
 	workspaceReplaceInFile: "edit_file",
+};
+const FALLBACK_MARKDOWN_THEME: MarkdownTheme = {
+	heading: (text) => text,
+	link: (text) => text,
+	linkUrl: (text) => text,
+	code: (text) => text,
+	codeBlock: (text) => text,
+	codeBlockBorder: (text) => text,
+	quote: (text) => text,
+	quoteBorder: (text) => text,
+	hr: (text) => text,
+	listBullet: (text) => text,
+	bold: (text) => text,
+	italic: (text) => text,
+	strikethrough: (text) => text,
+	underline: (text) => text,
 };
 
 // Patterns matched against TUI-displayed text to suppress internal prompt
@@ -205,6 +223,8 @@ export type MastraAgentsViewMode = "list" | "cards" | "detail";
 export class MastraAgentsWidgetViewController {
 	private mode: MastraAgentsViewMode;
 	private focusedToolCallId: string | undefined;
+	private detailStreamOnly = false;
+	private readonly detailScrollOffsets = new Map<string, number>();
 	private readonly listeners = new Set<() => void>();
 
 	constructor(initialMode: MastraAgentsViewMode = "list") {
@@ -213,6 +233,29 @@ export class MastraAgentsWidgetViewController {
 
 	getMode(): MastraAgentsViewMode {
 		return this.mode;
+	}
+
+	isDetailStreamOnly(): boolean {
+		return this.detailStreamOnly;
+	}
+
+	toggleDetailStreamOnly(): boolean {
+		this.detailStreamOnly = !this.detailStreamOnly;
+		this.notify();
+		return this.detailStreamOnly;
+	}
+
+	reset(mode: MastraAgentsViewMode = "list"): void {
+		const changed =
+			this.mode !== mode ||
+			this.focusedToolCallId !== undefined ||
+			this.detailStreamOnly ||
+			this.detailScrollOffsets.size > 0;
+		this.mode = mode;
+		this.focusedToolCallId = undefined;
+		this.detailStreamOnly = false;
+		this.detailScrollOffsets.clear();
+		if (changed) this.notify();
 	}
 
 	setMode(mode: MastraAgentsViewMode): void {
@@ -248,9 +291,57 @@ export class MastraAgentsWidgetViewController {
 		return nextActivity;
 	}
 
+	scrollDetail(toolCallId: string | undefined, deltaRows: number): number {
+		if (!toolCallId || deltaRows === 0) return toolCallId ? this.getDetailScrollOffset(toolCallId) : 0;
+		const current = this.getDetailScrollOffset(toolCallId);
+		const next = Math.min(MAX_DETAIL_SCROLL_OFFSET_ROWS, Math.max(0, current + Math.trunc(deltaRows)));
+		if (next !== current) {
+			if (next === 0) this.detailScrollOffsets.delete(toolCallId);
+			else this.detailScrollOffsets.set(toolCallId, next);
+			this.notify();
+		}
+		return next;
+	}
+
+	scrollDetailUp(toolCallId: string | undefined, rows = DETAIL_SCROLL_STEP_ROWS): number {
+		return this.scrollDetail(toolCallId, Math.abs(rows));
+	}
+
+	scrollDetailDown(toolCallId: string | undefined, rows = DETAIL_SCROLL_STEP_ROWS): number {
+		return this.scrollDetail(toolCallId, -Math.abs(rows));
+	}
+
+	getDetailScrollOffset(toolCallId: string | undefined): number {
+		if (!toolCallId) return 0;
+		return this.detailScrollOffsets.get(toolCallId) ?? 0;
+	}
+
+	resolveDetailScrollOffset(toolCallId: string | undefined, offsetRows: number): void {
+		if (!toolCallId) return;
+		const next = Math.max(0, Math.floor(offsetRows));
+		if (next === 0) this.detailScrollOffsets.delete(toolCallId);
+		else this.detailScrollOffsets.set(toolCallId, next);
+	}
+
 	getFocusedActivity(activities: MastraAgentActivity[]): MastraAgentActivity | undefined {
 		const focusable = visibleWidgetActivities(activities);
 		return focusable.find((activity) => activity.toolCallId === this.focusedToolCallId) ?? focusable.at(-1);
+	}
+
+	syncActivities(activities: MastraAgentActivity[]): void {
+		const visibleIds = new Set(visibleWidgetActivities(activities).map((activity) => activity.toolCallId));
+		let changed = false;
+		if (this.focusedToolCallId !== undefined && !visibleIds.has(this.focusedToolCallId)) {
+			this.focusedToolCallId = undefined;
+			changed = true;
+		}
+		for (const toolCallId of this.detailScrollOffsets.keys()) {
+			if (!visibleIds.has(toolCallId)) {
+				this.detailScrollOffsets.delete(toolCallId);
+				changed = true;
+			}
+		}
+		if (changed) this.notify();
 	}
 
 	subscribe(listener: () => void): () => void {
@@ -500,15 +591,22 @@ export class MastraAgentsWidget implements Component {
 
 		this.visibleToolCallIds = [activity.toolCallId];
 		const position = Math.max(0, orderedActivities.findIndex((candidate) => candidate.toolCallId === activity.toolCallId)) + 1;
-		const headerParts = [
-			`${position}/${orderedActivities.length}`,
-			formatActivityStatusLabel(activity),
-			activity.modeId ? `mode=${activity.modeId}` : undefined,
-		].filter(Boolean);
-		const header = truncateToWidth(
-			`${activityIcon(activity, th)} ${th.bold("Mastra Agent")} ${th.fg("accent", activity.agentId)} ${th.fg("dim", headerParts.join(" · "))}`,
-			width,
-		);
+		const streamOnly = this.options.viewController?.isDetailStreamOnly() ?? false;
+		const scrollOffset = this.options.viewController?.getDetailScrollOffset(activity.toolCallId) ?? 0;
+		const renderHeader = (effectiveScrollOffset: number) => {
+			const headerParts = [
+				`${position}/${orderedActivities.length}`,
+				formatActivityStatusLabel(activity),
+				activity.modeId ? `mode=${activity.modeId}` : undefined,
+				streamOnly ? "stream-only" : undefined,
+				effectiveScrollOffset > 0 ? `scroll +${effectiveScrollOffset}` : undefined,
+			].filter(Boolean);
+			return truncateToWidth(
+				`${activityIcon(activity, th)} ${th.bold("Mastra Agent")} ${th.fg("accent", activity.agentId)} ${th.fg("dim", headerParts.join(" · "))}`,
+				width,
+			);
+		};
+		const header = renderHeader(0);
 		if (maxLines <= 1) {
 			return this.finishRender([header].slice(0, maxLines), lineBudget, {
 				renderMode: "detail",
@@ -519,14 +617,37 @@ export class MastraAgentsWidget implements Component {
 				overflowCards: Math.max(0, orderedActivities.length - 1),
 			});
 		}
+		if (maxLines <= 3) {
+			const compactLine = truncateToWidth(th.fg("muted", activity.lastEvent || textTail(activity.text, 120) || formatActivityStatusLabel(activity)), width);
+			return this.finishRender([header, compactLine].slice(0, maxLines), lineBudget, {
+				renderMode: "detail",
+				totalActivities,
+				workingActivities: orderedActivities.length,
+				hiddenQueuedActivities,
+				visibleCards: 1,
+				overflowCards: Math.max(0, orderedActivities.length - 1),
+			});
+		}
 		const fixedTotalLines = Math.max(2, maxLines - 1);
 		const maxBodyLines = Math.max(0, fixedTotalLines - 2);
+		let resolvedScrollOffset = 0;
 		const cardLines = new MastraAgentCard(
 			activity.details,
-			{ isPartial: activity.lifecycleStatus === "working" && activity.status === "running", expanded: true, fixedTotalLines, maxBodyLines },
+			{
+				isPartial: activity.lifecycleStatus === "working" && activity.status === "running",
+				expanded: true,
+				fixedTotalLines,
+				maxBodyLines,
+				streamOnly,
+				scrollOffset,
+				onScrollOffsetResolved: (offset) => {
+					resolvedScrollOffset = offset;
+					this.options.viewController?.resolveDetailScrollOffset(activity.toolCallId, offset);
+				},
+			},
 			th,
 		).render(width);
-		return this.finishRender([header, ...cardLines].slice(0, maxLines), lineBudget, {
+		return this.finishRender([renderHeader(resolvedScrollOffset), ...cardLines].slice(0, maxLines), lineBudget, {
 			renderMode: "detail",
 			totalActivities,
 			workingActivities: orderedActivities.length,
@@ -761,6 +882,12 @@ function logWidgetDebug(entry: MastraWidgetDebugEntry, options: MastraAgentsWidg
 export interface MastraAgentCardOptions {
 	expanded?: boolean;
 	isPartial?: boolean;
+	/** In expanded detail mode, hide prompt and reasoning so only live stream content remains. */
+	streamOnly?: boolean;
+	/** Number of rows to move upward from the live tail in expanded detail mode. */
+	scrollOffset?: number;
+	/** Receives the content-clamped scroll offset used by the rendered card body. */
+	onScrollOffsetResolved?: (offsetRows: number) => void;
 	/** Optional body budget used by the async widget to stack multiple cards. */
 	maxBodyLines?: number;
 	/** Optional total card height. Short content is padded inside the card frame. */
@@ -795,7 +922,7 @@ export class MastraAgentCard implements Component {
 
 		const pinnedBodyLines: string[] = [];
 		const prompt = this.details.prompt?.trim();
-		if (prompt) {
+		if (prompt && !this.options.streamOnly) {
 			pinnedBodyLines.push(th.fg("muted", "Prompt"));
 			pinnedBodyLines.push(...renderPromptLines(prompt, innerWidth, this.options.expanded === true, th));
 		}
@@ -815,12 +942,10 @@ export class MastraAgentCard implements Component {
 		bodyLines.push(th.fg("muted", "Output"));
 		bodyLines.push(...renderMarkdownLines(markdownTail(text, textLimit), innerWidth));
 
-		if (this.details.reasoning && this.options.expanded) {
+		if (this.details.reasoning && this.options.expanded && !this.options.streamOnly) {
 			bodyLines.push("");
 			bodyLines.push(th.fg("muted", "Reasoning"));
-			for (const wrapped of wrapTextWithAnsi(th.fg("dim", textTail(this.details.reasoning, 1200)), innerWidth)) {
-				bodyLines.push(wrapped);
-			}
+			bodyLines.push(...renderMarkdownLines(markdownTail(this.details.reasoning, 4_000), innerWidth, { color: (value) => th.fg("dim", value), italic: true }));
 		}
 
 		if (this.details.errors.length > 0) {
@@ -846,7 +971,13 @@ export class MastraAgentCard implements Component {
 		const fixedBodyLines = fixedTotalLines !== undefined ? Math.max(0, fixedTotalLines - 2) : undefined;
 		const bodyLimit = fixedBodyLines ?? this.options.maxBodyLines ?? (this.options.expanded ? EXPANDED_CARD_BODY_LINES : COLLAPSED_CARD_BODY_LINES);
 		const remainingBodyLimit = Math.max(0, bodyLimit - pinnedBodyLines.length);
-		const scrolledBody = remainingBodyLimit > 0 ? [...pinnedBodyLines, ...tailLines(bodyLines, remainingBodyLimit, th)] : tailLines(pinnedBodyLines, bodyLimit, th);
+		const scrollOffset = this.options.expanded ? nonNegativeInteger(this.options.scrollOffset) ?? 0 : 0;
+		const viewport =
+			remainingBodyLimit > 0
+				? sliceViewportLines(bodyLines, remainingBodyLimit, scrollOffset, th)
+				: sliceViewportLines(pinnedBodyLines, bodyLimit, scrollOffset, th);
+		this.options.onScrollOffsetResolved?.(viewport.offset);
+		const scrolledBody = remainingBodyLimit > 0 ? [...pinnedBodyLines, ...viewport.lines] : viewport.lines;
 		const framedBody =
 			fixedBodyLines !== undefined && scrolledBody.length < fixedBodyLines
 				? [...scrolledBody, ...Array.from({ length: fixedBodyLines - scrolledBody.length }, () => "")]
@@ -1005,8 +1136,9 @@ function formatToolEventLines(event: MastraToolEvent, theme: Theme, width: numbe
 	const lines = wrapTextWithAnsi(`${prefix} ${theme.fg("dim", detail)}`, width);
 	const output = toolResultText(event.result);
 	if (!output || isShortSummary(detail, output)) return lines;
-	for (const line of output.split("\n").slice(0, 10)) {
-		lines.push(truncateToWidth(theme.fg("dim", `  ⎿ ${line}`), width));
+	const renderedOutput = renderMarkdownLines(markdownTail(output, 3_000), Math.max(1, width - 4));
+	for (const line of renderedOutput.slice(0, 12)) {
+		lines.push(truncateToWidth(`${theme.fg("dim", "  ⎿ ")}${line}`, width));
 	}
 	return lines;
 }
@@ -1160,24 +1292,35 @@ function toolEventIcon(event: MastraToolEvent, theme: Theme): string {
 	return theme.fg("muted", "…");
 }
 
-function toolEventDetail(event: MastraToolEvent): unknown {
-	if (event.type === "error") return event.error;
-	if (event.type === "result") return event.result;
-	return event.args;
-}
-
-function renderMarkdownLines(markdown: string, width: number): string[] {
+function renderMarkdownLines(markdown: string, width: number, defaultTextStyle?: DefaultTextStyle): string[] {
 	try {
-		return new Markdown(markdown, 0, 0, getMarkdownTheme()).render(width);
+		return new Markdown(markdown, 0, 0, getMarkdownTheme(), defaultTextStyle).render(width);
 	} catch {
-		return wrapTextWithAnsi(markdown, width);
+		try {
+			return new Markdown(markdown, 0, 0, FALLBACK_MARKDOWN_THEME, defaultTextStyle).render(width);
+		} catch {
+			return wrapTextWithAnsi(markdown, width);
+		}
 	}
 }
 
-function tailLines(lines: string[], limit: number, theme: Theme): string[] {
-	if (lines.length <= limit) return lines;
-	const kept = Math.max(1, limit - 1);
-	return [theme.fg("dim", `… ${lines.length - kept} earlier lines`), ...lines.slice(-kept)];
+function sliceViewportLines(lines: string[], limit: number, scrollOffset: number, theme: Theme): { lines: string[]; offset: number } {
+	if (limit <= 0) return { lines: [], offset: 0 };
+	if (lines.length <= limit) return { lines, offset: 0 };
+	const maxOffset = Math.max(0, lines.length - limit);
+	const offset = Math.min(Math.max(0, Math.floor(scrollOffset)), maxOffset);
+	const end = Math.max(limit, lines.length - offset);
+	const start = Math.max(0, end - limit);
+	const visible = lines.slice(start, end);
+	const hiddenBefore = start;
+	const hiddenAfter = Math.max(0, lines.length - end);
+	if (hiddenBefore > 0 && visible.length > 0) {
+		visible[0] = theme.fg("dim", `… ${hiddenBefore} earlier lines`);
+	}
+	if (hiddenAfter > 0 && visible.length > 0) {
+		visible[visible.length - 1] = theme.fg("dim", `… ${hiddenAfter} later lines`);
+	}
+	return { lines: visible, offset };
 }
 
 function headLines(lines: string[], limit: number, theme: Theme): string[] {


### PR DESCRIPTION
## Summary
- Adds bounded above-editor Mastra agent widget modes: compact list, shared card region, and single-agent detail region.
- Adds detail-mode scrolling and stream-only controls for focused live agent output.
- Renders primary agent output and expanded tool result bodies through Pi Markdown, while keeping compact list rows as readable summaries.
- Adds configurable theme-color roles for prompt bodies, tool argument/result details, and reasoning text.
- Keeps completed and cancelled jobs out of the visible widget surface so stale cards do not return after later dispatches.

## Rationale
- The widget stays inside the config-driven render region instead of growing the terminal buffer, which avoids the redraw/flicker behavior discovered during issue 15 testing.
- List/card/detail modes share the same lifecycle store but render different views over active work only: working jobs are visible; ended/cancelled jobs collapse.
- Tool names and section labels stay on the normal foreground so the card hierarchy remains stable while stream contents update.
- Prompt bodies and tool details use the configured highlight color because those are the scan targets during live agent work; reasoning is muted because it is supporting context.
- Color config uses Pi theme tokens rather than raw hex so it remains compatible with user themes.

## Constraints / Notes
- Detail scrolling is keyboard-driven; mouse wheel scrolling is not implemented here.
- Reasoning updates render when Mastra emits reasoning stream chunks; the TUI does not synthesize reasoning deltas.
- Compact list mode intentionally remains a summary surface, not a full rich Markdown renderer.
- Shortcut defaults are configurable in `config.yaml` for terminals that reserve or reinterpret control-key sequences.

## Validation
- `npm test --workspace @mastrasystem/pi` passes: 160 tests.
- `npm run typecheck --workspace @mastrasystem/pi` passes.
- `git diff --check` passes.
- Manual Pi verification in the issue 21 worktree covered view cycling, detail scrolling, stream-only mode, bounded render behavior, and the updated color hierarchy.

Closes #21
Refs #15