### PR TITLE
Remap Pi harness agent navigation to Alt+O / Alt+I and document Alt+N for reasoning cycle

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,8 +6,8 @@ mastra-agent-extension:
   reservedRows: 10
   defaultViewMode: list
   viewModeShortcut: alt+h
-  nextAgentShortcut: ctrl+down
-  previousAgentShortcut: ctrl+up
+  nextAgentShortcut: alt+o
+  previousAgentShortcut: alt+i
   detailScrollDownShortcut: alt+j
   detailScrollUpShortcut: alt+k
   detailStreamOnlyShortcut: alt+s

--- a/pi/README.md
+++ b/pi/README.md
@@ -38,8 +38,8 @@ mastra-agent-extension:
   reservedRows: 10
   defaultViewMode: list
   viewModeShortcut: alt+h
-  nextAgentShortcut: ctrl+down
-  previousAgentShortcut: ctrl+up
+  nextAgentShortcut: alt+o
+  previousAgentShortcut: alt+i
   detailScrollDownShortcut: alt+j
   detailScrollUpShortcut: alt+k
   detailStreamOnlyShortcut: alt+s
@@ -51,7 +51,7 @@ mastra-agent-extension:
   debugPiRedraw: true
 ```
 
-Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 18`, `listMaxAgents: 5`, `reservedRows: 10`, and `defaultViewMode: list`. List mode renders a compact above-editor job list with three lines per visible agent and a `+N more` marker when more than `listMaxAgents` jobs are working. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
+Defaults are `maxCards: 4`, `maxLines: 60`, `listMaxLines: 18`, `listMaxAgents: 5`, `reservedRows: 10`, and `defaultViewMode: list`. Pi's default harness reasoning-effort cycle remains on `shift+tab`; you can also bind `alt+n` to `app.thinking.cycle` in your Pi keybindings if desired. List mode renders a compact above-editor job list with three lines per visible agent and a `+N more` marker when more than `listMaxAgents` jobs are working. `viewModeShortcut` cycles list → card region → detail region. The card/detail region also renders above the editor at a fixed height while jobs are visible, bounded by `maxLines` and the current terminal viewport. `nextAgentShortcut` and `previousAgentShortcut` focus running jobs in detail mode.
 
 Detail mode supports keyboard scrolling with `detailScrollDownShortcut` and `detailScrollUpShortcut`, and `detailStreamOnlyShortcut` hides the submitted prompt and reasoning while keeping agent output and tool events visible. Widget hotkeys are installed from the active session `config.yaml`; scroll keys are consumed only when detail mode has visible running jobs. Raw Backspace and Enter-compatible terminal bytes are not consumed for `ctrl+h` or `ctrl+j`; terminals that disambiguate control keys can still use those shortcuts, and other environments can remap them in `config.yaml`.
 

--- a/pi/src/extensions/config.ts
+++ b/pi/src/extensions/config.ts
@@ -15,8 +15,8 @@ export const DEFAULT_MASTRA_AGENT_WIDGET_OPTIONS: Required<Pick<MastraAgentsWidg
 export const DEFAULT_MASTRA_AGENT_VIEW_MODE: MastraAgentsViewMode = "list";
 export const DEFAULT_MASTRA_AGENT_EXTENSION_SHORTCUTS: MastraAgentExtensionShortcuts = {
 	viewMode: "alt+h",
-	nextAgent: "ctrl+down",
-	previousAgent: "ctrl+up",
+	nextAgent: "alt+o",
+	previousAgent: "alt+i",
 	detailScrollDown: "alt+j",
 	detailScrollUp: "alt+k",
 	detailStreamOnly: "alt+s",


### PR DESCRIPTION
### Motivation
- Remap the Mastra Pi widget agent-card navigation shortcuts away from `ctrl+up`/`ctrl+down` to alternate Alt-based bindings favored for the harness TUI.
- Preserve Pi's existing default reasoning-effort cycle on `shift+tab` while giving users a documented alternative binding (`alt+n`) they can enable in Pi keybindings.
- Keep project defaults and documentation consistent so out-of-the-box behavior and examples match the chosen shortcuts.

### Description
- Updated the default shortcut constants in `pi/src/extensions/config.ts` to use `nextAgent: "alt+o"` and `previousAgent: "alt+i"` instead of `ctrl+down`/`ctrl+up`.
- Updated the repository default runtime config in `config.yaml` to set `nextAgentShortcut: alt+o` and `previousAgentShortcut: alt+i`.
- Updated `pi/README.md` to reflect the new defaults and added a short note that Pi still uses `shift+tab` for the harness reasoning-effort cycle and that users can bind `alt+n` to `app.thinking.cycle` in their Pi keybindings if desired.

### Testing
- Ran the package build with `npm run build --workspace @mastrasystem/pi`, which produced `dist/` artifacts and succeeded.
- Attempted to run the package test command (`npm test --workspace @mastrasystem/pi`), which failed because the test runner expects compiled test files matching `dist/**/*.test.js` that are not present in this environment.
- Attempted to run compiled test files directly (`node --test dist/src/extensions/config.test.js dist/src/extensions/index.test.js`), which failed because the specific compiled test files were not found in `dist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40fc7c998832abefe44c9795fbcd9)