### PR TITLE
feat(agents): add DeepWiki MCP integration

### DIFF
--- a/mastra-agents/package.json
+++ b/mastra-agents/package.json
@@ -17,12 +17,13 @@
     "@daytona/sdk": "0.169.0",
     "@mastra/core": "1.28.0",
     "@mastra/daytona": "0.3.0",
-    "@mastra/editor": "0.7.19",
-    "@mastra/memory": "1.17.1",
-    "@mastra/pg": "1.9.2",
     "@mastra/duckdb": "1.2.0",
+    "@mastra/editor": "0.7.19",
     "@mastra/evals": "1.2.1",
+    "@mastra/mcp": "^1.6.0",
+    "@mastra/memory": "1.17.1",
     "@mastra/observability": "1.10.0",
+    "@mastra/pg": "1.9.2",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/mastra-agents/src/agents/advisor-agent.ts
+++ b/mastra-agents/src/agents/advisor-agent.ts
@@ -10,6 +10,11 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultAgentModel, withAgentModes } from "./shared.js";
+import { deepWikiMCP } from "../mcp/index.js";
+
+// Initialize DeepWiki tools for advisor agent
+// DeepWiki helps advisor with repo analysis, integration research, architecture reviews
+const deepWikiTools = await deepWikiMCP.listTools();
 
 export const advisorAgent = withAgentModes(new Agent({
   id: "advisor-agent",
@@ -25,4 +30,5 @@ export const advisorAgent = withAgentModes(new Agent({
   model: defaultAgentModel,
   memory: createAgentMemory(),
   defaultOptions: agentDefaultOptions.advisor,
+  tools: deepWikiTools,
 }), agentModesFromPrompts(advisorModePrompts));

--- a/mastra-agents/src/agents/developer-agent.ts
+++ b/mastra-agents/src/agents/developer-agent.ts
@@ -10,6 +10,11 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultAgentModel, withAgentModes } from "./shared.js";
+import { deepWikiMCP } from "../mcp/index.js";
+
+// Initialize DeepWiki tools for developer agent
+// DeepWiki helps developer with understanding external codebases, fork planning, integration
+const deepWikiTools = await deepWikiMCP.listTools();
 
 export const developerAgent = withAgentModes(new Agent({
   id: "developer-agent",
@@ -25,4 +30,5 @@ export const developerAgent = withAgentModes(new Agent({
   model: defaultAgentModel,
   memory: createAgentMemory(),
   defaultOptions: agentDefaultOptions.developer,
+  tools: deepWikiTools,
 }), agentModesFromPrompts(developerModePrompts));

--- a/mastra-agents/src/agents/researcher-agent.ts
+++ b/mastra-agents/src/agents/researcher-agent.ts
@@ -10,6 +10,11 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultAgentModel, withAgentModes } from "./shared.js";
+import { deepWikiMCP } from "../mcp/index.js";
+
+// Initialize DeepWiki tools for researcher agent
+// DeepWiki is primary for researcher - used for repo analysis, research, benchmarking
+const deepWikiTools = await deepWikiMCP.listTools();
 
 export const researcherAgent = withAgentModes(new Agent({
   id: "researcher-agent",
@@ -25,4 +30,5 @@ export const researcherAgent = withAgentModes(new Agent({
   model: defaultAgentModel,
   memory: createAgentMemory(),
   defaultOptions: agentDefaultOptions.researcher,
+  tools: deepWikiTools,
 }), agentModesFromPrompts(researcherModePrompts));

--- a/mastra-agents/src/mcp/index.ts
+++ b/mastra-agents/src/mcp/index.ts
@@ -1,0 +1,60 @@
+/**
+ * MCP Client Configuration
+ * 
+ * Configures remote MCP servers (like DeepWiki) that agents can use.
+ * Tools from these servers are made available to specific agents based on their roles.
+ */
+
+import { MCPClient } from "@mastra/mcp";
+
+/**
+ * DeepWiki MCP Client
+ * 
+ * Provides semantic understanding of external GitHub repositories for:
+ * - Fork analysis and planning
+ * - Plugin integration research
+ * - Code review benchmarking
+ * - Product and market analysis
+ * - Feature engineering
+ * - Reverse engineering
+ */
+export const deepWikiMCP = new MCPClient({
+  id: "deepwiki-mcp-client",
+  servers: {
+    deepwiki: {
+      url: new URL(process.env.DEEPWIKI_MCP_URL ?? "https://mcp.deepwiki.com/mcp"),
+      // DeepWiki may require API key for authenticated requests
+      ...(process.env.DEEPWIKI_API_KEY && {
+        requestInit: {
+          headers: {
+            Authorization: `Bearer ${process.env.DEEPWIKI_API_KEY}`,
+          },
+        },
+      }),
+    },
+  },
+  timeout: 60000, // 60 second timeout for DeepWiki queries
+});
+
+/**
+ * Get DeepWiki tools for agent use
+ * 
+ * Tools are namespaced as "deepwiki_<toolName>" to prevent conflicts.
+ * 
+ * Available tools:
+ * - deepwiki_read_wiki_structure: Get repository structure/topics
+ * - deepwiki_read_wiki_contents: Read specific topic contents
+ * - deepwiki_ask_question: Ask questions about the codebase
+ */
+export async function getDeepWikiTools() {
+  return deepWikiMCP.listTools();
+}
+
+/**
+ * Get DeepWiki toolsets for dynamic tool loading
+ * 
+ * Use this when tools should be loaded dynamically per request.
+ */
+export async function getDeepWikiToolsets() {
+  return deepWikiMCP.listToolsets();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@mastra/duckdb": "1.2.0",
         "@mastra/editor": "0.7.19",
         "@mastra/evals": "1.2.1",
+        "@mastra/mcp": "^1.6.0",
         "@mastra/memory": "1.17.1",
         "@mastra/observability": "1.10.0",
         "@mastra/pg": "1.9.2",
@@ -3206,6 +3207,24 @@
       },
       "peerDependencies": {
         "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+      }
+    },
+    "node_modules/@mastra/mcp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@mastra/mcp/-/mcp-1.6.0.tgz",
+      "integrity": "sha512-o63itm5R5nD8Q574Sj5EbG8TjIhczGrZT4N3ZxVA8W42CLUc+2ZH+Xmj2ElaLx30HCN1gIiNkjuqlfxuq2zA+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "exit-hook": "^5.1.0",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@mastra/memory": {
@@ -8063,6 +8082,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-5.1.0.tgz",
+      "integrity": "sha512-INjr2xyxHo7bhAqf5ong++GZPPnpcuBcaXUKt03yf7Fie9yWD7FapL4teOU0+awQazGs5ucBh7xWs/AD+6nhog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/expand-tilde": {


### PR DESCRIPTION
## Summary

Add DeepWiki MCP server integration for researcher, advisor, and developer agents.

## Changes

### New Files
- `mastra-agents/src/mcp/index.ts` - MCP client configuration for DeepWiki

### Modified Files
- `mastra-agents/package.json` - Added @mastra/mcp dependency
- `mastra-agents/src/agents/researcher-agent.ts` - Added DeepWiki tools
- `mastra-agents/src/agents/advisor-agent.ts` - Added DeepWiki tools
- `mastra-agents/src/agents/developer-agent.ts` - Added DeepWiki tools

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| DEEPWIKI_MCP_URL | https://mcp.deepwiki.com/mcp | DeepWiki server URL |
| DEEPWIKI_API_KEY | - | Optional API key for authenticated requests |

## Available Tools

Agents now have access to:
- `deepwiki_read_wiki_structure` - Get repository structure/topics
- `deepwiki_read_wiki_contents` - Read specific topic contents
- `deepwiki_ask_question` - Ask questions about codebases

## Usage

DeepWiki MCP tools support:
- Fork analysis and planning
- Plugin integration research
- Code review benchmarking
- Product and market analysis
- Feature engineering
- Reverse engineering

## Testing

TypeScript compilation verified with `tsc --noEmit`
