### PR TITLE
Implement Linear channel integration for Mastra supervisor agent

### DIFF
--- a/mastra-agents/package.json
+++ b/mastra-agents/package.json
@@ -24,7 +24,8 @@
     "@mastra/memory": "1.17.1",
     "@mastra/observability": "1.10.0",
     "@mastra/pg": "1.9.2",
-    "zod": "3.25.76"
+    "zod": "3.25.76",
+    "@chat-adapter/linear": "^4.27.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/mastra-agents/src/agents/agent.ts
+++ b/mastra-agents/src/agents/agent.ts
@@ -1,3 +1,4 @@
+import { createLinearAdapter } from "@chat-adapter/linear";
 import { Agent } from "@mastra/core/agent";
 
 import {
@@ -18,6 +19,27 @@ import { scoutAgent } from "./scout-agent.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultSupervisorModel, withAgentModes } from "./shared.js";
 import { validatorAgent } from "./validator-agent.js";
 
+function createLinearChannelsConfig() {
+  const linearWebhookSecret = process.env.LINEAR_WEBHOOK_SECRET;
+  const linearAuthConfigured = Boolean(
+    process.env.LINEAR_API_KEY ||
+      process.env.LINEAR_ACCESS_TOKEN ||
+      (process.env.LINEAR_CLIENT_ID && process.env.LINEAR_CLIENT_SECRET),
+  );
+
+  if (!linearWebhookSecret || !linearAuthConfigured) {
+    return undefined;
+  }
+
+  return {
+    adapters: {
+      linear: createLinearAdapter({
+        mode: process.env.LINEAR_CHANNEL_MODE === "agent-sessions" ? "agent-sessions" : "comments",
+      }),
+    },
+  };
+}
+
 export const supervisorAgent = withAgentModes(new Agent({
   id: "supervisor-agent",
   name: "Supervisor Lead",
@@ -33,6 +55,7 @@ export const supervisorAgent = withAgentModes(new Agent({
   model: defaultSupervisorModel,
   memory: createAgentMemory(),
   defaultOptions: agentDefaultOptions.supervisor,
+  channels: createLinearChannelsConfig(),
   agents: {
     scoutAgent,
     researcherAgent,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "name": "@mastrasystem/agents",
       "version": "0.1.0",
       "dependencies": {
+        "@chat-adapter/linear": "^4.27.0",
         "@daytona/sdk": "0.169.0",
         "@mastra/core": "1.28.0",
         "@mastra/daytona": "0.3.0",
@@ -1754,6 +1755,26 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@chat-adapter/linear": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@chat-adapter/linear/-/linear-4.27.0.tgz",
+      "integrity": "sha512-B3zcdPw7L20EylAE58wAJAmKUyBQp+RWE3yPDyEHLPudwOjL8C59ay2djBfQ0Zknxd9S7lSJtVguz7TO6/QEkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chat-adapter/shared": "4.27.0",
+        "@linear/sdk": "^76.0.0",
+        "chat": "4.27.0"
+      }
+    },
+    "node_modules/@chat-adapter/shared": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@chat-adapter/shared/-/shared-4.27.0.tgz",
+      "integrity": "sha512-Wz+YZ8Mp2/qcxxJ+rU0ofZQSEtOF/4toEh7wbA+q+uLlPrLue+7hImWluJpQUZqGjSwsUoXhjSNwgFv3hz20aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chat": "4.27.0"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
@@ -2550,6 +2571,15 @@
         }
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
@@ -2714,6 +2744,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@linear/sdk": {
+      "version": "76.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-76.0.0.tgz",
+      "integrity": "sha512-Xt0x5Kl6qBoWhGFypb8ykyP+c5kT7scmRPs1uJidSPOaRgkMJ/4y41QpmZCWCBUMmZtf/O0VktgQio6rLXT94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -6957,9 +6999,9 @@
       }
     },
     "node_modules/chat": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/chat/-/chat-4.26.0.tgz",
-      "integrity": "sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/chat/-/chat-4.27.0.tgz",
+      "integrity": "sha512-PrL4k263DSIlckhX8eHLT84RdTSznOBxCCfaDc5JVJtWaS0lJkCNctm/g3gIrI41AcDHcpc/3WDoUHVrbh0W4w==",
       "license": "MIT",
       "dependencies": {
         "@workflow/serde": "4.1.0-beta.2",
@@ -9109,6 +9151,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/gray-matter": {


### PR DESCRIPTION
### Motivation
- Enable the Mastra `supervisorAgent` to operate via Linear using the Mastra Channels/Chat SDK adapter so the agent can receive and respond to Linear events.
- Provide a guarded runtime configuration to avoid enabling Linear webhooks unless secrets and auth are explicitly present.
- Allow choosing Linear handling mode (`comments` vs `agent-sessions`) to support different integration patterns.

### Description
- Imported `createLinearAdapter` from `@chat-adapter/linear` and added `@chat-adapter/linear` to `mastra-agents` dependencies and the lockfile.
- Added `createLinearChannelsConfig()` which checks `LINEAR_WEBHOOK_SECRET` and one of the auth paths (`LINEAR_API_KEY`, `LINEAR_ACCESS_TOKEN`, or `LINEAR_CLIENT_ID` + `LINEAR_CLIENT_SECRET`) and returns `undefined` when not configured.
- Wired channels into the supervisor agent via `channels: createLinearChannelsConfig()` and selected the adapter `mode` from `LINEAR_CHANNEL_MODE` (defaults to `comments`, supports `agent-sessions`).
- Updated package metadata/lockfile to include the Linear adapter and related transitive packages.

### Testing
- Ran `npm view @chat-adapter/linear versions --json` to verify available adapter versions, which succeeded.
- Ran `npm install --package-lock-only --workspace mastra-agents` and `npm install --workspace mastra-agents` to update workspace dependencies, which completed.
- Ran workspace tests with `npm run -w mastra-agents test`, which failed due to the test runner glob not resolving in this environment and not because of the adapter change.
- Ran targeted tests with `node --test mastra-agents/test/prompts.test.js`, which produced failures unrelated to the Linear wiring (external MCP `deepwiki` connectivity errors and some pre-existing prompt expectation assertion failures); several subtests (prompt layout and workspace snapshot tool tests) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68b8916e0832a9650a2b60697c941)