### PR TITLE
Add ACP adapter and event mapper with tests

### DIFF
--- a/mastra-agents/src/acp/adapter.js
+++ b/mastra-agents/src/acp/adapter.js
@@ -1,0 +1,54 @@
+import { mapMastraEventToSessionUpdates } from './event-mapper.js';
+
+export class MastraAcpAdapter {
+  sessions = new Map();
+
+  newSession(sessionId) {
+    const session = { sessionId, activePromptId: undefined, abortController: undefined };
+    this.sessions.set(sessionId, session);
+    return session;
+  }
+
+  getSession(sessionId) {
+    return this.sessions.get(sessionId) ?? this.newSession(sessionId);
+  }
+
+  cancel(sessionId) {
+    const session = this.sessions.get(sessionId);
+    if (!session?.abortController || session.abortController.signal.aborted) return { cancelled: false };
+    session.abortController.abort();
+    return { cancelled: true };
+  }
+
+  async prompt(sessionId, streamFactory) {
+    const session = this.getSession(sessionId);
+    const abortController = new AbortController();
+    const promptId = Symbol('prompt');
+
+    session.abortController = abortController;
+    session.activePromptId = promptId;
+
+    const updates = [];
+
+    try {
+      const stream = await streamFactory(abortController.signal);
+      for await (const event of stream) {
+        updates.push(...mapMastraEventToSessionUpdates(event));
+      }
+      return { stopReason: abortController.signal.aborted ? 'cancelled' : 'end_turn', updates };
+    } catch (error) {
+      if (abortController.signal.aborted) return { stopReason: 'cancelled', updates };
+      updates.push({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: `Stream error: ${error?.message ?? 'unknown error'}` },
+      });
+      return { stopReason: 'end_turn', updates, error: 'stream_failed' };
+    } finally {
+      const current = this.sessions.get(sessionId);
+      if (current?.activePromptId === promptId) {
+        current.abortController = undefined;
+        current.activePromptId = undefined;
+      }
+    }
+  }
+}

--- a/mastra-agents/src/acp/event-mapper.js
+++ b/mastra-agents/src/acp/event-mapper.js
@@ -1,0 +1,68 @@
+function getUsageFromEvent(event) {
+  if (event?.usage && typeof event.usage === 'object') return event.usage;
+
+  const usage = {
+    inputTokens: event?.inputTokens,
+    outputTokens: event?.outputTokens,
+    thoughtTokens: event?.thoughtTokens,
+    totalTokens: event?.totalTokens,
+  };
+
+  return Object.values(usage).some(value => typeof value === 'number') ? usage : undefined;
+}
+
+function getToolStatus(event) {
+  if (event?.status) return event.status;
+  switch (event?.type) {
+    case 'tool-error':
+      return 'failed';
+    case 'tool-result':
+      return 'completed';
+    default:
+      return 'in_progress';
+  }
+}
+
+export function mapMastraEventToSessionUpdates(event) {
+  if (!event || typeof event !== 'object' || typeof event.type !== 'string') return [];
+
+  if (event.type === 'text-delta' && event.text) {
+    return [{ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: event.text } }];
+  }
+
+  if (event.type === 'reasoning-delta' && event.text) {
+    return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: event.text } }];
+  }
+
+  if (event.type === 'usage' || event.type === 'finish') {
+    const usage = getUsageFromEvent(event);
+    if (usage) return [{ sessionUpdate: 'usage_update', usage }];
+  }
+
+  if (event.type.startsWith('tool-')) {
+    return [{
+      sessionUpdate: 'tool_call_update',
+      toolCallId: event.toolCallId,
+      status: getToolStatus(event),
+      content: {
+        type: 'tool_call',
+        toolCallId: event.toolCallId,
+        name: event.name,
+        kind: event.kind,
+        args: event.args,
+        result: event.result,
+        error: event.error,
+      },
+      toolCall: {
+        id: event.toolCallId,
+        name: event.name,
+        kind: event.kind,
+        input: event.args,
+        output: event.result,
+        error: event.error,
+      },
+    }];
+  }
+
+  return [];
+}

--- a/mastra-agents/src/acp/index.js
+++ b/mastra-agents/src/acp/index.js
@@ -1,0 +1,2 @@
+export * from './adapter.js';
+export * from './event-mapper.js';

--- a/mastra-agents/src/index.ts
+++ b/mastra-agents/src/index.ts
@@ -14,3 +14,4 @@ export * from './scorers/index.js';
 export * from './daytona/index.js';
 export { mastra } from './mastra/index.js';
 export { workspace, workspaceAccessRoots, workspaceCommandCwd, workspaceRoot } from './workspace.js';
+export * from './acp/index.js';

--- a/mastra-agents/test/acp/adapter.test.js
+++ b/mastra-agents/test/acp/adapter.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MastraAcpAdapter } from '../../src/acp/adapter.js';
+import { mapMastraEventToSessionUpdates } from '../../src/acp/event-mapper.js';
+
+test('cancel returns cancelled true when prompt aborted', async () => {
+  const adapter = new MastraAcpAdapter();
+  const p = adapter.prompt('s1', async function* (signal) {
+    yield { type: 'text-delta', text: 'hi' };
+    await new Promise(r => setTimeout(r, 50));
+    if (signal.aborted) throw new Error('aborted');
+    yield { type: 'text-delta', text: 'after' };
+  });
+  await new Promise(r => setTimeout(r, 10));
+  assert.deepEqual(adapter.cancel('s1'), { cancelled: true });
+  const res = await p;
+  assert.equal(res.stopReason, 'cancelled');
+});
+
+test('cancel returns cancelled false without active prompt', () => {
+  const adapter = new MastraAcpAdapter();
+  adapter.newSession('s0');
+  assert.deepEqual(adapter.cancel('s0'), { cancelled: false });
+});
+
+test('prompt handles stream failure without throwing', async () => {
+  const adapter = new MastraAcpAdapter();
+  const res = await adapter.prompt('s2', async function* () {
+    throw new Error('network down');
+  });
+  assert.equal(res.error, 'stream_failed');
+  assert.equal(res.stopReason, 'end_turn');
+  assert.match(res.updates.at(-1).content.text, /network down/);
+});
+
+test('finish usage maps from token fields', () => {
+  const updates = mapMastraEventToSessionUpdates({ type: 'finish', inputTokens: 1, outputTokens: 2, totalTokens: 3 });
+  assert.equal(updates[0].sessionUpdate, 'usage_update');
+  assert.equal(updates[0].usage.outputTokens, 2);
+});
+
+test('tool call update keeps structured content', () => {
+  const updates = mapMastraEventToSessionUpdates({ type: 'tool-result', toolCallId: 'tc1', name: 'workspace.read-file', args: { path: 'a' }, result: 'ok' });
+  assert.equal(updates[0].sessionUpdate, 'tool_call_update');
+  assert.equal(updates[0].toolCall.id, 'tc1');
+  assert.deepEqual(updates[0].toolCall.input, { path: 'a' });
+  assert.deepEqual(updates[0].content.args, { path: 'a' });
+});
+
+test('invalid events are ignored', () => {
+  assert.deepEqual(mapMastraEventToSessionUpdates(null), []);
+  assert.deepEqual(mapMastraEventToSessionUpdates({}), []);
+});


### PR DESCRIPTION
### Motivation
- Introduce a lightweight ACP (agent control protocol) adapter to manage agent sessions, streaming prompts, and cancellation handling. 
- Provide an event-to-session-update mapper so Mastra events can be translated into the unified session update shapes used by the rest of the system. 

### Description
- Add `MastraAcpAdapter` in `src/acp/adapter.js` which manages sessions, tracks active prompts, supports `prompt(sessionId, streamFactory)` with streaming event consumption, and `cancel(sessionId)` to abort an in-flight prompt. 
- Add `mapMastraEventToSessionUpdates` in `src/acp/event-mapper.js` to convert Mastra event shapes (text deltas, reasoning deltas, tool events, and usage/finish events) into session update objects. 
- Re-export the new ACP modules via `src/acp/index.js` and add a top-level export in `src/index.ts` with `export * from './acp/index.js';`. 
- Add unit tests in `test/acp/adapter.test.js` covering cancellation behavior, stream failures, usage mapping from token fields, tool-call mapping, and ignoring invalid events. 

### Testing
- Ran the new unit tests in `test/acp/adapter.test.js` which include `cancel returns cancelled true when prompt aborted`, `cancel returns cancelled false without active prompt`, `prompt handles stream failure without throwing`, `finish usage maps from token fields`, `tool call update keeps structured content`, and `invalid events are ignored`. 
- All tests in `test/acp/adapter.test.js` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62e31e234832a9bbd409ef87bb1e7)