### PR TITLE
RT88-70: tighten delegation observability IDs and payload handling

### DIFF
--- a/docs/rt88-70-orchestration-audit.md
+++ b/docs/rt88-70-orchestration-audit.md
@@ -1,0 +1,17 @@
+# RT88-70 orchestration-layer hook and routing audit
+
+## Current layering validation
+
+- Connector channels are attached to `orchestratorAgent` (`orchestratorAgent.channels = createSupervisorChannelsConfig()`), making orchestrator the runtime ingress layer for connector entrypoints.
+- `supervisorAgent` remains defined as a secondary orchestration profile and is still available through the harness mode registry.
+- Both `orchestratorAgent` and `supervisorAgent` are configured with specialist subagents (`scout`, `researcher`, `architect`, `advisor`, `developer`, `validator`), so either orchestration layer can delegate.
+
+## Delegation observability implications
+
+- Delegation observability is implemented in the shared async job streaming pipeline (`streamHarnessMessage`) by emitting `delegation-event` chunks from delegation lifecycle events.
+- Because both orchestration layers run through the same harness/event stream path, no additional per-agent wiring is required for delegation event emission.
+- ACP maps `delegation-event` into `tool_call_update`, and now uses a uniqueness-preserving fallback ID derived from phase + correlation fields + timestamp.
+
+## Remaining gap
+
+- If future runtime changes bypass the shared harness stream path for one orchestrator profile, explicit hook registration at that profile should be reintroduced and covered with a focused integration test.

--- a/mastra-agents/src/acp/delegation-observability.spec.js
+++ b/mastra-agents/src/acp/delegation-observability.spec.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mapMastraChunkToUpdates } from './event-mapper.js';
+import { delegationPayloadFromEvent } from '../workflows/delegation-event.js';
+
+test('delegation payload preserves structured prompt/response/error fields', () => {
+  const payload = delegationPayloadFromEvent({
+    type: 'delegation_complete',
+    payload: {
+      delegatedName: 'Scout',
+      delegatedAgentId: 'scout-agent',
+      prompt: { objective: 'inspect', files: ['a.ts'] },
+      response: { findings: ['ok'] },
+      error: { code: 'E_TIMEOUT' },
+      success: false,
+    },
+  });
+  assert.deepEqual(payload.prompt, { objective: 'inspect', files: ['a.ts'] });
+  assert.deepEqual(payload.response, { findings: ['ok'] });
+  assert.deepEqual(payload.error, { code: 'E_TIMEOUT' });
+});
+
+test('delegation event mapper fallback IDs remain unique', () => {
+  const one = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: '1' } })[0];
+  const two = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: '2' } })[0];
+  assert.notEqual(one.toolCallId, two.toolCallId);
+});

--- a/mastra-agents/src/acp/event-mapper.js
+++ b/mastra-agents/src/acp/event-mapper.js
@@ -21,6 +21,41 @@ export function mapMastraChunkToUpdates(chunk) {
         return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: textFrom(chunk) }, _meta: { mastra: { reasoning: chunk } } }];
     if (type === 'finish')
         return chunk.usage ? [{ sessionUpdate: 'usage_update', used: num(chunk.usage, 'totalTokens') ?? 0, size: num(chunk.usage, 'totalTokens') ?? 0 }] : [];
+
+    if (type === "delegation-event") {
+        const payload = isRecord(chunk.payload) ? chunk.payload : {};
+        const fallbackIdParts = [
+            str(payload.delegationId),
+            str(payload.runId),
+            str(payload.agentRunId),
+            str(payload.threadId),
+            str(payload.timestamp),
+            str(payload.phase),
+            str(payload.delegatedAgentId) ?? str(payload.delegatedName),
+        ].filter(Boolean);
+        const fallbackId = fallbackIdParts.length > 0 ? `delegation:${fallbackIdParts.join(":")}` : `delegation:${Date.now()}`;
+        const phase = str(payload.phase) ?? "delegation";
+        const status = phase === "delegation_complete" ? (payload.success === false ? "failed" : "completed") : "in_progress";
+        const summary = {
+            target: payload.delegatedAgentId ?? payload.delegatedName,
+            prompt: payload.prompt,
+            response: payload.response,
+            error: payload.error,
+            success: payload.success,
+            durationMs: payload.durationMs,
+        };
+        return [{
+            sessionUpdate: "tool_call_update",
+            toolCallId: str(payload.delegationId) ?? fallbackId,
+            status,
+            title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? "delegation",
+            kind: "other",
+            rawInput: payload.prompt,
+            rawOutput: payload.response ?? payload.error,
+            content: [{ type: "content", content: { type: "text", text: JSON.stringify(summary) } }],
+            _meta: { mastra: chunk },
+        }];
+    }
     if (type?.startsWith('tool-')) {
         const p = isRecord(chunk.payload) ? chunk.payload : chunk;
         const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : (type === 'tool-call-input-streaming-start' ? 'in_progress' : 'pending');

--- a/mastra-agents/src/workflows/async-agent-job.ts
+++ b/mastra-agents/src/workflows/async-agent-job.ts
@@ -23,6 +23,7 @@ import {
 import { captureTurnSnapshot, initializeSessionSnapshot, type SnapshotCapture } from "../tools/snapshots.js";
 import { resolveWorkspacePath } from "../workspace.js";
 import { setSessionId } from "../session.js";
+import { delegationPayloadFromEvent } from "./delegation-event.js";
 
 const inputArgsSchema = z.record(z.string()).optional();
 const modePromptTrackerStore = new PostgresStore({
@@ -510,6 +511,14 @@ async function streamHarnessMessage({
       return;
     }
 
+    if (event.type === "delegation_start" || event.type === "delegation_complete") {
+      emitChunk({
+        type: "delegation-event",
+        payload: delegationPayloadFromEvent(event),
+      });
+      return;
+    }
+
     if (event.type === "error") {
       emitChunk({
         type: "error",
@@ -630,3 +639,4 @@ function safePathPart(value: string): string {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+

--- a/mastra-agents/src/workflows/delegation-event.js
+++ b/mastra-agents/src/workflows/delegation-event.js
@@ -1,0 +1,32 @@
+export function delegationPayloadFromEvent(event) {
+  const payload = isRecord(event?.payload) ? event.payload : event;
+  const phase = typeof event?.type === 'string' ? event.type : 'delegation';
+  return {
+    phase,
+    delegationId: stringFromUnknown(payload.delegationId) ?? stringFromUnknown(payload.id),
+    delegatedName: stringFromUnknown(payload.delegatedName) ?? stringFromUnknown(payload.agentName) ?? stringFromUnknown(payload.targetAgentName),
+    delegatedAgentId: stringFromUnknown(payload.delegatedAgentId) ?? stringFromUnknown(payload.agentId) ?? stringFromUnknown(payload.targetAgentId),
+    prompt: structuredFromUnknown(payload.prompt ?? payload.query ?? payload.input),
+    response: structuredFromUnknown(payload.response ?? payload.result ?? payload.output),
+    error: structuredFromUnknown(payload.error),
+    success: booleanFromUnknown(payload.success),
+    durationMs: numberFromUnknown(payload.durationMs ?? payload.duration),
+    runId: stringFromUnknown(payload.runId),
+    agentRunId: stringFromUnknown(payload.agentRunId),
+    threadId: stringFromUnknown(payload.threadId),
+    resourceId: stringFromUnknown(payload.resourceId),
+    timestamp: Date.now(),
+    raw: payload,
+  };
+}
+
+function structuredFromUnknown(value) {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (value instanceof Error) return { name: value.name, message: value.message, stack: value.stack };
+  try { JSON.stringify(value); return value; } catch { return String(value); }
+}
+const stringFromUnknown = (v) => (typeof v === 'string' && v.length > 0 ? v : undefined);
+const numberFromUnknown = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+const booleanFromUnknown = (v) => (typeof v === 'boolean' ? v : undefined);
+const isRecord = (v) => typeof v === 'object' && !!v && !Array.isArray(v);


### PR DESCRIPTION
### Motivation
- Improve delegation observability so orchestrator/supervisor delegations appear as distinct ACP/session events and do not collapse when repeatedly delegating to the same subagent. 
- Preserve structured delegation payloads (prompt/response/error) when they are objects rather than plain strings so no useful detail is dropped from streaming telemetry. 
- Add a minimal automated verification and document the orchestration-layer audit so the change surface is tested and the remaining layering risks are explicit.

### Description
- Map new `delegation-event` chunks to `tool_call_update` in the ACP mapper and construct a uniqueness-preserving fallback `toolCallId` derived from available correlation fields plus timestamp. 
- Add a shared delegation payload normalizer `delegationPayloadFromEvent` (`mastra-agents/src/workflows/delegation-event.js`) that preserves structured `prompt`, `response`, and `error` values and normalizes common correlation fields. 
- Emit `delegation-event` chunks from the async harness stream on `delegation_start` / `delegation_complete` by calling the normalizer from `streamHarnessMessage` in `async-agent-job.ts`. 
- Add a focused spec `mastra-agents/src/acp/delegation-observability.spec.js` covering structured payload preservation and fallback-ID uniqueness, and add `docs/rt88-70-orchestration-audit.md` documenting current orchestrator vs supervisor routing and the remaining validation gap. 
- Remaining gap: no full end-to-end integration test was added to prove runtime delegation hooks under both orchestration profiles, so the audit doc notes where such a focused integration test should be added if layering changes occur.

### Testing
- Ran the focused spec with `node --test src/acp/delegation-observability.spec.js` and it passed (assertions for structured fields and unique fallback IDs succeeded). 
- Built the package with `npm run build` and the build completed successfully, with non-fatal telemetry/PostHog network flush errors observed in this environment. 
- `npm test` (the repo-wide test script) still fails to discover tests due to the package's test glob; the new spec was executed directly to provide an automated verification pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fdee8448832abf894da3344ad92f)