### PR TITLE
RT88-70: Add delegation observability events and document workspace ownership

### DIFF
--- a/docs/rt88-70-delegation-observability.md
+++ b/docs/rt88-70-delegation-observability.md
@@ -1,0 +1,19 @@
+# RT88-70: Delegation observability and workspace ownership notes
+
+## Workspace ownership
+
+Current agent definitions do not assign explicit per-agent workspace instances. Workspace access remains centralized via shared workspace tools exposed by orchestration agents (`orchestrator` and `supervisor`) and inherited by specialist delegation context.
+
+## Delegation visibility in ACP
+
+Delegation lifecycle events are emitted from harness streaming and mapped into ACP updates:
+
+- `delegation_start` -> `delegation-event` (status: `started`)
+- `delegation_complete` -> `delegation-event` (status: `completed` or `failed`)
+
+The emitted payload includes delegated target, delegated prompt, response/error, run/thread/resource correlation fields, and duration.
+
+## Default tool stream events vs hook-style delegation events
+
+- Existing generic tool stream events (`tool-call`, `tool-result`, `tool-error`) are still emitted unchanged.
+- New explicit `delegation-event` chunks supplement tool events so ACP can render delegation activity as first-class observable updates.

--- a/mastra-agents/src/acp/event-mapper.js
+++ b/mastra-agents/src/acp/event-mapper.js
@@ -21,6 +21,24 @@ export function mapMastraChunkToUpdates(chunk) {
         return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: textFrom(chunk) }, _meta: { mastra: { reasoning: chunk } } }];
     if (type === 'finish')
         return chunk.usage ? [{ sessionUpdate: 'usage_update', used: num(chunk.usage, 'totalTokens') ?? 0, size: num(chunk.usage, 'totalTokens') ?? 0 }] : [];
+    if (type === 'delegation-event') {
+        const p = isRecord(chunk.payload) ? chunk.payload : chunk;
+        const status = str(p.status) === 'failed' ? 'failed' : str(p.status) === 'completed' ? 'completed' : 'in_progress';
+        const delegatedName = str(p.delegatedAgentName) ?? str(p.delegatedAgentId) ?? 'subagent';
+        const prompt = str(p.prompt) ?? '';
+        const response = str(p.response) ?? '';
+        return [{
+                sessionUpdate: 'tool_call_update',
+                toolCallId: str(p.delegationId) ?? `delegation:${delegatedName}`,
+                status,
+                title: `delegate:${delegatedName}`,
+                kind: 'other',
+                rawInput: prompt,
+                rawOutput: p.error ?? response,
+                content: [{ type: 'content', content: { type: 'text', text: JSON.stringify({ delegatedAgent: delegatedName, prompt, response, durationMs: p.durationMs, error: p.error }) } }],
+                _meta: { mastra: chunk },
+            }];
+    }
     if (type?.startsWith('tool-')) {
         const p = isRecord(chunk.payload) ? chunk.payload : chunk;
         const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : (type === 'tool-call-input-streaming-start' ? 'in_progress' : 'pending');

--- a/mastra-agents/src/workflows/async-agent-job.ts
+++ b/mastra-agents/src/workflows/async-agent-job.ts
@@ -510,6 +510,18 @@ async function streamHarnessMessage({
       return;
     }
 
+    if (event.type === "delegation_start") {
+      emitChunk(toDelegationChunk(event as Record<string, unknown>, "started"));
+      return;
+    }
+
+    if (event.type === "delegation_complete") {
+      const delegationEvent = event as Record<string, unknown>;
+      const status = delegationEvent.error ? "failed" : "completed";
+      emitChunk(toDelegationChunk(delegationEvent, status));
+      return;
+    }
+
     if (event.type === "error") {
       emitChunk({
         type: "error",
@@ -572,6 +584,45 @@ async function streamHarnessMessage({
     abortSignal?.removeEventListener("abort", onAbort);
     unsubscribe();
   }
+}
+
+
+
+type DelegationStatus = "started" | "completed" | "failed";
+
+function toDelegationChunk(event: Record<string, unknown>, status: DelegationStatus) {
+  const startedAt = asNumber(event.startedAt) ?? Date.now();
+  const endedAt = asNumber(event.completedAt) ?? asNumber(event.endedAt) ?? (status === "started" ? undefined : Date.now());
+  const durationMs = endedAt !== undefined ? Math.max(0, endedAt - startedAt) : undefined;
+
+  return {
+    type: "delegation-event",
+    payload: {
+      status,
+      delegationId: asString(event.delegationId) ?? asString(event.toolCallId),
+      delegatedAgentId: asString(event.agentId) ?? asString(event.delegateAgentId),
+      delegatedAgentName: asString(event.agentName) ?? asString(event.delegateAgentName),
+      prompt: asString(event.prompt) ?? asString(event.query) ?? asString(event.input),
+      response: asString(event.response) ?? asString(event.resultText),
+      success: status === "completed",
+      error: status === "failed" ? (event.error ?? event.result) : undefined,
+      runId: asString(event.runId),
+      threadId: asString(event.threadId),
+      resourceId: asString(event.resourceId),
+      startedAt,
+      endedAt,
+      durationMs,
+      raw: event,
+    },
+  };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function requestContextFromRecord(


### PR DESCRIPTION
### Motivation
- Ensure orchestration-layer delegation is observable so delegated subagent prompts and results are inspectable in ACP session streams.
- Surface delegation lifecycle explicitly (start/complete/failed) in the streaming pipeline while preserving existing generic `tool-*` events.
- Centralize workspace ownership on orchestration agents so specialist agents inherit workspace context and do not override orchestration-level workspace behavior.

### Description
- Emit explicit `delegation-event` chunks from the harness streaming pipeline by handling `delegation_start` and `delegation_complete` events and converting them with `toDelegationChunk` in `mastra-agents/src/workflows/async-agent-job.ts` (includes new helpers `toDelegationChunk`, `asString`, and `asNumber`).
- Map `delegation-event` to a first-class `tool_call_update` in `mastra-agents/src/acp/event-mapper.js` so ACP renders delegated activity with delegated agent identity, prompt, response/error, timing, and correlation fields.
- Add documentation `docs/rt88-70-delegation-observability.md` describing current workspace ownership behavior and the distinction between default tool stream events and the new explicit delegation events.

### Testing
- `npm run build` in `mastra-agents` completed successfully; the build logged PostHog telemetry network errors in this environment but completed the bundling step.
- `npm test` in `mastra-agents` failed because the package contains no test files matching `test/**/*.test.js` (no runtime failures in modified code reported by the build).
- Basic smoke validation: updated files compile as part of the project build and the new `delegation-event` mapping is present in `acp/event-mapper.js` for runtime streaming consumption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e8f82990832a9175e09c6211239f)