### PR TITLE
RT88-70: Complete workspace, proxy, and Palmer Linear channel setup

### DIFF
--- a/.agents/docs/linear-palmer-channel.md
+++ b/.agents/docs/linear-palmer-channel.md
@@ -1,0 +1,71 @@
+# Palmer Linear Channel
+
+Palmer is the Linear app actor currently connected to `supervisor-agent`.
+
+## Architecture
+
+Keep the channel setup inside the Mastra agent definition:
+
+```ts
+new Agent({
+  id: "supervisor-agent",
+  channels: {
+    adapters: {
+      linear: createLinearAdapter(...),
+    },
+  },
+});
+```
+
+Do not create a separate Chat SDK app instance for Palmer, and do not create a custom OAuth subsystem under `src/`. Mastra core owns the `AgentChannels` bridge: it creates the internal Chat SDK instance, registers the webhook route, and routes Linear events into the agent stream.
+
+## Current Palmer Target
+
+Use supervisor only:
+
+```txt
+https://webbb.renaissancelab.org/api/agents/supervisor-agent/channels/linear/webhook
+```
+
+Do not point the Palmer Linear app at the orchestrator webhook for this setup.
+
+## OAuth App Actor
+
+The Linear OAuth app must be installed as an app actor:
+
+```txt
+actor=app
+scope=read,write,comments:create,issues:create,app:mentionable,app:assignable
+```
+
+Runtime env should use app-tenant OAuth credentials:
+
+```txt
+LINEAR_BOT_USERNAME=Palmer
+LINEAR_CHANNEL_MODE=agent-sessions
+LINEAR_MODE=agent-sessions
+LINEAR_CLIENT_ID=<linear client id>
+LINEAR_CLIENT_SECRET=<linear client secret>
+LINEAR_REDIRECT_URI=https://webbb.renaissancelab.org/api/linear/callback
+LINEAR_WEBHOOK_SECRET=<linear webhook secret>
+LINEAR_OAUTH_SCOPES=read,write,comments:create,issues:create,app:mentionable,app:assignable
+```
+
+Leave personal fallback auth empty for this app-actor install:
+
+```txt
+LINEAR_API_KEY=
+LINEAR_ACCESS_TOKEN=
+```
+
+## State Persistence
+
+Chat SDK's Linear adapter stores OAuth workspace installations through its `StateAdapter` with keys like:
+
+```txt
+linear:installation:{organizationId}
+```
+
+Mastra's default `MastraStateAdapter` persists thread subscriptions, but its generic cache is in-memory. That means Linear OAuth installs can disappear after a server restart. Use an official Chat SDK persistent state adapter through the existing `channels.state` field. This repo uses `@chat-adapter/state-pg` because the stack already has Postgres.
+
+This is still the lean Mastra channel path: `Agent.channels -> Chat SDK Linear adapter -> official persistent state`.

--- a/.agents/docs/mastra-agents-acp-tarball-install.md
+++ b/.agents/docs/mastra-agents-acp-tarball-install.md
@@ -38,6 +38,21 @@ mastra-agents-acp --agent-id orchestrator-agent --cwd "$PWD" --mastra-base-url h
 
 The command will normally wait for ACP JSON-RPC over stdio. Use `command -v` as the primary binary check; use an ACP smoke client when available for a full handshake.
 
+## Runtime Env And Proxy Model
+
+`mastra-agents-acp` loads `.env` from the workspace passed with `--cwd` before it creates the ACP agent. Keep `--cwd` pointed at the Mastra workspace root so editor-spawned ACP processes see the same model and proxy settings as the local Mastra server.
+
+The expected proxy-backed model config is:
+
+```bash
+MASTRA_SUPERVISOR_MODEL=proxy/openai/gpt-5.5
+PROXY_API_KEY=<proxy bearer key>
+```
+
+Do not configure ACP clients with `openai/gpt-5.5` as the default model. That bypasses the registered Mastra `proxy` gateway and makes the runtime ask for `OPENAI_API_KEY`.
+
+Do not use `rl/openai/...` model IDs for this ACP app. The Mastra gateway registered by this repo is `proxy`, so the model ID passed to Mastra must keep the `proxy/` prefix.
+
 ## Upgrade Later
 
 On the source machine:
@@ -69,3 +84,5 @@ mastra-agents-acp --agent-id orchestrator-agent --cwd /path/to/workspace --mastr
 ```
 
 Keep `--cwd` explicit for editor/ACP clients because it defines the workspace root for the session. The installed binary path should not be hard-coded.
+
+The binary should resolve runtime model config from the workspace `.env`. If a client's model picker shows `openai/gpt-5.5` before `proxy/openai/gpt-5.5`, the ACP process is not seeing the intended workspace env or is running an older tarball.

--- a/.agents/docs/mastra-agents-acp-tarball-install.md
+++ b/.agents/docs/mastra-agents-acp-tarball-install.md
@@ -1,0 +1,71 @@
+# Mastra Agents ACP Tarball Install
+
+Use this when `mastra-agents-acp` needs to be installed as a user-global binary on another machine before the package is stable enough for npm publishing.
+
+## Build The Tarball
+
+From the source machine:
+
+```bash
+cd /container/shared/workspace/projects/mastra-system/mastra-agents
+npm run acp:build
+npm version patch --no-git-tag-version
+npm pack
+```
+
+This creates a package like:
+
+```bash
+mastrasystem-agents-0.1.1.tgz
+```
+
+If the version should not be bumped, skip `npm version patch --no-git-tag-version`, but prefer bumping before sharing upgrades so the receiving machine can clearly identify the installed build.
+
+## Install On Another Machine
+
+Copy the `.tgz` file to the target machine, then install it globally for the current user:
+
+```bash
+npm install -g ./mastrasystem-agents-0.1.1.tgz
+```
+
+Verify the binary:
+
+```bash
+command -v mastra-agents-acp
+mastra-agents-acp --agent-id orchestrator-agent --cwd "$PWD" --mastra-base-url http://127.0.0.1:4111
+```
+
+The command will normally wait for ACP JSON-RPC over stdio. Use `command -v` as the primary binary check; use an ACP smoke client when available for a full handshake.
+
+## Upgrade Later
+
+On the source machine:
+
+```bash
+cd /container/shared/workspace/projects/mastra-system/mastra-agents
+npm run acp:build
+npm version patch --no-git-tag-version
+npm pack
+```
+
+On the target machine:
+
+```bash
+npm install -g ./mastrasystem-agents-0.1.2.tgz
+```
+
+Reinstalling a newer tarball updates the global `mastra-agents-acp` command.
+
+## Client Config Shape
+
+After global install, clients should invoke the binary by name rather than using absolute paths to `src/acp/stdio.js`.
+
+Example args:
+
+```bash
+mastra-agents-acp --agent-id supervisor-agent --cwd /path/to/workspace --mastra-base-url http://127.0.0.1:4111
+mastra-agents-acp --agent-id orchestrator-agent --cwd /path/to/workspace --mastra-base-url http://127.0.0.1:4111
+```
+
+Keep `--cwd` explicit for editor/ACP clients because it defines the workspace root for the session. The installed binary path should not be hard-coded.

--- a/.agents/docs/model-api-config/proxy-gateway.md
+++ b/.agents/docs/model-api-config/proxy-gateway.md
@@ -1,0 +1,73 @@
+# Proxy Gateway Model API Config
+
+Mastra agents in this stack use the canonical `proxy` model gateway prefix.
+
+## Canonical Model ID
+
+Use:
+
+```txt
+proxy/openai/gpt-5.5
+```
+
+Do not use an `rl/` model prefix. The gateway ID registered by the Mastra server is `proxy`, so `proxy/openai/gpt-5.5` is the model ID Mastra should receive. The proxy gateway strips the gateway/provider namespace before sending the request upstream, so the hosted proxy receives:
+
+```txt
+gpt-5.5
+```
+
+## Environment
+
+Use these project-facing env vars:
+
+```txt
+PROXY_BASE_URL=https://aa.renaissancelab.org/v1
+PROXY_API_KEY=<proxy bearer key>
+MASTRA_SUPERVISOR_MODEL=proxy/openai/gpt-5.5
+```
+
+Do not document or configure `RL_PROXY_BASE_URL`, `RL_PROXY_API_KEY`, or `rl/openai/...` in this stack. Older CLI stack env names may exist elsewhere, but the Mastra agent app should expose the neutral `PROXY_*` prefix.
+
+## Verification
+
+Verify the proxy key and model catalog:
+
+```bash
+node scripts/with-env.mjs node --input-type=module <<'NODE'
+const baseUrl = process.env.PROXY_BASE_URL.replace(/\/+$/, '');
+const response = await fetch(`${baseUrl}/models`, {
+  headers: { Authorization: `Bearer ${process.env.PROXY_API_KEY}` },
+});
+const body = await response.json();
+const models = body.data?.map((model) => model.id || model.name || model.model) ?? [];
+console.log({
+  ok: response.ok,
+  hasGpt55: models.includes('gpt-5.5'),
+});
+NODE
+```
+
+Verify a direct completion smoke test:
+
+```bash
+node scripts/with-env.mjs node --input-type=module <<'NODE'
+const baseUrl = process.env.PROXY_BASE_URL.replace(/\/+$/, '');
+const response = await fetch(`${baseUrl}/chat/completions`, {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${process.env.PROXY_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    model: 'gpt-5.5',
+    messages: [{ role: 'user', content: 'Reply with exactly: proxy-ok' }],
+    max_tokens: 12,
+  }),
+});
+const body = await response.json();
+console.log({
+  ok: response.ok,
+  content: body.choices?.[0]?.message?.content,
+});
+NODE
+```

--- a/.agents/skills/idea-validation/SKILL.md
+++ b/.agents/skills/idea-validation/SKILL.md
@@ -1,22 +1,27 @@
 ---
 name: idea-validation
-description: Preprocess step for running idea validation.
-Given any newly presented idea - that is awaited to be implemented as a feature, infrastructure, refactor, etc. Employ this decision framework
+description: >-
+  Preprocess step for running idea validation. Given any newly presented idea -
+  that is awaited to be implemented as a feature, infrastructure, refactor, etc.
+  Employ this decision framework.
 ---
 
 Based on user submitted ideas - interrogate the idea step by step:
 
 Phase 1 - intend classification:
+
 - understand and confirm with user the motivation of suggested ideas
 - understand and confirm user with underlying mechanism that leads to materialization of perceived success
 
 Phase 2 - Problem scoping and validation
 -> After confirming user intend, motivation and mechanism - act as a intellectual sparing partner. Challenge user's idea given the following objective:
+
 - Determine if user's idea actually solve real world problems
 - Determine if this problem is worth solving or not
 - Understand user's problem and propose alternative business case
 
 You can use these variables in presenting business case:
+
 1. Implementation Difficulty
 2. Problem it solves
 3. Time needed
@@ -25,7 +30,8 @@ You can use these variables in presenting business case:
 You can use the grill-me skills in walking through the problem solving feature tree/ design tree process.
 
 Phase 3 - complete scope
-Once completing scope - write up ideation document - awaiting for technical implementation brainstorming session. This can come in a form of 
+Once completing scope - write up ideation document - awaiting for technical implementation brainstorming session. This can come in a form of
+
 - Feature request
 - Implementation note
 - Github Discussion

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 # Mastra generated runtime/build state
 .mastra/
 .agents/exec/snapshots/
+.pi-lens/
 
 # Generated scratch artifacts
 test*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,6 @@
 
 - The Scout rewrite should use Claude subagent references and Claude Code system prompt references as evidence for role depth, tool discipline, and output contracts.
 - Do not use Mastra Code or `references/mastra/mastracode` as a reference source for this rewrite. Mastra Code is out of scope for the Scout prompt rewrite and should be treated as irrelevant unless the user explicitly reintroduces it.
+- Mastra Agents ACP user-global binary distribution notes live at `.agents/docs/mastra-agents-acp-tarball-install.md`. Use that doc when packaging `mastra-agents-acp` as an npm tarball for install or upgrade on another machine before public/private npm publishing is appropriate.
+- Palmer/Linear channel setup notes live at `.agents/docs/linear-palmer-channel.md`. Keep the Linear app lean: configure Chat SDK's Linear adapter through the Mastra `Agent.channels` field on `supervisor-agent`; do not create a separate Chat SDK app or custom OAuth subsystem.
+- Before implementing infrastructure that may already exist in an upstream library, query DeepWiki for the relevant repository and feature area first. Prefer official packages/classes/adapters/state implementations from the library over custom code; document the chosen package or API when adopting it.

--- a/compose.webhooks.yml
+++ b/compose.webhooks.yml
@@ -1,4 +1,21 @@
 services:
+  mastra-postgres:
+    image: ${POSTGRES_IMAGE:-postgres:16-alpine}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-mastra}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mastra}
+      POSTGRES_DB: ${POSTGRES_DB:-mastra}
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    volumes:
+      - mastra-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", 'pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   webhook-server:
     build:
       context: .
@@ -28,3 +45,6 @@ services:
       TUNNEL_TOKEN: ${CLOUDFLARED_TUNNEL_TOKEN:-}
       TUNNEL_METRICS: ${CLOUDFLARED_METRICS:-0.0.0.0:2000}
       TUNNEL_LOGLEVEL: ${CLOUDFLARED_LOGLEVEL:-info}
+
+volumes:
+  mastra-postgres-data:

--- a/docs/rt88-70-delegation-observability.md
+++ b/docs/rt88-70-delegation-observability.md
@@ -1,0 +1,19 @@
+# RT88-70: Delegation observability and workspace ownership notes
+
+## Workspace ownership
+
+Current agent definitions do not assign explicit per-agent workspace instances. Workspace access remains centralized via shared workspace tools exposed by orchestration agents (`orchestrator` and `supervisor`) and inherited by specialist delegation context.
+
+## Delegation visibility in ACP
+
+Delegation lifecycle events are emitted from harness streaming and mapped into ACP updates:
+
+- `delegation_start` -> `delegation-event` (status: `started`)
+- `delegation_complete` -> `delegation-event` (status: `completed` or `failed`)
+
+The emitted payload includes delegated target, delegated prompt, response/error, run/thread/resource correlation fields, and duration.
+
+## Default tool stream events vs hook-style delegation events
+
+- Existing generic tool stream events (`tool-call`, `tool-result`, `tool-error`) are still emitted unchanged.
+- New explicit `delegation-event` chunks supplement tool events so ACP can render delegation activity as first-class observable updates.

--- a/docs/rt88-70-delegation-observability.md
+++ b/docs/rt88-70-delegation-observability.md
@@ -7,7 +7,7 @@ Workspace ownership is now explicit at the orchestration boundary:
 - `orchestratorAgent` and `supervisorAgent` are configured with the shared `workspace`.
 - `createMastraAgentHarness()` is also configured with the same shared `workspace` so harness modes without their own workspace receive it through Mastra's inheritance path.
 - Specialist definitions (`scout`, `architect`, `researcher`, `advisor`, `developer`, `validator`) do not declare their own `workspace`; they inherit the active orchestration/harness workspace unless a future design adds a specific override.
-- Auto-injected Mastra workspace tools are disabled on the shared workspace; role-specific tool access still comes from explicit agent `tools` definitions so read-only/write-capable lanes stay separate and snapshot-aware write tools are not overridden.
+- The shared workspace exposes inherited read-only inspection tools under Mastra's default `mastra_workspace_*` names. Write, edit, mkdir, delete, indexing, and shell execution remain disabled there, so role-specific explicit tools remain the write/command permission boundary and snapshot-aware write tools are not overridden.
 
 ## Delegation visibility in ACP
 

--- a/docs/rt88-70-delegation-observability.md
+++ b/docs/rt88-70-delegation-observability.md
@@ -2,18 +2,24 @@
 
 ## Workspace ownership
 
-Current agent definitions do not assign explicit per-agent workspace instances. Workspace access remains centralized via shared workspace tools exposed by orchestration agents (`orchestrator` and `supervisor`) and inherited by specialist delegation context.
+Workspace ownership is now explicit at the orchestration boundary:
+
+- `orchestratorAgent` and `supervisorAgent` are configured with the shared `workspace`.
+- `createMastraAgentHarness()` is also configured with the same shared `workspace` so harness modes without their own workspace receive it through Mastra's inheritance path.
+- Specialist definitions (`scout`, `architect`, `researcher`, `advisor`, `developer`, `validator`) do not declare their own `workspace`; they inherit the active orchestration/harness workspace unless a future design adds a specific override.
+- Auto-injected Mastra workspace tools are disabled on the shared workspace; role-specific tool access still comes from explicit agent `tools` definitions so read-only/write-capable lanes stay separate and snapshot-aware write tools are not overridden.
 
 ## Delegation visibility in ACP
 
-Delegation lifecycle events are emitted from harness streaming and mapped into ACP updates:
+Delegation lifecycle events are emitted from orchestration `delegation` hooks and mapped into ACP updates:
 
 - `delegation_start` -> `delegation-event` (status: `started`)
 - `delegation_complete` -> `delegation-event` (status: `completed` or `failed`)
 
-The emitted payload includes delegated target, delegated prompt, response/error, run/thread/resource correlation fields, and duration.
+The emitted payload includes delegated target, delegated prompt, response/error, run/thread/resource correlation fields, and duration. The async harness stream subscribes to those hook payloads for the current thread/resource pair and forwards them as `delegation-event` chunks.
 
 ## Default tool stream events vs hook-style delegation events
 
 - Existing generic tool stream events (`tool-call`, `tool-result`, `tool-error`) are still emitted unchanged.
 - New explicit `delegation-event` chunks supplement tool events so ACP can render delegation activity as first-class observable updates.
+- Default tool events remain useful for raw tool-call diagnostics, while hook events are the source of delegated target, prompt, response/result, success/failure, and timing data.

--- a/docs/rt88-70-orchestration-audit.md
+++ b/docs/rt88-70-orchestration-audit.md
@@ -1,0 +1,17 @@
+# RT88-70 orchestration-layer hook and routing audit
+
+## Current layering validation
+
+- Connector channels are attached to `orchestratorAgent` (`orchestratorAgent.channels = createSupervisorChannelsConfig()`), making orchestrator the runtime ingress layer for connector entrypoints.
+- `supervisorAgent` remains defined as a secondary orchestration profile and is still available through the harness mode registry.
+- Both `orchestratorAgent` and `supervisorAgent` are configured with specialist subagents (`scout`, `researcher`, `architect`, `advisor`, `developer`, `validator`), so either orchestration layer can delegate.
+
+## Delegation observability implications
+
+- Delegation observability is implemented in the shared async job streaming pipeline (`streamHarnessMessage`) by emitting `delegation-event` chunks from delegation lifecycle events.
+- Because both orchestration layers run through the same harness/event stream path, no additional per-agent wiring is required for delegation event emission.
+- ACP maps `delegation-event` into `tool_call_update`, and now uses a uniqueness-preserving fallback ID derived from phase + correlation fields + timestamp.
+
+## Remaining gap
+
+- If future runtime changes bypass the shared harness stream path for one orchestrator profile, explicit hook registration at that profile should be reintroduced and covered with a focused integration test.

--- a/docs/rt88-70-orchestration-audit.md
+++ b/docs/rt88-70-orchestration-audit.md
@@ -5,13 +5,15 @@
 - Connector channels are attached to `orchestratorAgent` (`orchestratorAgent.channels = createSupervisorChannelsConfig()`), making orchestrator the runtime ingress layer for connector entrypoints.
 - `supervisorAgent` remains defined as a secondary orchestration profile and is still available through the harness mode registry.
 - Both `orchestratorAgent` and `supervisorAgent` are configured with specialist subagents (`scout`, `researcher`, `architect`, `advisor`, `developer`, `validator`), so either orchestration layer can delegate.
+- Both orchestration agents register `delegation.onDelegationStart` and `delegation.onDelegationComplete` through `createDelegationObservabilityOptions(...)`.
+- Both orchestration agents own the shared workspace directly; specialist harness modes inherit the same workspace from `createMastraAgentHarness()`.
 
 ## Delegation observability implications
 
-- Delegation observability is implemented in the shared async job streaming pipeline (`streamHarnessMessage`) by emitting `delegation-event` chunks from delegation lifecycle events.
-- Because both orchestration layers run through the same harness/event stream path, no additional per-agent wiring is required for delegation event emission.
+- Delegation observability is implemented at the orchestration agent call boundary by hook registration, then surfaced in the shared async job streaming pipeline (`streamHarnessMessage`) as `delegation-event` chunks.
+- Because both orchestration layers register the same hook factory, orchestrator and supervisor delegation behavior is inspectable through the same ACP mapping.
 - ACP maps `delegation-event` into `tool_call_update`, and now uses a uniqueness-preserving fallback ID derived from phase + correlation fields + timestamp.
 
 ## Remaining gap
 
-- If future runtime changes bypass the shared harness stream path for one orchestrator profile, explicit hook registration at that profile should be reintroduced and covered with a focused integration test.
+- A full live LLM delegation smoke remains environment-dependent. The focused local spec verifies hook payload emission, structured payload preservation, numeric timestamp fallback IDs, and ACP mapping without requiring provider credentials.

--- a/mastra-agents/.env.example
+++ b/mastra-agents/.env.example
@@ -5,6 +5,11 @@ MASTRA_DAYTONA_ENDPOINT=https://api.daytona.io
 
 # Database
 DATABASE_URL=postgresql://mastra:mastra@localhost:5432/mastra
+POSTGRES_IMAGE=postgres:16-alpine
+POSTGRES_HOST_PORT=5432
+POSTGRES_USER=mastra
+POSTGRES_PASSWORD=mastra
+POSTGRES_DB=mastra
 
 # Cloudflare Tunnel connector for public webhooks
 # Create a remotely managed tunnel in Cloudflare Zero Trust and set its connector token here.

--- a/mastra-agents/.env.example
+++ b/mastra-agents/.env.example
@@ -30,7 +30,8 @@ WEBHOOK_FORWARD_TIMEOUT_MS=30000
 MASTRA_UPSTREAM_URL=http://host.docker.internal:4111
 
 # Mastra Channels - Slack
-# Webhook URL: https://your-domain.com/api/agents/supervisor-agent/channels/slack/webhook
+# Webhook URL: https://your-domain.com/api/agents/orchestrator-agent/channels/slack/webhook
+# Alternate agent URL: https://your-domain.com/api/agents/supervisor-agent/channels/slack/webhook
 ENABLE_SLACK_CHANNEL=false
 SLACK_BOT_TOKEN=
 SLACK_SIGNING_SECRET=
@@ -45,28 +46,30 @@ SLACK_REDIRECT_URI=
 SLACK_ENCRYPTION_KEY=
 
 # Mastra Channels - Linear
-# Webhook URL: https://your-domain.com/api/agents/supervisor-agent/channels/linear/webhook
+# Palmer app actor webhook URL: https://your-domain.com/api/agents/supervisor-agent/channels/linear/webhook
 LINEAR_WEBHOOK_SECRET=
-LINEAR_BOT_USERNAME=
+LINEAR_BOT_USERNAME=Palmer
 # Inbound mode: comments or agent-sessions. LINEAR_MODE is the adapter-native name;
 # LINEAR_CHANNEL_MODE is also supported by this codebase and takes precedence.
-LINEAR_CHANNEL_MODE=comments
-LINEAR_MODE=comments
-# Option A: personal API key
-LINEAR_API_KEY=
-# Option B: pre-obtained OAuth access token
-LINEAR_ACCESS_TOKEN=
-# Option C: multi-tenant OAuth app
+LINEAR_CHANNEL_MODE=agent-sessions
+LINEAR_MODE=agent-sessions
+# Multi-tenant OAuth app. Install the app with actor=app and these scopes.
 LINEAR_CLIENT_ID=
 LINEAR_CLIENT_SECRET=
 LINEAR_REDIRECT_URI=
-# Option D: single-tenant client credentials
+LINEAR_ENCRYPTION_KEY=
+LINEAR_OAUTH_SCOPES=read,write,comments:create,issues:create,app:mentionable,app:assignable
+# Fallback auth modes for local testing only; leave empty for OAuth app-tenant installs.
+LINEAR_API_KEY=
+LINEAR_ACCESS_TOKEN=
 LINEAR_CLIENT_CREDENTIALS_CLIENT_ID=
 LINEAR_CLIENT_CREDENTIALS_CLIENT_SECRET=
-LINEAR_CLIENT_CREDENTIALS_SCOPES=read,write,comments:create,issues:create
+LINEAR_CLIENT_CREDENTIALS_SCOPES=read,write,comments:create,issues:create,app:mentionable,app:assignable
+MASTRA_CHANNEL_STATE_PREFIX=mastra-agents-channels
 
 # Mastra Channels - GitHub
-# Webhook URL: https://your-domain.com/api/agents/supervisor-agent/channels/github/webhook
+# Webhook URL: https://your-domain.com/api/agents/orchestrator-agent/channels/github/webhook
+# Alternate agent URL: https://your-domain.com/api/agents/supervisor-agent/channels/github/webhook
 ENABLE_GITHUB_CHANNEL=false
 GITHUB_WEBHOOK_SECRET=
 GITHUB_BOT_USERNAME=
@@ -96,6 +99,8 @@ MASTRA_SUBAGENT_MODEL=
 MASTRA_SUPERVISOR_MODEL=
 MASTRA_CONTROL_MODEL=
 MASTRA_OBSERVATIONAL_MEMORY_MODEL=
+PROXY_BASE_URL=https://aa.renaissancelab.org/v1
+PROXY_API_KEY=
 
 # Scorer model
 MASTRA_EVAL_MODEL=

--- a/mastra-agents/README.md
+++ b/mastra-agents/README.md
@@ -77,10 +77,17 @@ Configure GitHub webhooks or GitHub App events for issue comments and pull reque
 
 The stack in `compose.webhooks.yml` runs:
 
+- `mastra-postgres`: Postgres storage for Mastra memory, workflows, and control-plane state.
 - `webhook-server`: a small raw-body HTTP proxy that forwards webhook requests to the Mastra server already running on the Docker host.
 - `cloudflare-webhook-tunnel`: a Cloudflare Tunnel connector forwarding public HTTPS traffic to `webhook-server`.
 
 Create a remotely managed Cloudflare Tunnel in Cloudflare Zero Trust, copy its connector token into `CLOUDFLARED_TUNNEL_TOKEN`, and configure a public hostname for the tunnel with this service target:
+
+```text
+http://webhook-server:8080
+```
+
+The deployed internal Docker network endpoint is:
 
 ```text
 http://webhook-server:8080
@@ -94,16 +101,22 @@ http://host.docker.internal:4111
 
 If Docker cannot reach `host.docker.internal` from this workspace, set `MASTRA_UPSTREAM_URL` to the workspace container IP, for example `http://172.30.10.102:4111`.
 
+The stack exposes Postgres on the Docker host at:
+
+```text
+postgresql://mastra:mastra@localhost:5432/mastra
+```
+
 Then start the webhook stack:
 
 ```bash
 docker compose -f compose.webhooks.yml --env-file mastra-agents/.env up -d --build
 ```
 
-Use the public hostname for platform webhooks:
+Use the deployed public hostname for platform webhooks:
 
 ```text
-https://your-webhook-domain.example.com/api/agents/supervisor-agent/channels/slack/webhook
-https://your-webhook-domain.example.com/api/agents/supervisor-agent/channels/linear/webhook
-https://your-webhook-domain.example.com/api/agents/supervisor-agent/channels/github/webhook
+https://webb.renaissancelab.org/api/agents/supervisor-agent/channels/slack/webhook
+https://webb.renaissancelab.org/api/agents/supervisor-agent/channels/linear/webhook
+https://webb.renaissancelab.org/api/agents/supervisor-agent/channels/github/webhook
 ```

--- a/mastra-agents/README.md
+++ b/mastra-agents/README.md
@@ -24,7 +24,7 @@ src/
 
 ## Slack Channel Integration (RT88-66)
 
-The shared `supervisorAgent` now supports Mastra Channels with the official Chat SDK Slack adapter.
+The shared `orchestratorAgent` and `supervisorAgent` support Mastra Channels with the official Chat SDK Slack adapter.
 
 - Adapter package: `@chat-adapter/slack`
 - Enable Slack adapter: set `ENABLE_SLACK_CHANNEL=true`
@@ -32,8 +32,9 @@ The shared `supervisorAgent` now supports Mastra Channels with the official Chat
   - `SLACK_BOT_TOKEN`
   - `SLACK_SIGNING_SECRET`
 
-When enabled, Mastra exposes this webhook endpoint for Slack events:
+When enabled, Mastra exposes agent-owned webhook endpoints for Slack events:
 
+- `/api/agents/orchestrator-agent/channels/slack/webhook`
 - `/api/agents/supervisor-agent/channels/slack/webhook`
 
 Recommended Slack behavior for this integration:
@@ -44,22 +45,27 @@ Recommended Slack behavior for this integration:
 
 ## Linear Channel Integration (RT88-68)
 
-The shared `supervisorAgent` supports Mastra Channels with the official Chat SDK Linear adapter.
+The shared `supervisorAgent` supports the Palmer Linear app actor through Mastra Channels with the official Chat SDK Linear adapter.
 
 - Adapter package: `@chat-adapter/linear`
 - Required webhook secret: `LINEAR_WEBHOOK_SECRET`
-- Required auth: one of `LINEAR_API_KEY`, `LINEAR_ACCESS_TOKEN`, `LINEAR_CLIENT_ID` + `LINEAR_CLIENT_SECRET`, or `LINEAR_CLIENT_CREDENTIALS_CLIENT_ID` + `LINEAR_CLIENT_CREDENTIALS_CLIENT_SECRET`
-- Inbound mode: `LINEAR_CHANNEL_MODE=comments` or `LINEAR_CHANNEL_MODE=agent-sessions`
+- Required auth for the production app: `LINEAR_CLIENT_ID` + `LINEAR_CLIENT_SECRET`
+- Required mode for the app actor: `LINEAR_CHANNEL_MODE=agent-sessions`
+- Recommended token encryption: `LINEAR_ENCRYPTION_KEY`
+- Install scopes: `read,write,comments:create,issues:create,app:mentionable,app:assignable`
+- Persistent channel state: `@chat-adapter/state-pg` using `DATABASE_URL`
 
-When configured, Mastra exposes this webhook endpoint for Linear events:
+When configured, Mastra exposes the supervisor-owned webhook endpoint for Palmer Linear events:
 
 - `/api/agents/supervisor-agent/channels/linear/webhook`
 
-`comments` mode uses Linear comment webhooks. `agent-sessions` mode is for Linear app-actor agent session events.
+The Linear OAuth app should enable both Comments and Agent session events, plus Issues and Emoji reactions if those events are needed by the agent. `agent-sessions` mode is required for Linear app-actor sessions; the code explicitly prefers top-level OAuth app credentials over fallback API-key auth when `LINEAR_CLIENT_ID` and `LINEAR_CLIENT_SECRET` are set. OAuth workspace installations are stored in Chat SDK state, so the channel config uses the official Postgres state adapter rather than Mastra's default in-memory cache for generic `state.get/set` keys.
+
+Use `npm run linear:install-url` to generate the Linear app-actor install URL from `LINEAR_CLIENT_ID`, `LINEAR_REDIRECT_URI`, and `LINEAR_OAUTH_SCOPES`. This is an operator helper only; runtime traffic still uses the Mastra channel webhook route.
 
 ## GitHub Channel Integration
 
-The shared `supervisorAgent` supports Mastra Channels with the official Chat SDK GitHub adapter.
+The shared `orchestratorAgent` and `supervisorAgent` support Mastra Channels with the official Chat SDK GitHub adapter.
 
 - Adapter package: `@chat-adapter/github`
 - Enable GitHub adapter: set `ENABLE_GITHUB_CHANNEL=true`
@@ -67,11 +73,23 @@ The shared `supervisorAgent` supports Mastra Channels with the official Chat SDK
 - Required auth: either `GITHUB_TOKEN` or `GITHUB_APP_ID` + `GITHUB_PRIVATE_KEY`
 - Optional single-tenant GitHub App install: `GITHUB_INSTALLATION_ID`
 
-When enabled, Mastra exposes this webhook endpoint for GitHub events:
+When enabled, Mastra exposes agent-owned webhook endpoints for GitHub events:
 
+- `/api/agents/orchestrator-agent/channels/github/webhook`
 - `/api/agents/supervisor-agent/channels/github/webhook`
 
 Configure GitHub webhooks or GitHub App events for issue comments and pull request review comments.
+
+## Proxy Gateway
+
+The Mastra server registers the hosted OpenAI-compatible proxy as a custom model gateway with ID `proxy`.
+
+- Gateway-facing model ID: `proxy/openai/gpt-5.5`
+- Proxy endpoint: `https://aa.renaissancelab.org/v1`
+- Proxy auth: set `PROXY_API_KEY`
+- Upstream reference: [`router-for-me/CLIProxyAPI`](https://github.com/router-for-me/CLIProxyAPI), also indexed on [DeepWiki](https://deepwiki.com/router-for-me/CLIProxyAPI)
+
+The proxy expects the upstream model name without the gateway/provider namespace, for example `gpt-5.5`. ACP thinking levels use CLIProxy's model suffix shape, for example `proxy/openai/gpt-5.5` with `High` thinking is sent through Mastra as `proxy/openai/gpt-5.5(high)` and reaches the proxy as `gpt-5.5(high)`.
 
 ## Webhook Server With Cloudflare Tunnel
 
@@ -116,7 +134,9 @@ docker compose -f compose.webhooks.yml --env-file mastra-agents/.env up -d --bui
 Use the deployed public hostname for platform webhooks:
 
 ```text
-https://webb.renaissancelab.org/api/agents/supervisor-agent/channels/slack/webhook
-https://webb.renaissancelab.org/api/agents/supervisor-agent/channels/linear/webhook
-https://webb.renaissancelab.org/api/agents/supervisor-agent/channels/github/webhook
+https://webbb.renaissancelab.org/api/agents/orchestrator-agent/channels/slack/webhook
+https://webbb.renaissancelab.org/api/agents/orchestrator-agent/channels/github/webhook
+https://webbb.renaissancelab.org/api/agents/supervisor-agent/channels/slack/webhook
+https://webbb.renaissancelab.org/api/agents/supervisor-agent/channels/linear/webhook
+https://webbb.renaissancelab.org/api/agents/supervisor-agent/channels/github/webhook
 ```

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -118,23 +118,25 @@ function buildPromptPayload(session: MastraAcpSession, content: string, config: 
   const modeId = mode.id;
   const modelId = normalizeModelId(session.modelId, config);
   const thinkingOptions = resolveThinkingProviderOptions({ modelId, thinkingLevel: session.thinkingOptionId });
+  const effectiveModelId = thinkingOptions.modelId ?? modelId;
   return {
     messages: [{ role: 'user', content: `${mode.prompt}\n\n${content}` }],
     memory: { thread: session.threadId, resource: session.resourceId },
-    model: modelId,
+    model: effectiveModelId,
     ...(thinkingOptions.providerOptions ? { providerOptions: thinkingOptions.providerOptions } : {}),
     requestContext: {
       acp: {
         sessionId: session.sessionId,
         cwd: session.cwd,
         modeId,
-        modelId,
+        modelId: effectiveModelId,
+        selectedModelId: modelId,
         thinkingOptionId: session.thinkingOptionId,
         thinking: thinkingOptions.metadata,
       },
       activeAgentId: mode.agentId,
       modeId,
-      modelId,
+      modelId: effectiveModelId,
       harnessMode: mode.harnessMode,
       harnessModeId: mode.harnessModeId,
       hardnessMode: mode.harnessModeId,

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -1,9 +1,9 @@
 import type { AgentSideConnection, InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModelRequest, SetSessionModelResponse } from '@agentclientprotocol/sdk';
-import { buildConfigOptions, AVAILABLE_MODELS, AVAILABLE_MODES } from './config-options.js';
+import { buildConfigOptions, AVAILABLE_MODELS, AVAILABLE_MODES, normalizeModeId, normalizeModelId, type SupervisorModeId } from './config-options.js';
 import { mapMastraChunkToUpdates } from './event-mapper.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
-import type { ACPAgent, MastraAcpAgentOptions } from './types.js';
+import type { ACPAgent, MastraAcpAgentOptions, MastraAcpSession } from './types.js';
 import { getSlashCommands } from './slash-commands.js';
 
 export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: MastraAcpAgentOptions): ACPAgent {
@@ -23,7 +23,7 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
     async newSession(_params: NewSessionRequest): Promise<NewSessionResponse> {
       const session = store.create({ agentId: options.agentId, cwd: options.cwd, resourceId: options.defaultResourceId, threadId: options.defaultThreadId });
       await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'available_commands_update', availableCommands: getSlashCommands() } });
-      return { sessionId: session.sessionId, modes: { availableModes: AVAILABLE_MODES.map(id=>({id,name:id})), currentModeId: session.modeId ?? 'balanced' }, models: { availableModels: AVAILABLE_MODELS.map(modelId=>({modelId,name:modelId})), currentModelId: session.modelId ?? AVAILABLE_MODELS[0] }, configOptions: buildConfigOptions(session) };
+      return sessionStateResponse(session);
     },
     async prompt(params: PromptRequest): Promise<PromptResponse> {
       const session = store.get(params.sessionId);
@@ -32,7 +32,7 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
       const content = (last && 'text' in last) ? last.text : '';
       const ac = new AbortController();
       session.abortController = ac; store.update(session);
-      for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, { messages: [{ role: 'user', content }], memory: { thread: session.threadId, resource: session.resourceId }, requestContext: { acp: { sessionId: session.sessionId, cwd: session.cwd, modeId: session.modeId, modelId: session.modelId, thinkingOptionId: session.thinkingOptionId }, modeId: session.modeId, harnessMode: session.modeId } }, ac.signal)) {
+      for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content), ac.signal)) {
         for (const update of mapMastraChunkToUpdates(chunk)) {
           await conn.sessionUpdate({ sessionId: session.sessionId, update });
         }
@@ -43,29 +43,95 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
     async closeSession(params) { store.delete(params.sessionId); },
     async setSessionMode(params: SetSessionModeRequest) {
       const s = store.get(params.sessionId); if (!s) throw new Error(`Unknown session: ${params.sessionId}`);
-      s.modeId = params.modeId; store.update(s);
-      await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'current_mode_update', currentModeId: s.modeId ?? 'balanced' } });
-      await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'config_option_update', configOptions: buildConfigOptions(s) } });
+      s.modeId = normalizeModeId(params.modeId); store.update(s);
+      await emitSessionConfigUpdate(conn, s, true);
       return {};
     },
     async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
       const s = store.get(params.sessionId); if (!s) throw new Error(`Unknown session: ${params.sessionId}`);
-      s.modelId = params.modelId; store.update(s);
-      await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'config_option_update', configOptions: buildConfigOptions(s) } });
+      s.modelId = normalizeModelId(params.modelId); store.update(s);
+      await emitSessionConfigUpdate(conn, s, false);
       return {};
     },
     async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
       const s = store.get(params.sessionId); if (!s) throw new Error(`Unknown session: ${params.sessionId}`);
+      let modeChanged = false;
       if (typeof params.value === 'string') {
-        if (params.configId === 'mode') s.modeId = params.value;
-        if (params.configId === 'model') s.modelId = params.value;
+        if (params.configId === 'mode') {
+          s.modeId = normalizeModeId(params.value);
+          modeChanged = true;
+        }
+        if (params.configId === 'model') s.modelId = normalizeModelId(params.value);
         if (params.configId === 'thinking') s.thinkingOptionId = params.value;
       }
       store.update(s);
       const configOptions = buildConfigOptions(s);
-      await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'config_option_update', configOptions } });
+      await emitSessionConfigUpdate(conn, s, modeChanged);
       return { configOptions };
     },
     async authenticate() {},
   };
+}
+
+function sessionStateResponse(session: MastraAcpSession): NewSessionResponse {
+  const modeId = normalizeModeId(session.modeId);
+  const modelId = normalizeModelId(session.modelId);
+  return {
+    sessionId: session.sessionId,
+    modes: {
+      availableModes: AVAILABLE_MODES.map(id=>({id,name:id})),
+      currentModeId: modeId,
+    },
+    models: {
+      availableModels: AVAILABLE_MODELS.map(modelId=>({modelId,name:modelId})),
+      currentModelId: modelId,
+    },
+    configOptions: buildConfigOptions(session),
+  };
+}
+
+async function emitSessionConfigUpdate(conn: AgentSideConnection, session: MastraAcpSession, modeChanged: boolean): Promise<void> {
+  const modeId = normalizeModeId(session.modeId);
+  const configOptions = buildConfigOptions(session);
+  if (modeChanged) {
+    await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'current_mode_update', currentModeId: modeId } });
+  }
+  await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'config_option_update', configOptions } });
+}
+
+function buildPromptPayload(session: MastraAcpSession, content: string) {
+  const modeId = normalizeModeId(session.modeId);
+  const modelId = normalizeModelId(session.modelId);
+  const harnessModeId = `supervisor.${modeId}`;
+  return {
+    messages: [{ role: 'user', content: `${formatSupervisorScopePrompt(modeId)}\n\n${content}` }],
+    memory: { thread: session.threadId, resource: session.resourceId },
+    model: modelId,
+    requestContext: {
+      acp: {
+        sessionId: session.sessionId,
+        cwd: session.cwd,
+        modeId,
+        modelId,
+        thinkingOptionId: session.thinkingOptionId,
+      },
+      activeAgentId: 'supervisor',
+      modeId,
+      modelId,
+      harnessMode: modeId,
+      harnessModeId,
+      hardnessMode: harnessModeId,
+      supervisorScope: modeId,
+    },
+  };
+}
+
+function formatSupervisorScopePrompt(modeId: SupervisorModeId): string {
+  const prompt = {
+    base: 'Supervisor Lead Base:\n- Orchestrate the work pragmatically across scoping, planning, building, and verification.\n- Delegate only when a specialist can advance a bounded part of the task.\n- Keep ownership of the final answer, evidence quality, and next action.',
+    scope: 'Supervisor Lead Scope:\n- Identify the smallest useful slice, non-goals, assumptions, and evidence needed.\n- Route discovery to the right specialist before committing to implementation.\n- Stop for a decision when product scope or write boundaries are unclear.',
+    spec: 'Supervisor Lead Spec:\n- Convert the scoped slice into a concrete execution plan with boundaries and verification.\n- Use specialists to sharpen contracts, risks, and acceptance criteria.\n- Do not present implementation as complete while still planning.',
+    exec: 'Supervisor Lead Exec:\n- Drive implementation through the appropriate specialist agents while preserving the approved boundary.\n- Keep build progress tied to concrete files, behavior, and evidence.\n- Escalate if implementation requires a new scope or architecture decision.\n- Audit the completed or claimed work before final synthesis.',
+  } satisfies Record<SupervisorModeId, string>;
+  return `<harness-mode id="supervisor.${modeId}" agent="supervisor" mode="${modeId}">\nAgent: Supervisor Lead\nMode: ${modeId}\n${prompt[modeId]}\n</harness-mode>`;
 }

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -1,5 +1,5 @@
 import type { AgentSideConnection, InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModelRequest, SetSessionModelResponse } from '@agentclientprotocol/sdk';
-import { buildConfigOptions, AVAILABLE_MODELS, AVAILABLE_MODES, normalizeModeId, normalizeModelId, type SupervisorModeId } from './config-options.js';
+import { buildConfigOptions, loadAcpRuntimeConfig, modeDefinitionForSession, modelOptionsForSession, normalizeModeId, normalizeModelId, type AcpRuntimeConfig } from './config-options.js';
 import { mapMastraChunkToUpdates } from './event-mapper.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
@@ -8,6 +8,7 @@ import { getSlashCommands } from './slash-commands.js';
 
 export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: MastraAcpAgentOptions): ACPAgent {
   const store = new MastraAcpSessionStore();
+  const runtimeConfig = () => loadAcpRuntimeConfig(options.agentId, options.mastraBaseUrl);
   return {
     async initialize(_params: InitializeRequest): Promise<InitializeResponse> {
       return {
@@ -21,18 +22,27 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
       };
     },
     async newSession(_params: NewSessionRequest): Promise<NewSessionResponse> {
-      const session = store.create({ agentId: options.agentId, cwd: options.cwd, resourceId: options.defaultResourceId, threadId: options.defaultThreadId });
+      const config = await runtimeConfig();
+      const session = store.create({
+        agentId: options.agentId,
+        cwd: options.cwd,
+        resourceId: options.defaultResourceId,
+        threadId: options.defaultThreadId,
+        defaultModeId: config.defaultModeId,
+        defaultModelId: config.defaultModelId,
+      });
       await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'available_commands_update', availableCommands: getSlashCommands() } });
-      return sessionStateResponse(session);
+      return sessionStateResponse(session, config);
     },
     async prompt(params: PromptRequest): Promise<PromptResponse> {
+      const config = await runtimeConfig();
       const session = store.get(params.sessionId);
       if (!session) throw new Error(`Unknown session: ${params.sessionId}`);
       const last = params.prompt.findLast((b) => b.type === 'text' && typeof b.text === 'string');
       const content = (last && 'text' in last) ? last.text : '';
       const ac = new AbortController();
       session.abortController = ac; store.update(session);
-      for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content), ac.signal)) {
+      for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content, config), ac.signal)) {
         for (const update of mapMastraChunkToUpdates(chunk)) {
           await conn.sessionUpdate({ sessionId: session.sessionId, update });
         }
@@ -42,69 +52,72 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
     async cancel(params) { const s = store.get(params.sessionId); s?.abortController?.abort(); },
     async closeSession(params) { store.delete(params.sessionId); },
     async setSessionMode(params: SetSessionModeRequest) {
+      const config = await runtimeConfig();
       const s = store.get(params.sessionId); if (!s) throw new Error(`Unknown session: ${params.sessionId}`);
-      s.modeId = normalizeModeId(params.modeId); store.update(s);
-      await emitSessionConfigUpdate(conn, s, true);
+      s.modeId = normalizeModeId(params.modeId, config); store.update(s);
+      await emitSessionConfigUpdate(conn, s, config, true);
       return {};
     },
     async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
+      const config = await runtimeConfig();
       const s = store.get(params.sessionId); if (!s) throw new Error(`Unknown session: ${params.sessionId}`);
-      s.modelId = normalizeModelId(params.modelId); store.update(s);
-      await emitSessionConfigUpdate(conn, s, false);
+      s.modelId = normalizeModelId(params.modelId, config); store.update(s);
+      await emitSessionConfigUpdate(conn, s, config, false);
       return {};
     },
     async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
+      const config = await runtimeConfig();
       const s = store.get(params.sessionId); if (!s) throw new Error(`Unknown session: ${params.sessionId}`);
       let modeChanged = false;
       if (typeof params.value === 'string') {
         if (params.configId === 'mode') {
-          s.modeId = normalizeModeId(params.value);
+          s.modeId = normalizeModeId(params.value, config);
           modeChanged = true;
         }
-        if (params.configId === 'model') s.modelId = normalizeModelId(params.value);
+        if (params.configId === 'model') s.modelId = normalizeModelId(params.value, config);
         if (params.configId === 'thinking') s.thinkingOptionId = params.value;
       }
       store.update(s);
-      const configOptions = buildConfigOptions(s);
-      await emitSessionConfigUpdate(conn, s, modeChanged);
+      const configOptions = buildConfigOptions(s, config);
+      await emitSessionConfigUpdate(conn, s, config, modeChanged);
       return { configOptions };
     },
     async authenticate() {},
   };
 }
 
-function sessionStateResponse(session: MastraAcpSession): NewSessionResponse {
-  const modeId = normalizeModeId(session.modeId);
-  const modelId = normalizeModelId(session.modelId);
+function sessionStateResponse(session: MastraAcpSession, config: AcpRuntimeConfig): NewSessionResponse {
+  const modeId = normalizeModeId(session.modeId, config);
+  const modelId = normalizeModelId(session.modelId, config);
   return {
     sessionId: session.sessionId,
     modes: {
-      availableModes: AVAILABLE_MODES.map(id=>({id,name:id})),
+      availableModes: config.modes.map(mode=>({id:mode.id,name:mode.name})),
       currentModeId: modeId,
     },
     models: {
-      availableModels: AVAILABLE_MODELS.map(modelId=>({modelId,name:modelId})),
+      availableModels: modelOptionsForSession(session, config).map(modelId=>({modelId,name:modelId})),
       currentModelId: modelId,
     },
-    configOptions: buildConfigOptions(session),
+    configOptions: buildConfigOptions(session, config),
   };
 }
 
-async function emitSessionConfigUpdate(conn: AgentSideConnection, session: MastraAcpSession, modeChanged: boolean): Promise<void> {
-  const modeId = normalizeModeId(session.modeId);
-  const configOptions = buildConfigOptions(session);
+async function emitSessionConfigUpdate(conn: AgentSideConnection, session: MastraAcpSession, config: AcpRuntimeConfig, modeChanged: boolean): Promise<void> {
+  const modeId = normalizeModeId(session.modeId, config);
+  const configOptions = buildConfigOptions(session, config);
   if (modeChanged) {
     await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'current_mode_update', currentModeId: modeId } });
   }
   await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'config_option_update', configOptions } });
 }
 
-function buildPromptPayload(session: MastraAcpSession, content: string) {
-  const modeId = normalizeModeId(session.modeId);
-  const modelId = normalizeModelId(session.modelId);
-  const harnessModeId = `supervisor.${modeId}`;
+function buildPromptPayload(session: MastraAcpSession, content: string, config: AcpRuntimeConfig) {
+  const mode = modeDefinitionForSession(session, config);
+  const modeId = mode.id;
+  const modelId = normalizeModelId(session.modelId, config);
   return {
-    messages: [{ role: 'user', content: `${formatSupervisorScopePrompt(modeId)}\n\n${content}` }],
+    messages: [{ role: 'user', content: `${mode.prompt}\n\n${content}` }],
     memory: { thread: session.threadId, resource: session.resourceId },
     model: modelId,
     requestContext: {
@@ -115,23 +128,13 @@ function buildPromptPayload(session: MastraAcpSession, content: string) {
         modelId,
         thinkingOptionId: session.thinkingOptionId,
       },
-      activeAgentId: 'supervisor',
+      activeAgentId: mode.agentId,
       modeId,
       modelId,
-      harnessMode: modeId,
-      harnessModeId,
-      hardnessMode: harnessModeId,
-      supervisorScope: modeId,
+      harnessMode: mode.harnessMode,
+      harnessModeId: mode.harnessModeId,
+      hardnessMode: mode.harnessModeId,
+      ...(mode.agentId === 'supervisor' ? { supervisorScope: mode.harnessMode } : { orchestratorMode: mode.harnessMode }),
     },
   };
-}
-
-function formatSupervisorScopePrompt(modeId: SupervisorModeId): string {
-  const prompt = {
-    base: 'Supervisor Lead Base:\n- Orchestrate the work pragmatically across scoping, planning, building, and verification.\n- Delegate only when a specialist can advance a bounded part of the task.\n- Keep ownership of the final answer, evidence quality, and next action.',
-    scope: 'Supervisor Lead Scope:\n- Identify the smallest useful slice, non-goals, assumptions, and evidence needed.\n- Route discovery to the right specialist before committing to implementation.\n- Stop for a decision when product scope or write boundaries are unclear.',
-    spec: 'Supervisor Lead Spec:\n- Convert the scoped slice into a concrete execution plan with boundaries and verification.\n- Use specialists to sharpen contracts, risks, and acceptance criteria.\n- Do not present implementation as complete while still planning.',
-    exec: 'Supervisor Lead Exec:\n- Drive implementation through the appropriate specialist agents while preserving the approved boundary.\n- Keep build progress tied to concrete files, behavior, and evidence.\n- Escalate if implementation requires a new scope or architecture decision.\n- Audit the completed or claimed work before final synthesis.',
-  } satisfies Record<SupervisorModeId, string>;
-  return `<harness-mode id="supervisor.${modeId}" agent="supervisor" mode="${modeId}">\nAgent: Supervisor Lead\nMode: ${modeId}\n${prompt[modeId]}\n</harness-mode>`;
 }

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -5,6 +5,7 @@ import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
 import type { ACPAgent, MastraAcpAgentOptions, MastraAcpSession } from './types.js';
 import { getSlashCommands } from './slash-commands.js';
+import { resolveThinkingProviderOptions } from './thinking-options.js';
 
 export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: MastraAcpAgentOptions): ACPAgent {
   const store = new MastraAcpSessionStore();
@@ -116,10 +117,12 @@ function buildPromptPayload(session: MastraAcpSession, content: string, config: 
   const mode = modeDefinitionForSession(session, config);
   const modeId = mode.id;
   const modelId = normalizeModelId(session.modelId, config);
+  const thinkingOptions = resolveThinkingProviderOptions({ modelId, thinkingLevel: session.thinkingOptionId });
   return {
     messages: [{ role: 'user', content: `${mode.prompt}\n\n${content}` }],
     memory: { thread: session.threadId, resource: session.resourceId },
     model: modelId,
+    ...(thinkingOptions.providerOptions ? { providerOptions: thinkingOptions.providerOptions } : {}),
     requestContext: {
       acp: {
         sessionId: session.sessionId,
@@ -127,6 +130,7 @@ function buildPromptPayload(session: MastraAcpSession, content: string, config: 
         modeId,
         modelId,
         thinkingOptionId: session.thinkingOptionId,
+        thinking: thinkingOptions.metadata,
       },
       activeAgentId: mode.agentId,
       modeId,

--- a/mastra-agents/acp/config-options.ts
+++ b/mastra-agents/acp/config-options.ts
@@ -1,11 +1,53 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk';
 import type { MastraAcpSession } from './types.js';
-export const AVAILABLE_MODES = ['balanced','scope','plan','build','verify','research','analysis','audit','debug'];
-export const AVAILABLE_MODELS = ['gpt-5.3-codex','gpt-5.3','gpt-5.1-mini'];
+
+export const SUPERVISOR_MODE_IDS = ['base','scope','spec','exec'] as const;
+export type SupervisorModeId = typeof SUPERVISOR_MODE_IDS[number];
+
+export const DEFAULT_ACP_MODE_ID: SupervisorModeId = 'base';
+export const DEFAULT_ACP_MODEL_ID =
+  process.env.MASTRA_SUPERVISOR_MODEL?.trim() ||
+  process.env.MASTRA_AGENT_MODEL?.trim() ||
+  process.env.MASTRA_SUBAGENT_MODEL?.trim() ||
+  process.env.MASTRA_MODEL?.trim() ||
+  'minimax-coding-plan/MiniMax-M2.7';
+
+export const AVAILABLE_MODES = [...SUPERVISOR_MODE_IDS];
+export const AVAILABLE_MODELS = [
+  DEFAULT_ACP_MODEL_ID,
+  'gpt-5.3-codex',
+  'gpt-5.3',
+  'gpt-5.1-mini',
+].filter((modelId, index, models) => modelId && models.indexOf(modelId) === index);
+
+const modeAliases = new Map<string, SupervisorModeId>([
+  ['base', 'base'],
+  ['balance', 'base'],
+  ['balanced', 'base'],
+  ['scope', 'scope'],
+  ['spec', 'spec'],
+  ['plan', 'spec'],
+  ['exec', 'exec'],
+  ['execution', 'exec'],
+  ['build', 'exec'],
+  ['verify', 'exec'],
+]);
+
+export function normalizeModeId(value: unknown): SupervisorModeId {
+  if (typeof value !== 'string') return DEFAULT_ACP_MODE_ID;
+  return modeAliases.get(value.trim().toLowerCase().replace(/_/g, '-')) ?? DEFAULT_ACP_MODE_ID;
+}
+
+export function normalizeModelId(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : DEFAULT_ACP_MODEL_ID;
+}
+
 export function buildConfigOptions(session: MastraAcpSession): SessionConfigOption[] {
+  const modeId = normalizeModeId(session.modeId);
+  const modelId = normalizeModelId(session.modelId);
   return [
-    { id:'mode', name:'Mode', category:'mode', type:'select', currentValue: session.modeId ?? 'balanced', options: AVAILABLE_MODES.map(v=>({value:v,name:v})) },
-    { id:'model', name:'Model', category:'model', type:'select', currentValue: session.modelId ?? AVAILABLE_MODELS[0], options: AVAILABLE_MODELS.map(v=>({value:v,name:v})) },
+    { id:'mode', name:'Mode', category:'mode', type:'select', currentValue: modeId, options: AVAILABLE_MODES.map(v=>({value:v,name:v})) },
+    { id:'model', name:'Model', category:'model', type:'select', currentValue: modelId, options: AVAILABLE_MODELS.map(v=>({value:v,name:v})) },
     { id:'thinking', name:'Thinking', category:'thought_level', type:'select', currentValue: session.thinkingOptionId ?? 'medium', options: ['low','medium','high'].map(v=>({value:v,name:v[0].toUpperCase()+v.slice(1)})) },
   ];
 }

--- a/mastra-agents/acp/config-options.ts
+++ b/mastra-agents/acp/config-options.ts
@@ -107,8 +107,8 @@ async function loadMastraRuntimeConfig(agentId: AcpRuntimeAgentId, apiAgentId: s
   const defaultMode = modes.find((mode: AcpModeDefinition) => mode.default) ?? modes[0];
   const configuredModels = unique([
     ...modes.map((mode: AcpModeDefinition & { defaultModelId?: string }) => mode.defaultModelId),
-    await modelIdFromMastraAgentApi(apiAgentId, mastraBaseUrl),
     ...configuredModelEnvValues(agentId),
+    await modelIdFromMastraAgentApi(apiAgentId, mastraBaseUrl),
   ]);
   const defaultModelId = configuredModels[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
 
@@ -131,14 +131,14 @@ async function modelIdFromMastraAgentApi(agentId: string | undefined, mastraBase
     const provider = typeof agentConfig.provider === 'string' ? agentConfig.provider.trim() : '';
     const modelId = typeof agentConfig.modelId === 'string' ? agentConfig.modelId.trim() : '';
     if (!modelId) return undefined;
-    return provider && !modelId.includes('/') ? `${provider}/${modelId}` : modelId;
+    return provider && !modelId.startsWith(`${provider}/`) ? `${provider}/${modelId}` : modelId;
   } catch {
     return undefined;
   }
 }
 
 function fallbackRuntimeConfig(agentId: AcpRuntimeAgentId, apiModelId?: string): AcpRuntimeConfig {
-  const models = unique([apiModelId, ...configuredModelEnvValues(agentId)]);
+  const models = unique([...configuredModelEnvValues(agentId), apiModelId]);
   const defaultModelId = models[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
   const fallbackModes: AcpModeDefinition[] = agentId === 'orchestrator'
     ? ['quick', 'precision', 'auto'].map((id) => fallbackMode(agentId, id, id === 'auto'))

--- a/mastra-agents/acp/config-options.ts
+++ b/mastra-agents/acp/config-options.ts
@@ -1,24 +1,25 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk';
 import type { MastraAcpSession } from './types.js';
 
-export const SUPERVISOR_MODE_IDS = ['base','scope','spec','exec'] as const;
-export type SupervisorModeId = typeof SUPERVISOR_MODE_IDS[number];
+export type AcpRuntimeAgentId = 'orchestrator' | 'supervisor';
 
-export const DEFAULT_ACP_MODE_ID: SupervisorModeId = 'base';
-export const DEFAULT_ACP_MODEL_ID =
-  process.env.MASTRA_SUPERVISOR_MODEL?.trim() ||
-  process.env.MASTRA_AGENT_MODEL?.trim() ||
-  process.env.MASTRA_SUBAGENT_MODEL?.trim() ||
-  process.env.MASTRA_MODEL?.trim() ||
-  'minimax-coding-plan/MiniMax-M2.7';
+export type AcpModeDefinition = {
+  id: string;
+  name: string;
+  agentId: AcpRuntimeAgentId;
+  harnessMode: string;
+  harnessModeId: string;
+  default: boolean;
+  prompt: string;
+};
 
-export const AVAILABLE_MODES = [...SUPERVISOR_MODE_IDS];
-export const AVAILABLE_MODELS = [
-  DEFAULT_ACP_MODEL_ID,
-  'gpt-5.3-codex',
-  'gpt-5.3',
-  'gpt-5.1-mini',
-].filter((modelId, index, models) => modelId && models.indexOf(modelId) === index);
+export type AcpRuntimeConfig = {
+  agentId: AcpRuntimeAgentId;
+  modes: AcpModeDefinition[];
+  defaultModeId: string;
+  models: string[];
+  defaultModelId: string;
+};
 
 const modeAliases = new Map<string, SupervisorModeId>([
   ['base', 'base'],
@@ -33,21 +34,187 @@ const modeAliases = new Map<string, SupervisorModeId>([
   ['verify', 'exec'],
 ]);
 
-export function normalizeModeId(value: unknown): SupervisorModeId {
-  if (typeof value !== 'string') return DEFAULT_ACP_MODE_ID;
-  return modeAliases.get(value.trim().toLowerCase().replace(/_/g, '-')) ?? DEFAULT_ACP_MODE_ID;
+type SupervisorModeId = 'base' | 'scope' | 'spec' | 'exec';
+
+const configCache = new Map<string, Promise<AcpRuntimeConfig>>();
+
+export function runtimeAgentIdFromAgentId(agentId: string | undefined): AcpRuntimeAgentId {
+  const normalized = agentId?.trim().toLowerCase().replace(/_/g, '-') ?? '';
+  return normalized.includes('orchestrator') ? 'orchestrator' : 'supervisor';
 }
 
-export function normalizeModelId(value: unknown): string {
-  return typeof value === 'string' && value.trim() ? value.trim() : DEFAULT_ACP_MODEL_ID;
+export function loadAcpRuntimeConfig(agentId: string | undefined, mastraBaseUrl?: string): Promise<AcpRuntimeConfig> {
+  const runtimeAgentId = runtimeAgentIdFromAgentId(agentId);
+  const cacheKey = `${runtimeAgentId}:${mastraBaseUrl ?? ''}`;
+  const existing = configCache.get(cacheKey);
+  if (existing) return existing;
+
+  const config = loadMastraRuntimeConfig(runtimeAgentId, agentId, mastraBaseUrl)
+    .catch(async () => fallbackRuntimeConfig(runtimeAgentId, await modelIdFromMastraAgentApi(agentId, mastraBaseUrl)));
+  configCache.set(cacheKey, config);
+  return config;
 }
 
-export function buildConfigOptions(session: MastraAcpSession): SessionConfigOption[] {
-  const modeId = normalizeModeId(session.modeId);
-  const modelId = normalizeModelId(session.modelId);
+export function normalizeModeId(value: unknown, config: AcpRuntimeConfig): string {
+  if (typeof value !== 'string' || !value.trim()) return config.defaultModeId;
+  const normalized = value.trim().toLowerCase().replace(/_/g, '-');
+  const aliased = config.agentId === 'supervisor' ? modeAliases.get(normalized) : undefined;
+  const requested = aliased ?? normalized.split('.').at(-1) ?? normalized;
+  return config.modes.some((mode) => mode.id === requested) ? requested : config.defaultModeId;
+}
+
+export function normalizeModelId(value: unknown, config: AcpRuntimeConfig): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : config.defaultModelId;
+}
+
+export function modeDefinitionForSession(session: MastraAcpSession, config: AcpRuntimeConfig): AcpModeDefinition {
+  const modeId = normalizeModeId(session.modeId, config);
+  return config.modes.find((mode) => mode.id === modeId) ?? config.modes[0];
+}
+
+export function modelOptionsForSession(session: MastraAcpSession, config: AcpRuntimeConfig): string[] {
+  return unique([normalizeModelId(session.modelId, config), ...config.models]);
+}
+
+export function buildConfigOptions(session: MastraAcpSession, config: AcpRuntimeConfig): SessionConfigOption[] {
+  const modeId = normalizeModeId(session.modeId, config);
+  const modelId = normalizeModelId(session.modelId, config);
   return [
-    { id:'mode', name:'Mode', category:'mode', type:'select', currentValue: modeId, options: AVAILABLE_MODES.map(v=>({value:v,name:v})) },
-    { id:'model', name:'Model', category:'model', type:'select', currentValue: modelId, options: AVAILABLE_MODELS.map(v=>({value:v,name:v})) },
+    { id:'mode', name:'Mode', category:'mode', type:'select', currentValue: modeId, options: config.modes.map(v=>({value:v.id,name:v.name})) },
+    { id:'model', name:'Model', category:'model', type:'select', currentValue: modelId, options: modelOptionsForSession(session, config).map(v=>({value:v,name:v})) },
     { id:'thinking', name:'Thinking', category:'thought_level', type:'select', currentValue: session.thinkingOptionId ?? 'medium', options: ['low','medium','high'].map(v=>({value:v,name:v[0].toUpperCase()+v.slice(1)})) },
   ];
+}
+
+async function loadMastraRuntimeConfig(agentId: AcpRuntimeAgentId, apiAgentId: string | undefined, mastraBaseUrl: string | undefined): Promise<AcpRuntimeConfig> {
+  const harnessModule = await import(new URL('../agents/harness.js', import.meta.url).href);
+  const modes = harnessModule.mastraAgentHarnessModes
+    .filter((mode: { id: string }) => mode.id.startsWith(`${agentId}.`))
+    .map((mode: { id: string; name: string; default?: boolean; defaultModelId?: string }) => {
+      const resolved = harnessModule.resolveMastraAgentHarnessMode({ agentId, harnessMode: mode.id });
+      return {
+        id: resolved.harnessMode,
+        name: mode.name,
+        agentId: resolved.activeAgentId,
+        harnessMode: resolved.harnessMode,
+        harnessModeId: resolved.harnessModeId,
+        default: Boolean(mode.default),
+        prompt: harnessModule.formatMastraAgentHarnessModePrompt(resolved),
+        defaultModelId: mode.defaultModelId,
+      };
+    });
+
+  const defaultMode = modes.find((mode: AcpModeDefinition) => mode.default) ?? modes[0];
+  const configuredModels = unique([
+    ...modes.map((mode: AcpModeDefinition & { defaultModelId?: string }) => mode.defaultModelId),
+    await modelIdFromMastraAgentApi(apiAgentId, mastraBaseUrl),
+    ...configuredModelEnvValues(agentId),
+  ]);
+  const defaultModelId = configuredModels[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
+
+  return {
+    agentId,
+    modes,
+    defaultModeId: defaultMode?.id ?? fallbackRuntimeConfig(agentId).defaultModeId,
+    models: configuredModels.length > 0 ? configuredModels : [defaultModelId],
+    defaultModelId,
+  };
+}
+
+async function modelIdFromMastraAgentApi(agentId: string | undefined, mastraBaseUrl: string | undefined): Promise<string | undefined> {
+  if (!agentId || !mastraBaseUrl) return undefined;
+  try {
+    const baseUrl = mastraBaseUrl.replace(/\/+$/, '');
+    const response = await fetch(`${baseUrl}/api/agents/${encodeURIComponent(agentId)}`);
+    if (!response.ok) return undefined;
+    const agentConfig = await response.json() as { provider?: unknown; modelId?: unknown };
+    const provider = typeof agentConfig.provider === 'string' ? agentConfig.provider.trim() : '';
+    const modelId = typeof agentConfig.modelId === 'string' ? agentConfig.modelId.trim() : '';
+    if (!modelId) return undefined;
+    return provider && !modelId.includes('/') ? `${provider}/${modelId}` : modelId;
+  } catch {
+    return undefined;
+  }
+}
+
+function fallbackRuntimeConfig(agentId: AcpRuntimeAgentId, apiModelId?: string): AcpRuntimeConfig {
+  const models = unique([apiModelId, ...configuredModelEnvValues(agentId)]);
+  const defaultModelId = models[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
+  const fallbackModes: AcpModeDefinition[] = agentId === 'orchestrator'
+    ? ['quick', 'precision', 'auto'].map((id) => fallbackMode(agentId, id, id === 'auto'))
+    : ['base', 'scope', 'spec', 'exec'].map((id, index) => fallbackMode(agentId, id, index === 0));
+  const defaultMode = fallbackModes.find((mode) => mode.default) ?? fallbackModes[0];
+  return {
+    agentId,
+    modes: fallbackModes,
+    defaultModeId: defaultMode.id,
+    models: models.length > 0 ? models : [defaultModelId],
+    defaultModelId,
+  };
+}
+
+function fallbackMode(agentId: AcpRuntimeAgentId, id: string, isDefault: boolean): AcpModeDefinition {
+  const harnessModeId = `${agentId}.${id}`;
+  const prompt = fallbackModePrompt(agentId, id);
+  return {
+    id,
+    name: `${agentId === 'supervisor' ? 'Supervisor Lead' : 'Orchestrator'} / ${fallbackModeName(id)}`,
+    agentId,
+    harnessMode: id,
+    harnessModeId,
+    default: isDefault,
+    prompt: `<harness-mode id="${harnessModeId}" agent="${agentId}" mode="${id}">\n${prompt}\n</harness-mode>`,
+  };
+}
+
+function fallbackModeName(id: string): string {
+  return {
+    base: 'Base',
+    scope: 'Scope',
+    spec: 'Spec',
+    exec: 'Execution',
+    quick: 'Quick',
+    precision: 'Precision',
+    auto: 'Auto',
+  }[id] ?? id;
+}
+
+function fallbackModePrompt(agentId: AcpRuntimeAgentId, id: string): string {
+  if (agentId === 'orchestrator') {
+    return {
+      quick: 'Agent: Orchestrator\nMode: Quick',
+      precision: 'Agent: Orchestrator\nMode: Precision',
+      auto: 'Agent: Orchestrator\nMode: Auto',
+    }[id] ?? `Agent: Orchestrator\nMode: ${id}`;
+  }
+
+  const prompts: Record<string, string> = {
+    base: 'Agent: Supervisor Lead\nMode: Base\nSupervisor Lead Base:\n- Orchestrate the work pragmatically across scoping, planning, building, and verification.\n- Delegate only when a specialist can advance a bounded part of the task.\n- Keep ownership of the final answer, evidence quality, and next action.',
+    scope: 'Agent: Supervisor Lead\nMode: Scope\nSupervisor Lead Scope:\n- Identify the smallest useful slice, non-goals, assumptions, and evidence needed.\n- Route discovery to the right specialist before committing to implementation.\n- Stop for a decision when product scope or write boundaries are unclear.',
+    spec: 'Agent: Supervisor Lead\nMode: Spec\nSupervisor Lead Spec:\n- Convert the scoped slice into a concrete execution plan with boundaries and verification.\n- Use specialists to sharpen contracts, risks, and acceptance criteria.\n- Do not present implementation as complete while still planning.',
+    exec: 'Agent: Supervisor Lead\nMode: Execution\nSupervisor Lead Exec:\n- Drive implementation through the appropriate specialist agents while preserving the approved boundary.\n- Keep build progress tied to concrete files, behavior, and evidence.\n- Escalate if implementation requires a new scope or architecture decision.\n- Audit the completed or claimed work before final synthesis.\n- Require evidence from tests, inspected diffs, snapshot turn/session diffs, tool output, or explicit verification gaps.\n- When a specialist claims it changed code, require snapshot-backed audit evidence unless snapshots are unavailable and that gap is stated.\n- Separate confirmed results from residual risk.',
+  };
+  return prompts[id] ?? `Agent: Supervisor Lead\nMode: ${id}`;
+}
+
+function configuredModelEnvValues(agentId: AcpRuntimeAgentId): string[] {
+  const agentSpecificKeys = agentId === 'orchestrator'
+    ? ['MASTRA_ORCHESTRATE_MODEL', 'MASTRA_CODE_MODEL']
+    : ['MASTRA_SUPERVISOR_MODEL'];
+  return unique([
+    ...agentSpecificKeys.map((key) => process.env[key]),
+    process.env.MASTRA_AGENT_MODEL,
+    process.env.MASTRA_SUBAGENT_MODEL,
+    process.env.MASTRA_MODEL,
+    ...Object.entries(process.env)
+      .filter(([key]) => /^MASTRA_.*MODEL$/.test(key))
+      .map(([, value]) => value),
+  ]);
+}
+
+function unique(values: Array<string | undefined>): string[] {
+  return values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+    .filter((value, index, all) => all.indexOf(value) === index);
 }

--- a/mastra-agents/acp/event-mapper.ts
+++ b/mastra-agents/acp/event-mapper.ts
@@ -16,6 +16,41 @@ export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
   if (type === 'reasoning-delta' || type === 'reasoning') return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: textFrom(chunk) }, _meta: { mastra: { reasoning: chunk } } }];
   if (type === 'finish') return chunk.usage ? [{ sessionUpdate:'usage_update', used: num(chunk.usage,'totalTokens') ?? 0, size: num(chunk.usage,'totalTokens') ?? 0 }] : [];
 
+  if (type === "delegation-event") {
+    const payload = isRecord(chunk.payload) ? chunk.payload : {};
+    const fallbackIdParts = [
+      idPart(payload.delegationId),
+      idPart(payload.runId),
+      idPart(payload.agentRunId),
+      idPart(payload.threadId),
+      idPart(payload.timestamp),
+      idPart(payload.phase),
+      idPart(payload.delegatedAgentId) ?? idPart(payload.delegatedName),
+    ].filter(Boolean);
+    const fallbackId = fallbackIdParts.length > 0 ? `delegation:${fallbackIdParts.join(":")}` : `delegation:${Date.now()}`;
+    const phase = str(payload.phase) ?? "delegation";
+    const status = phase === "delegation_complete" ? (payload.success === false ? "failed" : "completed") : "in_progress";
+    const summary = {
+      target: payload.delegatedAgentId ?? payload.delegatedName,
+      prompt: payload.prompt,
+      response: payload.response,
+      error: payload.error,
+      success: payload.success,
+      durationMs: payload.durationMs,
+    };
+    return [{
+      sessionUpdate: "tool_call_update",
+      toolCallId: str(payload.delegationId) ?? fallbackId,
+      status,
+      title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? "delegation",
+      kind: "other",
+      rawInput: payload.prompt,
+      rawOutput: payload.response ?? payload.error,
+      content: [{ type: "content", content: { type: "text", text: JSON.stringify(summary) } }],
+      _meta: { mastra: chunk },
+    }];
+  }
+
   if (type?.startsWith('tool-')) {
     const p = isRecord(chunk.payload) ? chunk.payload : chunk;
     const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : (type === 'tool-call-input-streaming-start' ? 'in_progress' : 'pending');
@@ -37,5 +72,11 @@ export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
 
 const isRecord = (v: unknown): v is Record<string, any> => typeof v === 'object' && !!v;
 const str = (v: unknown) => (typeof v === 'string' ? v : undefined);
+const idPart = (v: unknown) => {
+  if (typeof v === 'string') return v.length > 0 ? v : undefined;
+  if (typeof v === 'number') return Number.isFinite(v) ? String(v) : undefined;
+  if (typeof v === 'boolean') return String(v);
+  return undefined;
+};
 const textFrom = (c: Record<string, any>) => str(c.text) ?? str(c.delta) ?? str(c.payload?.text) ?? '';
 const num = (o: any, k: string) => (typeof o?.[k] === 'number' ? o[k] : undefined);

--- a/mastra-agents/acp/mastra-stream.ts
+++ b/mastra-agents/acp/mastra-stream.ts
@@ -1,7 +1,44 @@
 function normalizeBaseUrl(baseUrl?: string): string { return (baseUrl ?? 'http://localhost:4111').replace(/\/+$/, ''); }
 async function* parseSse(stream: ReadableStream<Uint8Array>) { const d=new TextDecoder(); let b=''; for await (const c of stream){ b+=d.decode(c,{stream:true}); let i; while((i=b.indexOf('\n\n'))!==-1){const blk=b.slice(0,i); b=b.slice(i+2); const data=blk.split('\n').filter(l=>l.startsWith('data:')).map(l=>l.slice(5).trimStart()).join('\n'); if(data) yield data;}} }
+
 export async function* streamMastraAgent(baseUrl: string | undefined, agentId: string, payload: unknown, signal?: AbortSignal): AsyncGenerator<unknown> {
-  const response = await fetch(`${normalizeBaseUrl(baseUrl)}/api/agents/${agentId}/stream`, { method:'POST', headers:{accept:'text/event-stream','content-type':'application/json'}, body:JSON.stringify(payload), signal });
-  if (!response.ok || !response.body) throw new Error(`Mastra stream failed: ${response.status} ${response.statusText}`);
-  for await (const data of parseSse(response.body)) { if (data === '[DONE]') return; yield JSON.parse(data); }
+  const url = `${normalizeBaseUrl(baseUrl)}/api/agents/${encodeURIComponent(agentId)}/stream`;
+  let response: Response;
+  try {
+    response = await fetch(url, { method:'POST', headers:{accept:'text/event-stream','content-type':'application/json'}, body:JSON.stringify(payload), signal });
+  } catch (error) {
+    throw new Error(`Mastra stream request failed for ${url}: ${errorMessage(error)}`);
+  }
+
+  if (!response.ok || !response.body) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Mastra stream failed for ${url}: ${response.status} ${response.statusText}${body ? ` - ${body.slice(0, 500)}` : ''}`);
+  }
+
+  for await (const data of parseSse(response.body)) {
+    if (data === '[DONE]') return;
+    const chunk = JSON.parse(data);
+    const streamError = mastraErrorMessage(chunk);
+    if (streamError) throw new Error(`Mastra stream error: ${streamError}`);
+    yield chunk;
+  }
+}
+
+function mastraErrorMessage(chunk: unknown): string | undefined {
+  if (!isRecord(chunk) || chunk.type !== 'error') return undefined;
+  const payload = isRecord(chunk.payload) ? chunk.payload : undefined;
+  const error = isRecord(payload?.error) ? payload.error : isRecord(chunk.error) ? chunk.error : undefined;
+  return str(error?.message) ?? str(payload?.message) ?? str(chunk.message) ?? 'Unknown Mastra stream error';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
 }

--- a/mastra-agents/acp/session-store.ts
+++ b/mastra-agents/acp/session-store.ts
@@ -1,11 +1,18 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { DEFAULT_ACP_MODE_ID, DEFAULT_ACP_MODEL_ID } from './config-options.js';
 import type { MastraAcpSession } from './types.js';
 
 export class MastraAcpSessionStore {
   private readonly sessions = new Map<string, MastraAcpSession>();
 
-  create(params: { sessionId?: string; agentId: string; cwd: string; resourceId?: string; threadId?: string }): MastraAcpSession {
+  create(params: {
+    sessionId?: string;
+    agentId: string;
+    cwd: string;
+    resourceId?: string;
+    threadId?: string;
+    defaultModeId: string;
+    defaultModelId: string;
+  }): MastraAcpSession {
     const sessionId = params.sessionId ?? randomUUID();
     const now = new Date().toISOString();
     const session: MastraAcpSession = {
@@ -14,8 +21,8 @@ export class MastraAcpSessionStore {
       cwd: params.cwd,
       resourceId: params.resourceId ?? `acp:${shortHash(params.cwd)}`,
       threadId: params.threadId ?? `acp:${sessionId}:${params.agentId}`,
-      modeId: DEFAULT_ACP_MODE_ID,
-      modelId: DEFAULT_ACP_MODEL_ID,
+      modeId: params.defaultModeId,
+      modelId: params.defaultModelId,
       thinkingOptionId: 'medium',
       createdAt: now,
       updatedAt: now,

--- a/mastra-agents/acp/session-store.ts
+++ b/mastra-agents/acp/session-store.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { DEFAULT_ACP_MODE_ID, DEFAULT_ACP_MODEL_ID } from './config-options.js';
 import type { MastraAcpSession } from './types.js';
 
 export class MastraAcpSessionStore {
@@ -13,6 +14,9 @@ export class MastraAcpSessionStore {
       cwd: params.cwd,
       resourceId: params.resourceId ?? `acp:${shortHash(params.cwd)}`,
       threadId: params.threadId ?? `acp:${sessionId}:${params.agentId}`,
+      modeId: DEFAULT_ACP_MODE_ID,
+      modelId: DEFAULT_ACP_MODEL_ID,
+      thinkingOptionId: 'medium',
       createdAt: now,
       updatedAt: now,
     };

--- a/mastra-agents/acp/stdio.ts
+++ b/mastra-agents/acp/stdio.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import { AgentSideConnection, ndJsonStream } from '@agentclientprotocol/sdk';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { Readable, Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
 import { createMastraAcpAgent } from './index.js';
 
 interface CliOptions {
@@ -34,10 +37,65 @@ function readCliOptions(argv: string[], env: NodeJS.ProcessEnv): CliOptions {
   return options;
 }
 
+function unquoteEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const quote = trimmed[0];
+  if ((quote !== '"' && quote !== "'") || trimmed.at(-1) !== quote) return trimmed;
+  const body = trimmed.slice(1, -1);
+  return quote === '"' ? body.replace(/\\n/g, '\n').replace(/\\"/g, '"') : body;
+}
+
+function parseEnvFile(filePath: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  if (!existsSync(filePath)) return values;
+
+  for (const rawLine of readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const assignment = line.startsWith('export ') ? line.slice(7).trim() : line;
+    const equalsIndex = assignment.indexOf('=');
+    if (equalsIndex <= 0) continue;
+
+    const key = assignment.slice(0, equalsIndex).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    values[key] = unquoteEnvValue(assignment.slice(equalsIndex + 1));
+  }
+
+  return values;
+}
+
+function mergeNonEmpty(...sources: Array<Record<string, string>>): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const source of sources) {
+    for (const [key, value] of Object.entries(source)) {
+      if (value === '' && merged[key]) continue;
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+function loadProjectEnv(options: CliOptions): void {
+  const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const fileEnv = mergeNonEmpty(
+    parseEnvFile(path.join(options.cwd, '.env')),
+    parseEnvFile(path.join(packageRoot, '.env')),
+  );
+
+  for (const [key, value] of Object.entries(fileEnv)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+const options = readCliOptions(process.argv.slice(2), process.env);
+loadProjectEnv(options);
+
 const output = Writable.toWeb(process.stdout);
 const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
 const stream = ndJsonStream(output, input);
-const agent = createMastraAcpAgent(readCliOptions(process.argv.slice(2), process.env));
+const agent = createMastraAcpAgent(options);
 const connection = new AgentSideConnection(agent, stream);
 
 await connection.closed;

--- a/mastra-agents/acp/thinking-options.ts
+++ b/mastra-agents/acp/thinking-options.ts
@@ -5,6 +5,7 @@ export type ThinkingMetadata =
       requestedLevel: ThinkingLevel;
       status: 'applied';
       provider: string;
+      strategy: 'provider_options' | 'model_name_suffix';
       providerOptionPath: string;
       providerOptionValue: unknown;
     }
@@ -21,9 +22,29 @@ export type ThinkingMetadata =
     };
 
 export type ThinkingProviderOptionsResult = {
+  modelId?: string;
   providerOptions?: Record<string, unknown>;
   metadata: ThinkingMetadata;
 };
+
+type ThinkingLevelAdapter = {
+  provider: string;
+  strategy: 'provider_options' | 'model_name_suffix';
+  supportsModel: (modelId: string) => boolean;
+};
+
+const thinkingLevelAdapters: ThinkingLevelAdapter[] = [
+  {
+    provider: 'openai',
+    strategy: 'provider_options',
+    supportsModel: isOpenAiReasoningModel,
+  },
+  {
+    provider: 'proxy',
+    strategy: 'model_name_suffix',
+    supportsModel: isOpenAiReasoningModel,
+  },
+];
 
 export function resolveThinkingProviderOptions({
   modelId,
@@ -52,7 +73,8 @@ export function resolveThinkingProviderOptions({
   }
 
   const provider = providerFromModelId(modelId);
-  if (provider === 'openai' && isOpenAiReasoningModel(modelId)) {
+  const adapter = thinkingLevelAdapters.find((candidate) => candidate.provider === provider && candidate.supportsModel(modelId));
+  if (adapter?.strategy === 'provider_options') {
     return {
       providerOptions: {
         openai: {
@@ -63,8 +85,23 @@ export function resolveThinkingProviderOptions({
         requestedLevel: normalizedLevel,
         status: 'applied',
         provider,
+        strategy: adapter.strategy,
         providerOptionPath: 'providerOptions.openai.reasoningEffort',
         providerOptionValue: normalizedLevel,
+      },
+    };
+  }
+  if (adapter?.strategy === 'model_name_suffix') {
+    const effectiveModelId = appendThinkingLevelSuffix(modelId, normalizedLevel);
+    return {
+      modelId: effectiveModelId,
+      metadata: {
+        requestedLevel: normalizedLevel,
+        status: 'applied',
+        provider,
+        strategy: adapter.strategy,
+        providerOptionPath: 'model',
+        providerOptionValue: effectiveModelId,
       },
     };
   }
@@ -97,7 +134,7 @@ function providerFromModelId(modelId: string): string {
 }
 
 function isOpenAiReasoningModel(modelId: string): boolean {
-  const modelName = modelNameFromModelId(modelId.trim().toLowerCase());
+  const modelName = stripThinkingLevelSuffix(modelNameFromModelId(modelId.trim().toLowerCase()));
   return (
     modelName.startsWith('gpt-5') ||
     /^o\d/.test(modelName)
@@ -106,4 +143,12 @@ function isOpenAiReasoningModel(modelId: string): boolean {
 
 function modelNameFromModelId(modelId: string): string {
   return modelId.includes('/') ? modelId.split('/').at(-1) ?? modelId : modelId;
+}
+
+function appendThinkingLevelSuffix(modelId: string, thinkingLevel: ThinkingLevel): string {
+  return `${stripThinkingLevelSuffix(modelId.trim())}(${thinkingLevel})`;
+}
+
+function stripThinkingLevelSuffix(modelId: string): string {
+  return modelId.replace(/\([^()/]*\)\s*$/, '');
 }

--- a/mastra-agents/acp/thinking-options.ts
+++ b/mastra-agents/acp/thinking-options.ts
@@ -1,0 +1,109 @@
+export type ThinkingLevel = 'low' | 'medium' | 'high';
+
+export type ThinkingMetadata =
+  | {
+      requestedLevel: ThinkingLevel;
+      status: 'applied';
+      provider: string;
+      providerOptionPath: string;
+      providerOptionValue: unknown;
+    }
+  | {
+      requestedLevel?: string;
+      status: 'omitted' | 'invalid_level';
+      reason: string;
+    }
+  | {
+      requestedLevel: ThinkingLevel;
+      status: 'unsupported_provider';
+      provider: string;
+      reason: string;
+    };
+
+export type ThinkingProviderOptionsResult = {
+  providerOptions?: Record<string, unknown>;
+  metadata: ThinkingMetadata;
+};
+
+export function resolveThinkingProviderOptions({
+  modelId,
+  thinkingLevel,
+}: {
+  modelId: string;
+  thinkingLevel?: string;
+}): ThinkingProviderOptionsResult {
+  const normalizedLevel = normalizeThinkingLevel(thinkingLevel);
+  if (!thinkingLevel?.trim()) {
+    return {
+      metadata: {
+        status: 'omitted',
+        reason: 'No ACP thinking level was selected',
+      },
+    };
+  }
+  if (!normalizedLevel) {
+    return {
+      metadata: {
+        requestedLevel: thinkingLevel,
+        status: 'invalid_level',
+        reason: `Unknown ACP thinking level ${thinkingLevel}`,
+      },
+    };
+  }
+
+  const provider = providerFromModelId(modelId);
+  if (provider === 'openai' && isOpenAiReasoningModel(modelId)) {
+    return {
+      providerOptions: {
+        openai: {
+          reasoningEffort: normalizedLevel,
+        },
+      },
+      metadata: {
+        requestedLevel: normalizedLevel,
+        status: 'applied',
+        provider,
+        providerOptionPath: 'providerOptions.openai.reasoningEffort',
+        providerOptionValue: normalizedLevel,
+      },
+    };
+  }
+
+  return {
+    metadata: {
+      requestedLevel: normalizedLevel,
+      status: 'unsupported_provider',
+      provider,
+      reason: `No ACP thinking mapping is defined for provider ${provider}`,
+    },
+  };
+}
+
+function normalizeThinkingLevel(value: string | undefined): ThinkingLevel | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === 'low' || normalized === 'medium' || normalized === 'high') return normalized;
+  return undefined;
+}
+
+function providerFromModelId(modelId: string): string {
+  const normalized = modelId.trim().toLowerCase();
+  if (normalized.includes('/')) return normalized.split('/')[0] || 'unknown';
+  const modelName = modelNameFromModelId(normalized);
+  if (modelName.startsWith('gpt-') || /^o\d/.test(modelName)) return 'openai';
+  if (modelName.startsWith('claude-')) return 'anthropic';
+  if (modelName.startsWith('gemini-') || modelName.startsWith('gemma-')) return 'google';
+  if (modelName.startsWith('grok-')) return 'xai';
+  return 'unknown';
+}
+
+function isOpenAiReasoningModel(modelId: string): boolean {
+  const modelName = modelNameFromModelId(modelId.trim().toLowerCase());
+  return (
+    modelName.startsWith('gpt-5') ||
+    /^o\d/.test(modelName)
+  );
+}
+
+function modelNameFromModelId(modelId: string): string {
+  return modelId.includes('/') ? modelId.split('/').at(-1) ?? modelId : modelId;
+}

--- a/mastra-agents/docs/linear-webhook-issue.md
+++ b/mastra-agents/docs/linear-webhook-issue.md
@@ -1,0 +1,77 @@
+# Linear Channel Webhook Issue — Orchestrator & Supervisor Agent
+
+## Problem Statement
+
+The Linear webhook endpoint (`/api/agents/{agentId}/channels/linear/webhook`) returns **404 Not Found** despite having a valid `LINEAR_API_KEY` and `LINEAR_WEBHOOK_SECRET` configured.
+
+## Root Cause
+
+### 1. Channels assigned post-construction (original bug)
+
+In `src/agents/agent.ts`, channels were assigned **after** the `Agent` constructor finished:
+
+```typescript
+(orchestratorAgent as typeof orchestratorAgent & { channels?: unknown }).channels = createSupervisorChannelsConfig();
+```
+
+Mastra's `Agent` class reads `config.channels` **only during construction** into a private `#agentChannels` field. Post-construction assignment does **not** update the internal field, so `agent.getChannels()` returns `null` and Mastra never registers webhook routes.
+
+### 2. Constructor fix and agent-owned URLs
+
+We moved `buildAgentChannels()` into the `Agent` constructor for both `orchestratorAgent` and `supervisorAgent`:
+
+```typescript
+export const orchestratorAgent = withAgentModes(new Agent({
+  id: "orchestrator-agent",
+  channels: buildAgentChannels(), // ← now in constructor
+  ...
+}), ...);
+```
+
+The dev server logs should confirm:
+- `AgentChannels` initializes successfully
+- Linear auth completes (`botUserId`, `organizationId` populated)
+- Chat SDK reports: `Chat instance initialized { adapters: [ 'linear' ] }`
+
+Mastra owns the generated channel handlers from the agent constructor. In this dev server line, those generated routes must also be passed into `server.apiRoutes` early and marked `_mastraInternal` so the server accepts the `/api` path. Do not rewrite URLs or add a custom middleware bridge. Each configured agent owns its own route:
+
+- `/api/agents/orchestrator-agent/channels/linear/webhook`
+- `/api/agents/supervisor-agent/channels/linear/webhook`
+
+With the current local env, Slack and GitHub stay disabled unless `ENABLE_SLACK_CHANNEL=true` or `ENABLE_GITHUB_CHANNEL=true`; Linear is enabled when `LINEAR_WEBHOOK_SECRET` and Linear auth are present.
+
+## Files Changed
+
+- `src/agents/channels.ts` — new generic `buildAgentChannels()` factory
+- `src/agents/channels.ts` — exposes `channelWebhookApiRoutesForAgents()` to pass Mastra-generated internal routes into server startup
+- `src/agents/orchestrator-agent.ts` — added `channels: buildAgentChannels()` to constructor
+- `src/agents/agent.ts` — removed broken post-construction assignment; added `channels: buildAgentChannels()` to `supervisorAgent`
+- `src/mastra/index.ts` — registers the generated channel routes during server construction
+- `package.json` — updated `mastra` to `1.8.1` and `@mastra/core` to `1.32.1`
+
+## Environment Config (verified)
+
+```bash
+LINEAR_WEBHOOK_SECRET=lin_wh_...
+LINEAR_API_KEY=lin_api_...
+LINEAR_CHANNEL_MODE=comments
+CLOUDFLARE_WEBHOOK_PUBLIC_URL=https://webb.renaissancelab.org
+```
+
+## Open Questions / Next Steps
+
+1. **Full restart**: Restart `npm run dev` on port 4111 after changing constructor-level channel config.
+
+2. **Linear-only verification**: With Slack/GitHub disabled, verify only:
+   - `/api/agents/orchestrator-agent/channels/linear/webhook`
+   - `/api/agents/supervisor-agent/channels/linear/webhook`
+
+3. **Route ownership**: Select the agent-specific URL in Linear based on which agent should handle the event. Do not share one custom handler across agents.
+
+4. **Expected probe result**: Unsigned local probe requests should return `400 Missing webhook signature`, not `404 Not Found`.
+
+## References
+
+- Mastra docs: channels must be passed in constructor — https://mastra.ai/docs/agents/channels
+- PR #14642: agent-level chat channels via Chat SDK adapters — https://github.com/mastra-ai/mastra/pull/14642
+- `AgentChannels.getWebhookRoutes()` generates `POST /api/agents/{agentId}/channels/{platform}/webhook`

--- a/mastra-agents/package.json
+++ b/mastra-agents/package.json
@@ -12,7 +12,7 @@
     "acp:smoke": "node src/acp/smoke-client.js",
     "dev": "node scripts/with-env.mjs mastra dev",
     "build": "node scripts/with-env.mjs mastra build",
-    "test": "node --test \"test/**/*.test.js\"",
+    "test": "node --test \"src/**/*.test.js\" \"test/**/*.test.js\"",
     "start": "node scripts/with-env.mjs mastra start",
     "studio": "node scripts/with-env.mjs node scripts/run-studio.mjs"
   },

--- a/mastra-agents/package.json
+++ b/mastra-agents/package.json
@@ -11,6 +11,7 @@
     "acp:build": "tsc --ignoreConfig --target ESNext --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --types node --rootDir acp --outDir src/acp --declaration acp/*.ts",
     "acp:smoke": "node src/acp/smoke-client.js",
     "dev": "node scripts/with-env.mjs mastra dev",
+    "linear:install-url": "node scripts/linear-install-url.mjs",
     "build": "node scripts/with-env.mjs mastra build",
     "test": "node --test \"src/**/*.test.js\" \"test/**/*.test.js\"",
     "start": "node scripts/with-env.mjs mastra start",
@@ -18,11 +19,13 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.21.0",
+    "@ai-sdk/openai-compatible": "1.0.39",
     "@chat-adapter/github": "^4.27.0",
     "@chat-adapter/linear": "^4.27.0",
     "@chat-adapter/slack": "^4.27.0",
+    "@chat-adapter/state-pg": "^4.27.0",
     "@daytona/sdk": "0.169.0",
-    "@mastra/core": "1.28.0",
+    "@mastra/core": "1.32.1",
     "@mastra/daytona": "0.3.0",
     "@mastra/duckdb": "1.2.0",
     "@mastra/editor": "0.7.19",
@@ -38,7 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "mastra": "1.6.3",
+    "mastra": "1.8.1",
     "typescript": "^6.0.3"
   }
 }

--- a/mastra-agents/scripts/linear-install-url.mjs
+++ b/mastra-agents/scripts/linear-install-url.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const defaultScopes = [
+  "read",
+  "write",
+  "comments:create",
+  "issues:create",
+  "app:mentionable",
+  "app:assignable",
+];
+
+function env(name) {
+  return process.env[name]?.trim();
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const quote = trimmed[0];
+  if ((quote !== `"` && quote !== `'`) || trimmed.at(-1) !== quote) return trimmed;
+  const body = trimmed.slice(1, -1);
+  return quote === `"` ? body.replace(/\\n/g, "\n").replace(/\\"/g, `"`) : body;
+}
+
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) return;
+
+  for (const rawLine of readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const assignment = line.startsWith("export ") ? line.slice(7).trim() : line;
+    const equalsIndex = assignment.indexOf("=");
+    if (equalsIndex <= 0) continue;
+
+    const key = assignment.slice(0, equalsIndex).trim();
+    if (process.env[key]) continue;
+    process.env[key] = unquote(assignment.slice(equalsIndex + 1));
+  }
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(packageRoot, "..");
+loadEnvFile(path.join(repoRoot, ".env"));
+loadEnvFile(path.join(packageRoot, ".env"));
+
+const clientId = env("LINEAR_CLIENT_ID");
+const redirectUri = env("LINEAR_REDIRECT_URI");
+const scopes = (env("LINEAR_OAUTH_SCOPES") || defaultScopes.join(","))
+  .split(",")
+  .map((scope) => scope.trim())
+  .filter(Boolean);
+
+const missing = [
+  ...(!clientId ? ["LINEAR_CLIENT_ID"] : []),
+  ...(!redirectUri ? ["LINEAR_REDIRECT_URI"] : []),
+];
+
+if (missing.length > 0) {
+  console.error(`Missing required Linear OAuth env: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+const params = new URLSearchParams({
+  client_id: clientId,
+  redirect_uri: redirectUri,
+  response_type: "code",
+  scope: scopes.join(","),
+  actor: "app",
+});
+
+console.log(`https://linear.app/oauth/authorize?${params.toString()}`);

--- a/mastra-agents/src/acp/adapter.js
+++ b/mastra-agents/src/acp/adapter.js
@@ -1,10 +1,11 @@
-import { buildConfigOptions, AVAILABLE_MODELS, AVAILABLE_MODES, normalizeModeId, normalizeModelId } from './config-options.js';
+import { buildConfigOptions, loadAcpRuntimeConfig, modeDefinitionForSession, modelOptionsForSession, normalizeModeId, normalizeModelId } from './config-options.js';
 import { mapMastraChunkToUpdates } from './event-mapper.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
 import { getSlashCommands } from './slash-commands.js';
 export function createMastraAcpAgentHandler(conn, options) {
     const store = new MastraAcpSessionStore();
+    const runtimeConfig = () => loadAcpRuntimeConfig(options.agentId, options.mastraBaseUrl);
     return {
         async initialize(_params) {
             return {
@@ -18,11 +19,20 @@ export function createMastraAcpAgentHandler(conn, options) {
             };
         },
         async newSession(_params) {
-            const session = store.create({ agentId: options.agentId, cwd: options.cwd, resourceId: options.defaultResourceId, threadId: options.defaultThreadId });
+            const config = await runtimeConfig();
+            const session = store.create({
+                agentId: options.agentId,
+                cwd: options.cwd,
+                resourceId: options.defaultResourceId,
+                threadId: options.defaultThreadId,
+                defaultModeId: config.defaultModeId,
+                defaultModelId: config.defaultModelId,
+            });
             await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'available_commands_update', availableCommands: getSlashCommands() } });
-            return sessionStateResponse(session);
+            return sessionStateResponse(session, config);
         },
         async prompt(params) {
+            const config = await runtimeConfig();
             const session = store.get(params.sessionId);
             if (!session)
                 throw new Error(`Unknown session: ${params.sessionId}`);
@@ -31,7 +41,7 @@ export function createMastraAcpAgentHandler(conn, options) {
             const ac = new AbortController();
             session.abortController = ac;
             store.update(session);
-            for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content), ac.signal)) {
+            for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content, config), ac.signal)) {
                 for (const update of mapMastraChunkToUpdates(chunk)) {
                     await conn.sessionUpdate({ sessionId: session.sessionId, update });
                 }
@@ -41,76 +51,79 @@ export function createMastraAcpAgentHandler(conn, options) {
         async cancel(params) { const s = store.get(params.sessionId); s?.abortController?.abort(); },
         async closeSession(params) { store.delete(params.sessionId); },
         async setSessionMode(params) {
+            const config = await runtimeConfig();
             const s = store.get(params.sessionId);
             if (!s)
                 throw new Error(`Unknown session: ${params.sessionId}`);
-            s.modeId = normalizeModeId(params.modeId);
+            s.modeId = normalizeModeId(params.modeId, config);
             store.update(s);
-            await emitSessionConfigUpdate(conn, s, true);
+            await emitSessionConfigUpdate(conn, s, config, true);
             return {};
         },
         async unstable_setSessionModel(params) {
+            const config = await runtimeConfig();
             const s = store.get(params.sessionId);
             if (!s)
                 throw new Error(`Unknown session: ${params.sessionId}`);
-            s.modelId = normalizeModelId(params.modelId);
+            s.modelId = normalizeModelId(params.modelId, config);
             store.update(s);
-            await emitSessionConfigUpdate(conn, s, false);
+            await emitSessionConfigUpdate(conn, s, config, false);
             return {};
         },
         async setSessionConfigOption(params) {
+            const config = await runtimeConfig();
             const s = store.get(params.sessionId);
             if (!s)
                 throw new Error(`Unknown session: ${params.sessionId}`);
             let modeChanged = false;
             if (typeof params.value === 'string') {
                 if (params.configId === 'mode') {
-                    s.modeId = normalizeModeId(params.value);
+                    s.modeId = normalizeModeId(params.value, config);
                     modeChanged = true;
                 }
                 if (params.configId === 'model')
-                    s.modelId = normalizeModelId(params.value);
+                    s.modelId = normalizeModelId(params.value, config);
                 if (params.configId === 'thinking')
                     s.thinkingOptionId = params.value;
             }
             store.update(s);
-            const configOptions = buildConfigOptions(s);
-            await emitSessionConfigUpdate(conn, s, modeChanged);
+            const configOptions = buildConfigOptions(s, config);
+            await emitSessionConfigUpdate(conn, s, config, modeChanged);
             return { configOptions };
         },
         async authenticate() { },
     };
 }
-function sessionStateResponse(session) {
-    const modeId = normalizeModeId(session.modeId);
-    const modelId = normalizeModelId(session.modelId);
+function sessionStateResponse(session, config) {
+    const modeId = normalizeModeId(session.modeId, config);
+    const modelId = normalizeModelId(session.modelId, config);
     return {
         sessionId: session.sessionId,
         modes: {
-            availableModes: AVAILABLE_MODES.map(id => ({ id, name: id })),
+            availableModes: config.modes.map(mode => ({ id: mode.id, name: mode.name })),
             currentModeId: modeId,
         },
         models: {
-            availableModels: AVAILABLE_MODELS.map(modelId => ({ modelId, name: modelId })),
+            availableModels: modelOptionsForSession(session, config).map(modelId => ({ modelId, name: modelId })),
             currentModelId: modelId,
         },
-        configOptions: buildConfigOptions(session),
+        configOptions: buildConfigOptions(session, config),
     };
 }
-async function emitSessionConfigUpdate(conn, session, modeChanged) {
-    const modeId = normalizeModeId(session.modeId);
-    const configOptions = buildConfigOptions(session);
+async function emitSessionConfigUpdate(conn, session, config, modeChanged) {
+    const modeId = normalizeModeId(session.modeId, config);
+    const configOptions = buildConfigOptions(session, config);
     if (modeChanged) {
         await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'current_mode_update', currentModeId: modeId } });
     }
     await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'config_option_update', configOptions } });
 }
-function buildPromptPayload(session, content) {
-    const modeId = normalizeModeId(session.modeId);
-    const modelId = normalizeModelId(session.modelId);
-    const harnessModeId = `supervisor.${modeId}`;
+function buildPromptPayload(session, content, config) {
+    const mode = modeDefinitionForSession(session, config);
+    const modeId = mode.id;
+    const modelId = normalizeModelId(session.modelId, config);
     return {
-        messages: [{ role: 'user', content: `${formatSupervisorScopePrompt(modeId)}\n\n${content}` }],
+        messages: [{ role: 'user', content: `${mode.prompt}\n\n${content}` }],
         memory: { thread: session.threadId, resource: session.resourceId },
         model: modelId,
         requestContext: {
@@ -121,22 +134,13 @@ function buildPromptPayload(session, content) {
                 modelId,
                 thinkingOptionId: session.thinkingOptionId,
             },
-            activeAgentId: 'supervisor',
+            activeAgentId: mode.agentId,
             modeId,
             modelId,
-            harnessMode: modeId,
-            harnessModeId,
-            hardnessMode: harnessModeId,
-            supervisorScope: modeId,
+            harnessMode: mode.harnessMode,
+            harnessModeId: mode.harnessModeId,
+            hardnessMode: mode.harnessModeId,
+            ...(mode.agentId === 'supervisor' ? { supervisorScope: mode.harnessMode } : { orchestratorMode: mode.harnessMode }),
         },
     };
-}
-function formatSupervisorScopePrompt(modeId) {
-    const prompt = {
-        base: 'Supervisor Lead Base:\n- Orchestrate the work pragmatically across scoping, planning, building, and verification.\n- Delegate only when a specialist can advance a bounded part of the task.\n- Keep ownership of the final answer, evidence quality, and next action.',
-        scope: 'Supervisor Lead Scope:\n- Identify the smallest useful slice, non-goals, assumptions, and evidence needed.\n- Route discovery to the right specialist before committing to implementation.\n- Stop for a decision when product scope or write boundaries are unclear.',
-        spec: 'Supervisor Lead Spec:\n- Convert the scoped slice into a concrete execution plan with boundaries and verification.\n- Use specialists to sharpen contracts, risks, and acceptance criteria.\n- Do not present implementation as complete while still planning.',
-        exec: 'Supervisor Lead Exec:\n- Drive implementation through the appropriate specialist agents while preserving the approved boundary.\n- Keep build progress tied to concrete files, behavior, and evidence.\n- Escalate if implementation requires a new scope or architecture decision.\n- Audit the completed or claimed work before final synthesis.',
-    };
-    return `<harness-mode id="supervisor.${modeId}" agent="supervisor" mode="${modeId}">\nAgent: Supervisor Lead\nMode: ${modeId}\n${prompt[modeId]}\n</harness-mode>`;
 }

--- a/mastra-agents/src/acp/adapter.js
+++ b/mastra-agents/src/acp/adapter.js
@@ -3,6 +3,7 @@ import { mapMastraChunkToUpdates } from './event-mapper.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
 import { getSlashCommands } from './slash-commands.js';
+import { resolveThinkingProviderOptions } from './thinking-options.js';
 export function createMastraAcpAgentHandler(conn, options) {
     const store = new MastraAcpSessionStore();
     const runtimeConfig = () => loadAcpRuntimeConfig(options.agentId, options.mastraBaseUrl);
@@ -122,10 +123,12 @@ function buildPromptPayload(session, content, config) {
     const mode = modeDefinitionForSession(session, config);
     const modeId = mode.id;
     const modelId = normalizeModelId(session.modelId, config);
+    const thinkingOptions = resolveThinkingProviderOptions({ modelId, thinkingLevel: session.thinkingOptionId });
     return {
         messages: [{ role: 'user', content: `${mode.prompt}\n\n${content}` }],
         memory: { thread: session.threadId, resource: session.resourceId },
         model: modelId,
+        ...(thinkingOptions.providerOptions ? { providerOptions: thinkingOptions.providerOptions } : {}),
         requestContext: {
             acp: {
                 sessionId: session.sessionId,
@@ -133,6 +136,7 @@ function buildPromptPayload(session, content, config) {
                 modeId,
                 modelId,
                 thinkingOptionId: session.thinkingOptionId,
+                thinking: thinkingOptions.metadata,
             },
             activeAgentId: mode.agentId,
             modeId,

--- a/mastra-agents/src/acp/adapter.js
+++ b/mastra-agents/src/acp/adapter.js
@@ -1,4 +1,4 @@
-import { buildConfigOptions, AVAILABLE_MODELS, AVAILABLE_MODES } from './config-options.js';
+import { buildConfigOptions, AVAILABLE_MODELS, AVAILABLE_MODES, normalizeModeId, normalizeModelId } from './config-options.js';
 import { mapMastraChunkToUpdates } from './event-mapper.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
@@ -20,7 +20,7 @@ export function createMastraAcpAgentHandler(conn, options) {
         async newSession(_params) {
             const session = store.create({ agentId: options.agentId, cwd: options.cwd, resourceId: options.defaultResourceId, threadId: options.defaultThreadId });
             await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'available_commands_update', availableCommands: getSlashCommands() } });
-            return { sessionId: session.sessionId, modes: { availableModes: AVAILABLE_MODES.map(id => ({ id, name: id })), currentModeId: session.modeId ?? 'balanced' }, models: { availableModels: AVAILABLE_MODELS.map(modelId => ({ modelId, name: modelId })), currentModelId: session.modelId ?? AVAILABLE_MODELS[0] }, configOptions: buildConfigOptions(session) };
+            return sessionStateResponse(session);
         },
         async prompt(params) {
             const session = store.get(params.sessionId);
@@ -31,7 +31,7 @@ export function createMastraAcpAgentHandler(conn, options) {
             const ac = new AbortController();
             session.abortController = ac;
             store.update(session);
-            for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, { messages: [{ role: 'user', content }], memory: { thread: session.threadId, resource: session.resourceId }, requestContext: { acp: { sessionId: session.sessionId, cwd: session.cwd, modeId: session.modeId, modelId: session.modelId, thinkingOptionId: session.thinkingOptionId }, modeId: session.modeId, harnessMode: session.modeId } }, ac.signal)) {
+            for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content), ac.signal)) {
                 for (const update of mapMastraChunkToUpdates(chunk)) {
                     await conn.sessionUpdate({ sessionId: session.sessionId, update });
                 }
@@ -44,38 +44,99 @@ export function createMastraAcpAgentHandler(conn, options) {
             const s = store.get(params.sessionId);
             if (!s)
                 throw new Error(`Unknown session: ${params.sessionId}`);
-            s.modeId = params.modeId;
+            s.modeId = normalizeModeId(params.modeId);
             store.update(s);
-            await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'current_mode_update', currentModeId: s.modeId ?? 'balanced' } });
-            await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'config_option_update', configOptions: buildConfigOptions(s) } });
+            await emitSessionConfigUpdate(conn, s, true);
             return {};
         },
         async unstable_setSessionModel(params) {
             const s = store.get(params.sessionId);
             if (!s)
                 throw new Error(`Unknown session: ${params.sessionId}`);
-            s.modelId = params.modelId;
+            s.modelId = normalizeModelId(params.modelId);
             store.update(s);
-            await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'config_option_update', configOptions: buildConfigOptions(s) } });
+            await emitSessionConfigUpdate(conn, s, false);
             return {};
         },
         async setSessionConfigOption(params) {
             const s = store.get(params.sessionId);
             if (!s)
                 throw new Error(`Unknown session: ${params.sessionId}`);
+            let modeChanged = false;
             if (typeof params.value === 'string') {
-                if (params.configId === 'mode')
-                    s.modeId = params.value;
+                if (params.configId === 'mode') {
+                    s.modeId = normalizeModeId(params.value);
+                    modeChanged = true;
+                }
                 if (params.configId === 'model')
-                    s.modelId = params.value;
+                    s.modelId = normalizeModelId(params.value);
                 if (params.configId === 'thinking')
                     s.thinkingOptionId = params.value;
             }
             store.update(s);
             const configOptions = buildConfigOptions(s);
-            await conn.sessionUpdate({ sessionId: s.sessionId, update: { sessionUpdate: 'config_option_update', configOptions } });
+            await emitSessionConfigUpdate(conn, s, modeChanged);
             return { configOptions };
         },
         async authenticate() { },
     };
+}
+function sessionStateResponse(session) {
+    const modeId = normalizeModeId(session.modeId);
+    const modelId = normalizeModelId(session.modelId);
+    return {
+        sessionId: session.sessionId,
+        modes: {
+            availableModes: AVAILABLE_MODES.map(id => ({ id, name: id })),
+            currentModeId: modeId,
+        },
+        models: {
+            availableModels: AVAILABLE_MODELS.map(modelId => ({ modelId, name: modelId })),
+            currentModelId: modelId,
+        },
+        configOptions: buildConfigOptions(session),
+    };
+}
+async function emitSessionConfigUpdate(conn, session, modeChanged) {
+    const modeId = normalizeModeId(session.modeId);
+    const configOptions = buildConfigOptions(session);
+    if (modeChanged) {
+        await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'current_mode_update', currentModeId: modeId } });
+    }
+    await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'config_option_update', configOptions } });
+}
+function buildPromptPayload(session, content) {
+    const modeId = normalizeModeId(session.modeId);
+    const modelId = normalizeModelId(session.modelId);
+    const harnessModeId = `supervisor.${modeId}`;
+    return {
+        messages: [{ role: 'user', content: `${formatSupervisorScopePrompt(modeId)}\n\n${content}` }],
+        memory: { thread: session.threadId, resource: session.resourceId },
+        model: modelId,
+        requestContext: {
+            acp: {
+                sessionId: session.sessionId,
+                cwd: session.cwd,
+                modeId,
+                modelId,
+                thinkingOptionId: session.thinkingOptionId,
+            },
+            activeAgentId: 'supervisor',
+            modeId,
+            modelId,
+            harnessMode: modeId,
+            harnessModeId,
+            hardnessMode: harnessModeId,
+            supervisorScope: modeId,
+        },
+    };
+}
+function formatSupervisorScopePrompt(modeId) {
+    const prompt = {
+        base: 'Supervisor Lead Base:\n- Orchestrate the work pragmatically across scoping, planning, building, and verification.\n- Delegate only when a specialist can advance a bounded part of the task.\n- Keep ownership of the final answer, evidence quality, and next action.',
+        scope: 'Supervisor Lead Scope:\n- Identify the smallest useful slice, non-goals, assumptions, and evidence needed.\n- Route discovery to the right specialist before committing to implementation.\n- Stop for a decision when product scope or write boundaries are unclear.',
+        spec: 'Supervisor Lead Spec:\n- Convert the scoped slice into a concrete execution plan with boundaries and verification.\n- Use specialists to sharpen contracts, risks, and acceptance criteria.\n- Do not present implementation as complete while still planning.',
+        exec: 'Supervisor Lead Exec:\n- Drive implementation through the appropriate specialist agents while preserving the approved boundary.\n- Keep build progress tied to concrete files, behavior, and evidence.\n- Escalate if implementation requires a new scope or architecture decision.\n- Audit the completed or claimed work before final synthesis.',
+    };
+    return `<harness-mode id="supervisor.${modeId}" agent="supervisor" mode="${modeId}">\nAgent: Supervisor Lead\nMode: ${modeId}\n${prompt[modeId]}\n</harness-mode>`;
 }

--- a/mastra-agents/src/acp/adapter.js
+++ b/mastra-agents/src/acp/adapter.js
@@ -124,23 +124,25 @@ function buildPromptPayload(session, content, config) {
     const modeId = mode.id;
     const modelId = normalizeModelId(session.modelId, config);
     const thinkingOptions = resolveThinkingProviderOptions({ modelId, thinkingLevel: session.thinkingOptionId });
+    const effectiveModelId = thinkingOptions.modelId ?? modelId;
     return {
         messages: [{ role: 'user', content: `${mode.prompt}\n\n${content}` }],
         memory: { thread: session.threadId, resource: session.resourceId },
-        model: modelId,
+        model: effectiveModelId,
         ...(thinkingOptions.providerOptions ? { providerOptions: thinkingOptions.providerOptions } : {}),
         requestContext: {
             acp: {
                 sessionId: session.sessionId,
                 cwd: session.cwd,
                 modeId,
-                modelId,
+                modelId: effectiveModelId,
+                selectedModelId: modelId,
                 thinkingOptionId: session.thinkingOptionId,
                 thinking: thinkingOptions.metadata,
             },
             activeAgentId: mode.agentId,
             modeId,
-            modelId,
+            modelId: effectiveModelId,
             harnessMode: mode.harnessMode,
             harnessModeId: mode.harnessModeId,
             hardnessMode: mode.harnessModeId,

--- a/mastra-agents/src/acp/adapter.test.js
+++ b/mastra-agents/src/acp/adapter.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createMastraAcpAgentHandler } from "./adapter.js";
+import { loadAcpRuntimeConfig } from "./config-options.js";
 
 class FakeConnection {
   updates = [];
@@ -94,6 +95,62 @@ test("ACP prompt sends selected mode and model as live execution inputs", async 
   assert.match(capturedRequest.messages[0].content, /Supervisor Lead Exec/);
 });
 
+test("ACP runtime config prefers explicit env model over API metadata fallback", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalModel = process.env.MASTRA_SUPERVISOR_MODEL;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalModel === undefined) {
+      delete process.env.MASTRA_SUPERVISOR_MODEL;
+    } else {
+      process.env.MASTRA_SUPERVISOR_MODEL = originalModel;
+    }
+  });
+
+  process.env.MASTRA_SUPERVISOR_MODEL = "proxy/openai/gpt-5.5";
+  globalThis.fetch = async () => Response.json({ provider: "openai", modelId: "gpt-5.5" });
+
+  const config = await loadAcpRuntimeConfig("supervisor-agent", "http://model-precedence.test");
+
+  assert.equal(config.defaultModelId, "proxy/openai/gpt-5.5");
+  assert.equal(config.models[0], "proxy/openai/gpt-5.5");
+  assert.ok(config.models.includes("openai/gpt-5.5"));
+});
+
+test("ACP prompt surfaces Mastra stream error chunks", async (t) => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async () => new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(
+          'data: {"type":"error","payload":{"error":{"message":"Could not find API key process.env.OPENAI_API_KEY"}}}\n\n',
+        ));
+        controller.close();
+      },
+    }),
+    { status: 200, statusText: "OK" },
+  );
+
+  await assert.rejects(
+    agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "Do the work." }],
+    }),
+    /Mastra stream error: Could not find API key process\.env\.OPENAI_API_KEY/,
+  );
+});
+
 test("ACP prompt reports applied thinking metadata for OpenAI reasoning models", async (t) => {
   const conn = new FakeConnection();
   const agent = createMastraAcpAgentHandler(conn, {
@@ -137,8 +194,57 @@ test("ACP prompt reports applied thinking metadata for OpenAI reasoning models",
     requestedLevel: "high",
     status: "applied",
     provider: "openai",
+    strategy: "provider_options",
     providerOptionPath: "providerOptions.openai.reasoningEffort",
     providerOptionValue: "high",
+  });
+});
+
+test("ACP prompt maps proxy gateway thinking to CLIProxy model suffix", async (t) => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "model", value: "proxy/openai/gpt-5.5" });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "thinking", value: "high" });
+
+  let capturedRequest;
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (_url, init) => {
+    capturedRequest = JSON.parse(init.body);
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"type":"text-delta","text":"ok"}\n\ndata: [DONE]\n\n'));
+          controller.close();
+        },
+      }),
+      { status: 200, statusText: "OK" },
+    );
+  };
+
+  await agent.prompt({
+    sessionId: session.sessionId,
+    prompt: [{ type: "text", text: "Use proxy reasoning." }],
+  });
+
+  assert.equal(capturedRequest.model, "proxy/openai/gpt-5.5(high)");
+  assert.equal(capturedRequest.providerOptions, undefined);
+  assert.equal(capturedRequest.requestContext.modelId, "proxy/openai/gpt-5.5(high)");
+  assert.equal(capturedRequest.requestContext.acp.selectedModelId, "proxy/openai/gpt-5.5");
+  assert.deepEqual(capturedRequest.requestContext.acp.thinking, {
+    requestedLevel: "high",
+    status: "applied",
+    provider: "proxy",
+    strategy: "model_name_suffix",
+    providerOptionPath: "model",
+    providerOptionValue: "proxy/openai/gpt-5.5(high)",
   });
 });
 

--- a/mastra-agents/src/acp/adapter.test.js
+++ b/mastra-agents/src/acp/adapter.test.js
@@ -93,3 +93,94 @@ test("ACP prompt sends selected mode and model as live execution inputs", async 
   assert.equal(capturedRequest.requestContext.harnessModeId, "supervisor.exec");
   assert.match(capturedRequest.messages[0].content, /Supervisor Lead Exec/);
 });
+
+test("ACP prompt reports applied thinking metadata for OpenAI reasoning models", async (t) => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "model", value: "openai/gpt-5.2" });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "thinking", value: "high" });
+
+  let capturedRequest;
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (_url, init) => {
+    capturedRequest = JSON.parse(init.body);
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"type":"text-delta","text":"ok"}\n\ndata: [DONE]\n\n'));
+          controller.close();
+        },
+      }),
+      { status: 200, statusText: "OK" },
+    );
+  };
+
+  await agent.prompt({
+    sessionId: session.sessionId,
+    prompt: [{ type: "text", text: "Use deeper reasoning." }],
+  });
+
+  assert.deepEqual(capturedRequest.providerOptions, {
+    openai: {
+      reasoningEffort: "high",
+    },
+  });
+  assert.deepEqual(capturedRequest.requestContext.acp.thinking, {
+    requestedLevel: "high",
+    status: "applied",
+    provider: "openai",
+    providerOptionPath: "providerOptions.openai.reasoningEffort",
+    providerOptionValue: "high",
+  });
+});
+
+test("ACP prompt omits thinking providerOptions and reports unsupported provider", async (t) => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "model", value: "minimax-coding-plan/MiniMax-M2.7" });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "thinking", value: "high" });
+
+  let capturedRequest;
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (_url, init) => {
+    capturedRequest = JSON.parse(init.body);
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"type":"text-delta","text":"ok"}\n\ndata: [DONE]\n\n'));
+          controller.close();
+        },
+      }),
+      { status: 200, statusText: "OK" },
+    );
+  };
+
+  await agent.prompt({
+    sessionId: session.sessionId,
+    prompt: [{ type: "text", text: "Use deeper reasoning." }],
+  });
+
+  assert.equal(capturedRequest.providerOptions, undefined);
+  assert.deepEqual(capturedRequest.requestContext.acp.thinking, {
+    requestedLevel: "high",
+    status: "unsupported_provider",
+    provider: "minimax-coding-plan",
+    reason: "No ACP thinking mapping is defined for provider minimax-coding-plan",
+  });
+});

--- a/mastra-agents/src/acp/adapter.test.js
+++ b/mastra-agents/src/acp/adapter.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMastraAcpAgentHandler } from "./adapter.js";
+
+class FakeConnection {
+  updates = [];
+
+  async sessionUpdate(update) {
+    this.updates.push(update);
+  }
+}
+
+function optionValue(configOptions, id) {
+  return configOptions.find((option) => option.id === id)?.currentValue;
+}
+
+test("ACP session config exposes complete canonical mode and model defaults", async () => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+  });
+
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  assert.equal(session.modes.currentModeId, "base");
+  assert.equal(optionValue(session.configOptions, "mode"), "base");
+  assert.equal(optionValue(session.configOptions, "model"), session.models.currentModelId);
+  assert.deepEqual(session.configOptions.map((option) => option.id), ["mode", "model", "thinking"]);
+});
+
+test("ACP mode config mutation returns full state and keeps legacy mode surface in sync", async () => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+  });
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  const result = await agent.setSessionConfigOption({
+    sessionId: session.sessionId,
+    configId: "mode",
+    value: "plan",
+  });
+
+  assert.deepEqual(result.configOptions.map((option) => option.id), ["mode", "model", "thinking"]);
+  assert.equal(optionValue(result.configOptions, "mode"), "spec");
+
+  const modeUpdate = conn.updates.find((entry) => entry.update.sessionUpdate === "current_mode_update");
+  const configUpdate = conn.updates.findLast((entry) => entry.update.sessionUpdate === "config_option_update");
+  assert.equal(modeUpdate.update.currentModeId, "spec");
+  assert.equal(optionValue(configUpdate.update.configOptions, "mode"), "spec");
+});
+
+test("ACP prompt sends selected mode and model as live execution inputs", async (t) => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const session = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "mode", value: "exec" });
+  await agent.setSessionConfigOption({ sessionId: session.sessionId, configId: "model", value: "provider/custom-model" });
+
+  let capturedRequest;
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (_url, init) => {
+    capturedRequest = JSON.parse(init.body);
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"type":"text-delta","text":"ok"}\n\ndata: [DONE]\n\n'));
+          controller.close();
+        },
+      }),
+      { status: 200, statusText: "OK" },
+    );
+  };
+
+  await agent.prompt({
+    sessionId: session.sessionId,
+    prompt: [{ type: "text", text: "Do the work." }],
+  });
+
+  assert.equal(capturedRequest.model, "provider/custom-model");
+  assert.equal(capturedRequest.requestContext.modelId, "provider/custom-model");
+  assert.equal(capturedRequest.requestContext.harnessMode, "exec");
+  assert.equal(capturedRequest.requestContext.harnessModeId, "supervisor.exec");
+  assert.match(capturedRequest.messages[0].content, /Supervisor Lead Exec/);
+});

--- a/mastra-agents/src/acp/config-options.d.ts
+++ b/mastra-agents/src/acp/config-options.d.ts
@@ -1,11 +1,26 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk';
 import type { MastraAcpSession } from './types.js';
-export declare const SUPERVISOR_MODE_IDS: readonly ["base", "scope", "spec", "exec"];
-export type SupervisorModeId = typeof SUPERVISOR_MODE_IDS[number];
-export declare const DEFAULT_ACP_MODE_ID: SupervisorModeId;
-export declare const DEFAULT_ACP_MODEL_ID: string;
-export declare const AVAILABLE_MODES: ("base" | "scope" | "spec" | "exec")[];
-export declare const AVAILABLE_MODELS: string[];
-export declare function normalizeModeId(value: unknown): SupervisorModeId;
-export declare function normalizeModelId(value: unknown): string;
-export declare function buildConfigOptions(session: MastraAcpSession): SessionConfigOption[];
+export type AcpRuntimeAgentId = 'orchestrator' | 'supervisor';
+export type AcpModeDefinition = {
+    id: string;
+    name: string;
+    agentId: AcpRuntimeAgentId;
+    harnessMode: string;
+    harnessModeId: string;
+    default: boolean;
+    prompt: string;
+};
+export type AcpRuntimeConfig = {
+    agentId: AcpRuntimeAgentId;
+    modes: AcpModeDefinition[];
+    defaultModeId: string;
+    models: string[];
+    defaultModelId: string;
+};
+export declare function runtimeAgentIdFromAgentId(agentId: string | undefined): AcpRuntimeAgentId;
+export declare function loadAcpRuntimeConfig(agentId: string | undefined, mastraBaseUrl?: string): Promise<AcpRuntimeConfig>;
+export declare function normalizeModeId(value: unknown, config: AcpRuntimeConfig): string;
+export declare function normalizeModelId(value: unknown, config: AcpRuntimeConfig): string;
+export declare function modeDefinitionForSession(session: MastraAcpSession, config: AcpRuntimeConfig): AcpModeDefinition;
+export declare function modelOptionsForSession(session: MastraAcpSession, config: AcpRuntimeConfig): string[];
+export declare function buildConfigOptions(session: MastraAcpSession, config: AcpRuntimeConfig): SessionConfigOption[];

--- a/mastra-agents/src/acp/config-options.d.ts
+++ b/mastra-agents/src/acp/config-options.d.ts
@@ -1,5 +1,11 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk';
 import type { MastraAcpSession } from './types.js';
-export declare const AVAILABLE_MODES: string[];
+export declare const SUPERVISOR_MODE_IDS: readonly ["base", "scope", "spec", "exec"];
+export type SupervisorModeId = typeof SUPERVISOR_MODE_IDS[number];
+export declare const DEFAULT_ACP_MODE_ID: SupervisorModeId;
+export declare const DEFAULT_ACP_MODEL_ID: string;
+export declare const AVAILABLE_MODES: ("base" | "scope" | "spec" | "exec")[];
 export declare const AVAILABLE_MODELS: string[];
+export declare function normalizeModeId(value: unknown): SupervisorModeId;
+export declare function normalizeModelId(value: unknown): string;
 export declare function buildConfigOptions(session: MastraAcpSession): SessionConfigOption[];

--- a/mastra-agents/src/acp/config-options.js
+++ b/mastra-agents/src/acp/config-options.js
@@ -1,17 +1,3 @@
-export const SUPERVISOR_MODE_IDS = ['base', 'scope', 'spec', 'exec'];
-export const DEFAULT_ACP_MODE_ID = 'base';
-export const DEFAULT_ACP_MODEL_ID = process.env.MASTRA_SUPERVISOR_MODEL?.trim() ||
-    process.env.MASTRA_AGENT_MODEL?.trim() ||
-    process.env.MASTRA_SUBAGENT_MODEL?.trim() ||
-    process.env.MASTRA_MODEL?.trim() ||
-    'minimax-coding-plan/MiniMax-M2.7';
-export const AVAILABLE_MODES = [...SUPERVISOR_MODE_IDS];
-export const AVAILABLE_MODELS = [
-    DEFAULT_ACP_MODEL_ID,
-    'gpt-5.3-codex',
-    'gpt-5.3',
-    'gpt-5.1-mini',
-].filter((modelId, index, models) => modelId && models.indexOf(modelId) === index);
 const modeAliases = new Map([
     ['base', 'base'],
     ['balance', 'base'],
@@ -24,20 +10,172 @@ const modeAliases = new Map([
     ['build', 'exec'],
     ['verify', 'exec'],
 ]);
-export function normalizeModeId(value) {
-    if (typeof value !== 'string')
-        return DEFAULT_ACP_MODE_ID;
-    return modeAliases.get(value.trim().toLowerCase().replace(/_/g, '-')) ?? DEFAULT_ACP_MODE_ID;
+const configCache = new Map();
+export function runtimeAgentIdFromAgentId(agentId) {
+    const normalized = agentId?.trim().toLowerCase().replace(/_/g, '-') ?? '';
+    return normalized.includes('orchestrator') ? 'orchestrator' : 'supervisor';
 }
-export function normalizeModelId(value) {
-    return typeof value === 'string' && value.trim() ? value.trim() : DEFAULT_ACP_MODEL_ID;
+export function loadAcpRuntimeConfig(agentId, mastraBaseUrl) {
+    const runtimeAgentId = runtimeAgentIdFromAgentId(agentId);
+    const cacheKey = `${runtimeAgentId}:${mastraBaseUrl ?? ''}`;
+    const existing = configCache.get(cacheKey);
+    if (existing)
+        return existing;
+    const config = loadMastraRuntimeConfig(runtimeAgentId, agentId, mastraBaseUrl)
+        .catch(async () => fallbackRuntimeConfig(runtimeAgentId, await modelIdFromMastraAgentApi(agentId, mastraBaseUrl)));
+    configCache.set(cacheKey, config);
+    return config;
 }
-export function buildConfigOptions(session) {
-    const modeId = normalizeModeId(session.modeId);
-    const modelId = normalizeModelId(session.modelId);
+export function normalizeModeId(value, config) {
+    if (typeof value !== 'string' || !value.trim())
+        return config.defaultModeId;
+    const normalized = value.trim().toLowerCase().replace(/_/g, '-');
+    const aliased = config.agentId === 'supervisor' ? modeAliases.get(normalized) : undefined;
+    const requested = aliased ?? normalized.split('.').at(-1) ?? normalized;
+    return config.modes.some((mode) => mode.id === requested) ? requested : config.defaultModeId;
+}
+export function normalizeModelId(value, config) {
+    return typeof value === 'string' && value.trim() ? value.trim() : config.defaultModelId;
+}
+export function modeDefinitionForSession(session, config) {
+    const modeId = normalizeModeId(session.modeId, config);
+    return config.modes.find((mode) => mode.id === modeId) ?? config.modes[0];
+}
+export function modelOptionsForSession(session, config) {
+    return unique([normalizeModelId(session.modelId, config), ...config.models]);
+}
+export function buildConfigOptions(session, config) {
+    const modeId = normalizeModeId(session.modeId, config);
+    const modelId = normalizeModelId(session.modelId, config);
     return [
-        { id: 'mode', name: 'Mode', category: 'mode', type: 'select', currentValue: modeId, options: AVAILABLE_MODES.map(v => ({ value: v, name: v })) },
-        { id: 'model', name: 'Model', category: 'model', type: 'select', currentValue: modelId, options: AVAILABLE_MODELS.map(v => ({ value: v, name: v })) },
+        { id: 'mode', name: 'Mode', category: 'mode', type: 'select', currentValue: modeId, options: config.modes.map(v => ({ value: v.id, name: v.name })) },
+        { id: 'model', name: 'Model', category: 'model', type: 'select', currentValue: modelId, options: modelOptionsForSession(session, config).map(v => ({ value: v, name: v })) },
         { id: 'thinking', name: 'Thinking', category: 'thought_level', type: 'select', currentValue: session.thinkingOptionId ?? 'medium', options: ['low', 'medium', 'high'].map(v => ({ value: v, name: v[0].toUpperCase() + v.slice(1) })) },
     ];
+}
+async function loadMastraRuntimeConfig(agentId, apiAgentId, mastraBaseUrl) {
+    const harnessModule = await import(new URL('../agents/harness.js', import.meta.url).href);
+    const modes = harnessModule.mastraAgentHarnessModes
+        .filter((mode) => mode.id.startsWith(`${agentId}.`))
+        .map((mode) => {
+        const resolved = harnessModule.resolveMastraAgentHarnessMode({ agentId, harnessMode: mode.id });
+        return {
+            id: resolved.harnessMode,
+            name: mode.name,
+            agentId: resolved.activeAgentId,
+            harnessMode: resolved.harnessMode,
+            harnessModeId: resolved.harnessModeId,
+            default: Boolean(mode.default),
+            prompt: harnessModule.formatMastraAgentHarnessModePrompt(resolved),
+            defaultModelId: mode.defaultModelId,
+        };
+    });
+    const defaultMode = modes.find((mode) => mode.default) ?? modes[0];
+    const configuredModels = unique([
+        ...modes.map((mode) => mode.defaultModelId),
+        await modelIdFromMastraAgentApi(apiAgentId, mastraBaseUrl),
+        ...configuredModelEnvValues(agentId),
+    ]);
+    const defaultModelId = configuredModels[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
+    return {
+        agentId,
+        modes,
+        defaultModeId: defaultMode?.id ?? fallbackRuntimeConfig(agentId).defaultModeId,
+        models: configuredModels.length > 0 ? configuredModels : [defaultModelId],
+        defaultModelId,
+    };
+}
+async function modelIdFromMastraAgentApi(agentId, mastraBaseUrl) {
+    if (!agentId || !mastraBaseUrl)
+        return undefined;
+    try {
+        const baseUrl = mastraBaseUrl.replace(/\/+$/, '');
+        const response = await fetch(`${baseUrl}/api/agents/${encodeURIComponent(agentId)}`);
+        if (!response.ok)
+            return undefined;
+        const agentConfig = await response.json();
+        const provider = typeof agentConfig.provider === 'string' ? agentConfig.provider.trim() : '';
+        const modelId = typeof agentConfig.modelId === 'string' ? agentConfig.modelId.trim() : '';
+        if (!modelId)
+            return undefined;
+        return provider && !modelId.includes('/') ? `${provider}/${modelId}` : modelId;
+    }
+    catch {
+        return undefined;
+    }
+}
+function fallbackRuntimeConfig(agentId, apiModelId) {
+    const models = unique([apiModelId, ...configuredModelEnvValues(agentId)]);
+    const defaultModelId = models[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
+    const fallbackModes = agentId === 'orchestrator'
+        ? ['quick', 'precision', 'auto'].map((id) => fallbackMode(agentId, id, id === 'auto'))
+        : ['base', 'scope', 'spec', 'exec'].map((id, index) => fallbackMode(agentId, id, index === 0));
+    const defaultMode = fallbackModes.find((mode) => mode.default) ?? fallbackModes[0];
+    return {
+        agentId,
+        modes: fallbackModes,
+        defaultModeId: defaultMode.id,
+        models: models.length > 0 ? models : [defaultModelId],
+        defaultModelId,
+    };
+}
+function fallbackMode(agentId, id, isDefault) {
+    const harnessModeId = `${agentId}.${id}`;
+    const prompt = fallbackModePrompt(agentId, id);
+    return {
+        id,
+        name: `${agentId === 'supervisor' ? 'Supervisor Lead' : 'Orchestrator'} / ${fallbackModeName(id)}`,
+        agentId,
+        harnessMode: id,
+        harnessModeId,
+        default: isDefault,
+        prompt: `<harness-mode id="${harnessModeId}" agent="${agentId}" mode="${id}">\n${prompt}\n</harness-mode>`,
+    };
+}
+function fallbackModeName(id) {
+    return {
+        base: 'Base',
+        scope: 'Scope',
+        spec: 'Spec',
+        exec: 'Execution',
+        quick: 'Quick',
+        precision: 'Precision',
+        auto: 'Auto',
+    }[id] ?? id;
+}
+function fallbackModePrompt(agentId, id) {
+    if (agentId === 'orchestrator') {
+        return {
+            quick: 'Agent: Orchestrator\nMode: Quick',
+            precision: 'Agent: Orchestrator\nMode: Precision',
+            auto: 'Agent: Orchestrator\nMode: Auto',
+        }[id] ?? `Agent: Orchestrator\nMode: ${id}`;
+    }
+    const prompts = {
+        base: 'Agent: Supervisor Lead\nMode: Base\nSupervisor Lead Base:\n- Orchestrate the work pragmatically across scoping, planning, building, and verification.\n- Delegate only when a specialist can advance a bounded part of the task.\n- Keep ownership of the final answer, evidence quality, and next action.',
+        scope: 'Agent: Supervisor Lead\nMode: Scope\nSupervisor Lead Scope:\n- Identify the smallest useful slice, non-goals, assumptions, and evidence needed.\n- Route discovery to the right specialist before committing to implementation.\n- Stop for a decision when product scope or write boundaries are unclear.',
+        spec: 'Agent: Supervisor Lead\nMode: Spec\nSupervisor Lead Spec:\n- Convert the scoped slice into a concrete execution plan with boundaries and verification.\n- Use specialists to sharpen contracts, risks, and acceptance criteria.\n- Do not present implementation as complete while still planning.',
+        exec: 'Agent: Supervisor Lead\nMode: Execution\nSupervisor Lead Exec:\n- Drive implementation through the appropriate specialist agents while preserving the approved boundary.\n- Keep build progress tied to concrete files, behavior, and evidence.\n- Escalate if implementation requires a new scope or architecture decision.\n- Audit the completed or claimed work before final synthesis.\n- Require evidence from tests, inspected diffs, snapshot turn/session diffs, tool output, or explicit verification gaps.\n- When a specialist claims it changed code, require snapshot-backed audit evidence unless snapshots are unavailable and that gap is stated.\n- Separate confirmed results from residual risk.',
+    };
+    return prompts[id] ?? `Agent: Supervisor Lead\nMode: ${id}`;
+}
+function configuredModelEnvValues(agentId) {
+    const agentSpecificKeys = agentId === 'orchestrator'
+        ? ['MASTRA_ORCHESTRATE_MODEL', 'MASTRA_CODE_MODEL']
+        : ['MASTRA_SUPERVISOR_MODEL'];
+    return unique([
+        ...agentSpecificKeys.map((key) => process.env[key]),
+        process.env.MASTRA_AGENT_MODEL,
+        process.env.MASTRA_SUBAGENT_MODEL,
+        process.env.MASTRA_MODEL,
+        ...Object.entries(process.env)
+            .filter(([key]) => /^MASTRA_.*MODEL$/.test(key))
+            .map(([, value]) => value),
+    ]);
+}
+function unique(values) {
+    return values
+        .map((value) => value?.trim())
+        .filter((value) => Boolean(value))
+        .filter((value, index, all) => all.indexOf(value) === index);
 }

--- a/mastra-agents/src/acp/config-options.js
+++ b/mastra-agents/src/acp/config-options.js
@@ -73,8 +73,8 @@ async function loadMastraRuntimeConfig(agentId, apiAgentId, mastraBaseUrl) {
     const defaultMode = modes.find((mode) => mode.default) ?? modes[0];
     const configuredModels = unique([
         ...modes.map((mode) => mode.defaultModelId),
-        await modelIdFromMastraAgentApi(apiAgentId, mastraBaseUrl),
         ...configuredModelEnvValues(agentId),
+        await modelIdFromMastraAgentApi(apiAgentId, mastraBaseUrl),
     ]);
     const defaultModelId = configuredModels[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
     return {
@@ -98,14 +98,14 @@ async function modelIdFromMastraAgentApi(agentId, mastraBaseUrl) {
         const modelId = typeof agentConfig.modelId === 'string' ? agentConfig.modelId.trim() : '';
         if (!modelId)
             return undefined;
-        return provider && !modelId.includes('/') ? `${provider}/${modelId}` : modelId;
+        return provider && !modelId.startsWith(`${provider}/`) ? `${provider}/${modelId}` : modelId;
     }
     catch {
         return undefined;
     }
 }
 function fallbackRuntimeConfig(agentId, apiModelId) {
-    const models = unique([apiModelId, ...configuredModelEnvValues(agentId)]);
+    const models = unique([...configuredModelEnvValues(agentId), apiModelId]);
     const defaultModelId = models[0] ?? 'minimax-coding-plan/MiniMax-M2.7';
     const fallbackModes = agentId === 'orchestrator'
         ? ['quick', 'precision', 'auto'].map((id) => fallbackMode(agentId, id, id === 'auto'))

--- a/mastra-agents/src/acp/config-options.js
+++ b/mastra-agents/src/acp/config-options.js
@@ -1,9 +1,43 @@
-export const AVAILABLE_MODES = ['balanced', 'scope', 'plan', 'build', 'verify', 'research', 'analysis', 'audit', 'debug'];
-export const AVAILABLE_MODELS = ['gpt-5.3-codex', 'gpt-5.3', 'gpt-5.1-mini'];
+export const SUPERVISOR_MODE_IDS = ['base', 'scope', 'spec', 'exec'];
+export const DEFAULT_ACP_MODE_ID = 'base';
+export const DEFAULT_ACP_MODEL_ID = process.env.MASTRA_SUPERVISOR_MODEL?.trim() ||
+    process.env.MASTRA_AGENT_MODEL?.trim() ||
+    process.env.MASTRA_SUBAGENT_MODEL?.trim() ||
+    process.env.MASTRA_MODEL?.trim() ||
+    'minimax-coding-plan/MiniMax-M2.7';
+export const AVAILABLE_MODES = [...SUPERVISOR_MODE_IDS];
+export const AVAILABLE_MODELS = [
+    DEFAULT_ACP_MODEL_ID,
+    'gpt-5.3-codex',
+    'gpt-5.3',
+    'gpt-5.1-mini',
+].filter((modelId, index, models) => modelId && models.indexOf(modelId) === index);
+const modeAliases = new Map([
+    ['base', 'base'],
+    ['balance', 'base'],
+    ['balanced', 'base'],
+    ['scope', 'scope'],
+    ['spec', 'spec'],
+    ['plan', 'spec'],
+    ['exec', 'exec'],
+    ['execution', 'exec'],
+    ['build', 'exec'],
+    ['verify', 'exec'],
+]);
+export function normalizeModeId(value) {
+    if (typeof value !== 'string')
+        return DEFAULT_ACP_MODE_ID;
+    return modeAliases.get(value.trim().toLowerCase().replace(/_/g, '-')) ?? DEFAULT_ACP_MODE_ID;
+}
+export function normalizeModelId(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : DEFAULT_ACP_MODEL_ID;
+}
 export function buildConfigOptions(session) {
+    const modeId = normalizeModeId(session.modeId);
+    const modelId = normalizeModelId(session.modelId);
     return [
-        { id: 'mode', name: 'Mode', category: 'mode', type: 'select', currentValue: session.modeId ?? 'balanced', options: AVAILABLE_MODES.map(v => ({ value: v, name: v })) },
-        { id: 'model', name: 'Model', category: 'model', type: 'select', currentValue: session.modelId ?? AVAILABLE_MODELS[0], options: AVAILABLE_MODELS.map(v => ({ value: v, name: v })) },
+        { id: 'mode', name: 'Mode', category: 'mode', type: 'select', currentValue: modeId, options: AVAILABLE_MODES.map(v => ({ value: v, name: v })) },
+        { id: 'model', name: 'Model', category: 'model', type: 'select', currentValue: modelId, options: AVAILABLE_MODELS.map(v => ({ value: v, name: v })) },
         { id: 'thinking', name: 'Thinking', category: 'thought_level', type: 'select', currentValue: session.thinkingOptionId ?? 'medium', options: ['low', 'medium', 'high'].map(v => ({ value: v, name: v[0].toUpperCase() + v.slice(1) })) },
     ];
 }

--- a/mastra-agents/src/acp/delegation-observability.spec.js
+++ b/mastra-agents/src/acp/delegation-observability.spec.js
@@ -2,7 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { mapMastraChunkToUpdates } from './event-mapper.js';
-import { delegationPayloadFromEvent } from '../workflows/delegation-event.js';
+import { createDelegationObservabilityOptions } from '../agents/delegation-observability.js';
+import { delegationPayloadFromEvent, subscribeDelegationEvents } from '../workflows/delegation-event.js';
 
 test('delegation payload preserves structured prompt/response/error fields', () => {
   const payload = delegationPayloadFromEvent({
@@ -25,4 +26,58 @@ test('delegation event mapper fallback IDs remain unique', () => {
   const one = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: 1 } })[0];
   const two = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: 2 } })[0];
   assert.notEqual(one.toolCallId, two.toolCallId);
+});
+
+test('orchestration delegation hooks emit ACP-visible start and complete payloads', () => {
+  const events = [];
+  const unsubscribe = subscribeDelegationEvents((payload) => events.push(payload));
+  try {
+    const hooks = createDelegationObservabilityOptions({
+      parentAgentId: 'orchestrator-agent',
+      parentAgentName: 'Orchestrator',
+    });
+
+    hooks.onDelegationStart({
+      primitiveId: 'scout-agent',
+      primitiveType: 'agent',
+      prompt: 'Inspect this workspace',
+      params: {},
+      iteration: 1,
+      runId: 'run-1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      parentAgentId: 'orchestrator-agent',
+      parentAgentName: 'Orchestrator',
+      toolCallId: 'tool-1',
+      messages: [],
+    });
+    hooks.onDelegationComplete({
+      primitiveId: 'scout-agent',
+      primitiveType: 'agent',
+      prompt: 'Inspect this workspace',
+      result: { text: 'Found evidence' },
+      duration: 42,
+      success: true,
+      iteration: 1,
+      runId: 'run-1',
+      toolCallId: 'tool-1',
+      parentAgentId: 'orchestrator-agent',
+      parentAgentName: 'Orchestrator',
+      messages: [],
+      bail: () => undefined,
+    });
+  } finally {
+    unsubscribe();
+  }
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0].phase, 'delegation_start');
+  assert.equal(events[0].delegatedAgentId, 'scout-agent');
+  assert.equal(events[0].prompt, 'Inspect this workspace');
+  assert.equal(events[1].phase, 'delegation_complete');
+  assert.deepEqual(events[1].response, { text: 'Found evidence' });
+  assert.equal(events[1].durationMs, 42);
+  assert.equal(events[1].threadId, 'thread-1');
+  assert.equal(events[1].resourceId, 'resource-1');
+  assert.equal(events[1].source, 'delegation-hook');
 });

--- a/mastra-agents/src/acp/delegation-observability.spec.js
+++ b/mastra-agents/src/acp/delegation-observability.spec.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mapMastraChunkToUpdates } from './event-mapper.js';
+import { delegationPayloadFromEvent } from '../workflows/delegation-event.js';
+
+test('delegation payload preserves structured prompt/response/error fields', () => {
+  const payload = delegationPayloadFromEvent({
+    type: 'delegation_complete',
+    payload: {
+      delegatedName: 'Scout',
+      delegatedAgentId: 'scout-agent',
+      prompt: { objective: 'inspect', files: ['a.ts'] },
+      response: { findings: ['ok'] },
+      error: { code: 'E_TIMEOUT' },
+      success: false,
+    },
+  });
+  assert.deepEqual(payload.prompt, { objective: 'inspect', files: ['a.ts'] });
+  assert.deepEqual(payload.response, { findings: ['ok'] });
+  assert.deepEqual(payload.error, { code: 'E_TIMEOUT' });
+});
+
+test('delegation event mapper fallback IDs remain unique', () => {
+  const one = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: 1 } })[0];
+  const two = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: 2 } })[0];
+  assert.notEqual(one.toolCallId, two.toolCallId);
+});

--- a/mastra-agents/src/acp/event-mapper.js
+++ b/mastra-agents/src/acp/event-mapper.js
@@ -21,6 +21,41 @@ export function mapMastraChunkToUpdates(chunk) {
         return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: textFrom(chunk) }, _meta: { mastra: { reasoning: chunk } } }];
     if (type === 'finish')
         return chunk.usage ? [{ sessionUpdate: 'usage_update', used: num(chunk.usage, 'totalTokens') ?? 0, size: num(chunk.usage, 'totalTokens') ?? 0 }] : [];
+
+    if (type === "delegation-event") {
+        const payload = isRecord(chunk.payload) ? chunk.payload : {};
+        const fallbackIdParts = [
+            idPart(payload.delegationId),
+            idPart(payload.runId),
+            idPart(payload.agentRunId),
+            idPart(payload.threadId),
+            idPart(payload.timestamp),
+            idPart(payload.phase),
+            idPart(payload.delegatedAgentId) ?? idPart(payload.delegatedName),
+        ].filter(Boolean);
+        const fallbackId = fallbackIdParts.length > 0 ? `delegation:${fallbackIdParts.join(":")}` : `delegation:${Date.now()}`;
+        const phase = str(payload.phase) ?? "delegation";
+        const status = phase === "delegation_complete" ? (payload.success === false ? "failed" : "completed") : "in_progress";
+        const summary = {
+            target: payload.delegatedAgentId ?? payload.delegatedName,
+            prompt: payload.prompt,
+            response: payload.response,
+            error: payload.error,
+            success: payload.success,
+            durationMs: payload.durationMs,
+        };
+        return [{
+            sessionUpdate: "tool_call_update",
+            toolCallId: str(payload.delegationId) ?? fallbackId,
+            status,
+            title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? "delegation",
+            kind: "other",
+            rawInput: payload.prompt,
+            rawOutput: payload.response ?? payload.error,
+            content: [{ type: "content", content: { type: "text", text: JSON.stringify(summary) } }],
+            _meta: { mastra: chunk },
+        }];
+    }
     if (type?.startsWith('tool-')) {
         const p = isRecord(chunk.payload) ? chunk.payload : chunk;
         const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : (type === 'tool-call-input-streaming-start' ? 'in_progress' : 'pending');
@@ -41,5 +76,14 @@ export function mapMastraChunkToUpdates(chunk) {
 }
 const isRecord = (v) => typeof v === 'object' && !!v;
 const str = (v) => (typeof v === 'string' ? v : undefined);
+const idPart = (v) => {
+    if (typeof v === 'string')
+        return v.length > 0 ? v : undefined;
+    if (typeof v === 'number')
+        return Number.isFinite(v) ? String(v) : undefined;
+    if (typeof v === 'boolean')
+        return String(v);
+    return undefined;
+};
 const textFrom = (c) => str(c.text) ?? str(c.delta) ?? str(c.payload?.text) ?? '';
 const num = (o, k) => (typeof o?.[k] === 'number' ? o[k] : undefined);

--- a/mastra-agents/src/acp/event-mapper.js
+++ b/mastra-agents/src/acp/event-mapper.js
@@ -21,7 +21,6 @@ export function mapMastraChunkToUpdates(chunk) {
         return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: textFrom(chunk) }, _meta: { mastra: { reasoning: chunk } } }];
     if (type === 'finish')
         return chunk.usage ? [{ sessionUpdate: 'usage_update', used: num(chunk.usage, 'totalTokens') ?? 0, size: num(chunk.usage, 'totalTokens') ?? 0 }] : [];
-
     if (type === "delegation-event") {
         const payload = isRecord(chunk.payload) ? chunk.payload : {};
         const fallbackIdParts = [
@@ -45,16 +44,16 @@ export function mapMastraChunkToUpdates(chunk) {
             durationMs: payload.durationMs,
         };
         return [{
-            sessionUpdate: "tool_call_update",
-            toolCallId: str(payload.delegationId) ?? fallbackId,
-            status,
-            title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? "delegation",
-            kind: "other",
-            rawInput: payload.prompt,
-            rawOutput: payload.response ?? payload.error,
-            content: [{ type: "content", content: { type: "text", text: JSON.stringify(summary) } }],
-            _meta: { mastra: chunk },
-        }];
+                sessionUpdate: "tool_call_update",
+                toolCallId: str(payload.delegationId) ?? fallbackId,
+                status,
+                title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? "delegation",
+                kind: "other",
+                rawInput: payload.prompt,
+                rawOutput: payload.response ?? payload.error,
+                content: [{ type: "content", content: { type: "text", text: JSON.stringify(summary) } }],
+                _meta: { mastra: chunk },
+            }];
     }
     if (type?.startsWith('tool-')) {
         const p = isRecord(chunk.payload) ? chunk.payload : chunk;

--- a/mastra-agents/src/acp/mastra-stream.js
+++ b/mastra-agents/src/acp/mastra-stream.js
@@ -11,12 +11,41 @@ async function* parseSse(stream) { const d = new TextDecoder(); let b = ''; for 
     }
 } }
 export async function* streamMastraAgent(baseUrl, agentId, payload, signal) {
-    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/api/agents/${agentId}/stream`, { method: 'POST', headers: { accept: 'text/event-stream', 'content-type': 'application/json' }, body: JSON.stringify(payload), signal });
-    if (!response.ok || !response.body)
-        throw new Error(`Mastra stream failed: ${response.status} ${response.statusText}`);
+    const url = `${normalizeBaseUrl(baseUrl)}/api/agents/${encodeURIComponent(agentId)}/stream`;
+    let response;
+    try {
+        response = await fetch(url, { method: 'POST', headers: { accept: 'text/event-stream', 'content-type': 'application/json' }, body: JSON.stringify(payload), signal });
+    }
+    catch (error) {
+        throw new Error(`Mastra stream request failed for ${url}: ${errorMessage(error)}`);
+    }
+    if (!response.ok || !response.body) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`Mastra stream failed for ${url}: ${response.status} ${response.statusText}${body ? ` - ${body.slice(0, 500)}` : ''}`);
+    }
     for await (const data of parseSse(response.body)) {
         if (data === '[DONE]')
             return;
-        yield JSON.parse(data);
+        const chunk = JSON.parse(data);
+        const streamError = mastraErrorMessage(chunk);
+        if (streamError)
+            throw new Error(`Mastra stream error: ${streamError}`);
+        yield chunk;
     }
+}
+function mastraErrorMessage(chunk) {
+    if (!isRecord(chunk) || chunk.type !== 'error')
+        return undefined;
+    const payload = isRecord(chunk.payload) ? chunk.payload : undefined;
+    const error = isRecord(payload?.error) ? payload.error : isRecord(chunk.error) ? chunk.error : undefined;
+    return str(error?.message) ?? str(payload?.message) ?? str(chunk.message) ?? 'Unknown Mastra stream error';
+}
+function errorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
+}
+function isRecord(value) {
+    return typeof value === 'object' && value !== null;
+}
+function str(value) {
+    return typeof value === 'string' && value.trim() ? value : undefined;
 }

--- a/mastra-agents/src/acp/session-store.d.ts
+++ b/mastra-agents/src/acp/session-store.d.ts
@@ -7,6 +7,8 @@ export declare class MastraAcpSessionStore {
         cwd: string;
         resourceId?: string;
         threadId?: string;
+        defaultModeId: string;
+        defaultModelId: string;
     }): MastraAcpSession;
     get(sessionId: string): MastraAcpSession | undefined;
     update(session: MastraAcpSession): void;

--- a/mastra-agents/src/acp/session-store.js
+++ b/mastra-agents/src/acp/session-store.js
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { DEFAULT_ACP_MODE_ID, DEFAULT_ACP_MODEL_ID } from './config-options.js';
 export class MastraAcpSessionStore {
     sessions = new Map();
     create(params) {
@@ -11,8 +10,8 @@ export class MastraAcpSessionStore {
             cwd: params.cwd,
             resourceId: params.resourceId ?? `acp:${shortHash(params.cwd)}`,
             threadId: params.threadId ?? `acp:${sessionId}:${params.agentId}`,
-            modeId: DEFAULT_ACP_MODE_ID,
-            modelId: DEFAULT_ACP_MODEL_ID,
+            modeId: params.defaultModeId,
+            modelId: params.defaultModelId,
             thinkingOptionId: 'medium',
             createdAt: now,
             updatedAt: now,

--- a/mastra-agents/src/acp/session-store.js
+++ b/mastra-agents/src/acp/session-store.js
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { DEFAULT_ACP_MODE_ID, DEFAULT_ACP_MODEL_ID } from './config-options.js';
 export class MastraAcpSessionStore {
     sessions = new Map();
     create(params) {
@@ -10,6 +11,9 @@ export class MastraAcpSessionStore {
             cwd: params.cwd,
             resourceId: params.resourceId ?? `acp:${shortHash(params.cwd)}`,
             threadId: params.threadId ?? `acp:${sessionId}:${params.agentId}`,
+            modeId: DEFAULT_ACP_MODE_ID,
+            modelId: DEFAULT_ACP_MODEL_ID,
+            thinkingOptionId: 'medium',
             createdAt: now,
             updatedAt: now,
         };

--- a/mastra-agents/src/acp/stdio.js
+++ b/mastra-agents/src/acp/stdio.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import { AgentSideConnection, ndJsonStream } from '@agentclientprotocol/sdk';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { Readable, Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
 import { createMastraAcpAgent } from './index.js';
 function readCliOptions(argv, env) {
     const options = {
@@ -26,9 +29,59 @@ function readCliOptions(argv, env) {
     }
     return options;
 }
+function unquoteEnvValue(value) {
+    const trimmed = value.trim();
+    if (trimmed.length < 2)
+        return trimmed;
+    const quote = trimmed[0];
+    if ((quote !== '"' && quote !== "'") || trimmed.at(-1) !== quote)
+        return trimmed;
+    const body = trimmed.slice(1, -1);
+    return quote === '"' ? body.replace(/\\n/g, '\n').replace(/\\"/g, '"') : body;
+}
+function parseEnvFile(filePath) {
+    const values = {};
+    if (!existsSync(filePath))
+        return values;
+    for (const rawLine of readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#'))
+            continue;
+        const assignment = line.startsWith('export ') ? line.slice(7).trim() : line;
+        const equalsIndex = assignment.indexOf('=');
+        if (equalsIndex <= 0)
+            continue;
+        const key = assignment.slice(0, equalsIndex).trim();
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
+            continue;
+        values[key] = unquoteEnvValue(assignment.slice(equalsIndex + 1));
+    }
+    return values;
+}
+function mergeNonEmpty(...sources) {
+    const merged = {};
+    for (const source of sources) {
+        for (const [key, value] of Object.entries(source)) {
+            if (value === '' && merged[key])
+                continue;
+            merged[key] = value;
+        }
+    }
+    return merged;
+}
+function loadProjectEnv(options) {
+    const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const fileEnv = mergeNonEmpty(parseEnvFile(path.join(options.cwd, '.env')), parseEnvFile(path.join(packageRoot, '.env')));
+    for (const [key, value] of Object.entries(fileEnv)) {
+        if (!process.env[key])
+            process.env[key] = value;
+    }
+}
+const options = readCliOptions(process.argv.slice(2), process.env);
+loadProjectEnv(options);
 const output = Writable.toWeb(process.stdout);
 const input = Readable.toWeb(process.stdin);
 const stream = ndJsonStream(output, input);
-const agent = createMastraAcpAgent(readCliOptions(process.argv.slice(2), process.env));
+const agent = createMastraAcpAgent(options);
 const connection = new AgentSideConnection(agent, stream);
 await connection.closed;

--- a/mastra-agents/src/acp/thinking-options.d.ts
+++ b/mastra-agents/src/acp/thinking-options.d.ts
@@ -1,0 +1,25 @@
+export type ThinkingLevel = 'low' | 'medium' | 'high';
+export type ThinkingMetadata = {
+    requestedLevel: ThinkingLevel;
+    status: 'applied';
+    provider: string;
+    providerOptionPath: string;
+    providerOptionValue: unknown;
+} | {
+    requestedLevel?: string;
+    status: 'omitted' | 'invalid_level';
+    reason: string;
+} | {
+    requestedLevel: ThinkingLevel;
+    status: 'unsupported_provider';
+    provider: string;
+    reason: string;
+};
+export type ThinkingProviderOptionsResult = {
+    providerOptions?: Record<string, unknown>;
+    metadata: ThinkingMetadata;
+};
+export declare function resolveThinkingProviderOptions({ modelId, thinkingLevel, }: {
+    modelId: string;
+    thinkingLevel?: string;
+}): ThinkingProviderOptionsResult;

--- a/mastra-agents/src/acp/thinking-options.d.ts
+++ b/mastra-agents/src/acp/thinking-options.d.ts
@@ -3,6 +3,7 @@ export type ThinkingMetadata = {
     requestedLevel: ThinkingLevel;
     status: 'applied';
     provider: string;
+    strategy: 'provider_options' | 'model_name_suffix';
     providerOptionPath: string;
     providerOptionValue: unknown;
 } | {
@@ -16,6 +17,7 @@ export type ThinkingMetadata = {
     reason: string;
 };
 export type ThinkingProviderOptionsResult = {
+    modelId?: string;
     providerOptions?: Record<string, unknown>;
     metadata: ThinkingMetadata;
 };

--- a/mastra-agents/src/acp/thinking-options.js
+++ b/mastra-agents/src/acp/thinking-options.js
@@ -1,0 +1,74 @@
+export function resolveThinkingProviderOptions({ modelId, thinkingLevel, }) {
+    const normalizedLevel = normalizeThinkingLevel(thinkingLevel);
+    if (!thinkingLevel?.trim()) {
+        return {
+            metadata: {
+                status: 'omitted',
+                reason: 'No ACP thinking level was selected',
+            },
+        };
+    }
+    if (!normalizedLevel) {
+        return {
+            metadata: {
+                requestedLevel: thinkingLevel,
+                status: 'invalid_level',
+                reason: `Unknown ACP thinking level ${thinkingLevel}`,
+            },
+        };
+    }
+    const provider = providerFromModelId(modelId);
+    if (provider === 'openai' && isOpenAiReasoningModel(modelId)) {
+        return {
+            providerOptions: {
+                openai: {
+                    reasoningEffort: normalizedLevel,
+                },
+            },
+            metadata: {
+                requestedLevel: normalizedLevel,
+                status: 'applied',
+                provider,
+                providerOptionPath: 'providerOptions.openai.reasoningEffort',
+                providerOptionValue: normalizedLevel,
+            },
+        };
+    }
+    return {
+        metadata: {
+            requestedLevel: normalizedLevel,
+            status: 'unsupported_provider',
+            provider,
+            reason: `No ACP thinking mapping is defined for provider ${provider}`,
+        },
+    };
+}
+function normalizeThinkingLevel(value) {
+    const normalized = value?.trim().toLowerCase();
+    if (normalized === 'low' || normalized === 'medium' || normalized === 'high')
+        return normalized;
+    return undefined;
+}
+function providerFromModelId(modelId) {
+    const normalized = modelId.trim().toLowerCase();
+    if (normalized.includes('/'))
+        return normalized.split('/')[0] || 'unknown';
+    const modelName = modelNameFromModelId(normalized);
+    if (modelName.startsWith('gpt-') || /^o\d/.test(modelName))
+        return 'openai';
+    if (modelName.startsWith('claude-'))
+        return 'anthropic';
+    if (modelName.startsWith('gemini-') || modelName.startsWith('gemma-'))
+        return 'google';
+    if (modelName.startsWith('grok-'))
+        return 'xai';
+    return 'unknown';
+}
+function isOpenAiReasoningModel(modelId) {
+    const modelName = modelNameFromModelId(modelId.trim().toLowerCase());
+    return (modelName.startsWith('gpt-5') ||
+        /^o\d/.test(modelName));
+}
+function modelNameFromModelId(modelId) {
+    return modelId.includes('/') ? modelId.split('/').at(-1) ?? modelId : modelId;
+}

--- a/mastra-agents/src/acp/thinking-options.js
+++ b/mastra-agents/src/acp/thinking-options.js
@@ -1,3 +1,15 @@
+const thinkingLevelAdapters = [
+    {
+        provider: 'openai',
+        strategy: 'provider_options',
+        supportsModel: isOpenAiReasoningModel,
+    },
+    {
+        provider: 'proxy',
+        strategy: 'model_name_suffix',
+        supportsModel: isOpenAiReasoningModel,
+    },
+];
 export function resolveThinkingProviderOptions({ modelId, thinkingLevel, }) {
     const normalizedLevel = normalizeThinkingLevel(thinkingLevel);
     if (!thinkingLevel?.trim()) {
@@ -18,7 +30,8 @@ export function resolveThinkingProviderOptions({ modelId, thinkingLevel, }) {
         };
     }
     const provider = providerFromModelId(modelId);
-    if (provider === 'openai' && isOpenAiReasoningModel(modelId)) {
+    const adapter = thinkingLevelAdapters.find((candidate) => candidate.provider === provider && candidate.supportsModel(modelId));
+    if (adapter?.strategy === 'provider_options') {
         return {
             providerOptions: {
                 openai: {
@@ -29,8 +42,23 @@ export function resolveThinkingProviderOptions({ modelId, thinkingLevel, }) {
                 requestedLevel: normalizedLevel,
                 status: 'applied',
                 provider,
+                strategy: adapter.strategy,
                 providerOptionPath: 'providerOptions.openai.reasoningEffort',
                 providerOptionValue: normalizedLevel,
+            },
+        };
+    }
+    if (adapter?.strategy === 'model_name_suffix') {
+        const effectiveModelId = appendThinkingLevelSuffix(modelId, normalizedLevel);
+        return {
+            modelId: effectiveModelId,
+            metadata: {
+                requestedLevel: normalizedLevel,
+                status: 'applied',
+                provider,
+                strategy: adapter.strategy,
+                providerOptionPath: 'model',
+                providerOptionValue: effectiveModelId,
             },
         };
     }
@@ -65,10 +93,16 @@ function providerFromModelId(modelId) {
     return 'unknown';
 }
 function isOpenAiReasoningModel(modelId) {
-    const modelName = modelNameFromModelId(modelId.trim().toLowerCase());
+    const modelName = stripThinkingLevelSuffix(modelNameFromModelId(modelId.trim().toLowerCase()));
     return (modelName.startsWith('gpt-5') ||
         /^o\d/.test(modelName));
 }
 function modelNameFromModelId(modelId) {
     return modelId.includes('/') ? modelId.split('/').at(-1) ?? modelId : modelId;
+}
+function appendThinkingLevelSuffix(modelId, thinkingLevel) {
+    return `${stripThinkingLevelSuffix(modelId.trim())}(${thinkingLevel})`;
+}
+function stripThinkingLevelSuffix(modelId) {
+    return modelId.replace(/\([^()/]*\)\s*$/, '');
 }

--- a/mastra-agents/src/agents/advisor-agent.ts
+++ b/mastra-agents/src/agents/advisor-agent.ts
@@ -10,11 +10,11 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultAgentModel, withAgentModes } from "./shared.js";
-import { deepWikiMCP } from "../mcp/index.js";
+import { getDeepWikiTools } from "../mcp/index.js";
 
 // Initialize DeepWiki tools for advisor agent
 // DeepWiki helps advisor with repo analysis, integration research, architecture reviews
-const deepWikiTools = await deepWikiMCP.listTools();
+const deepWikiTools = await getDeepWikiTools();
 
 export const advisorAgent = withAgentModes(new Agent({
   id: "advisor-agent",

--- a/mastra-agents/src/agents/agent.ts
+++ b/mastra-agents/src/agents/agent.ts
@@ -1,7 +1,4 @@
-import { createLinearAdapter } from "@chat-adapter/linear";
-import { createGitHubAdapter } from "@chat-adapter/github";
 import { Agent } from "@mastra/core/agent";
-import { createSlackAdapter } from "@chat-adapter/slack";
 
 import {
   supervisorAgentDescription,
@@ -21,53 +18,9 @@ import { createDelegationObservabilityOptions } from "./delegation-observability
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
+import { buildAgentChannels } from "./channels.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeModel, withAgentModes } from "./shared.js";
 import { validatorAgent } from "./validator-agent.js";
-
-function createSupervisorChannelsConfig() {
-  const adapters = {
-    ...(process.env.ENABLE_SLACK_CHANNEL === "true"
-      ? {
-          slack: createSlackAdapter(),
-        }
-      : {}),
-  };
-
-  const githubWebhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
-  const githubAuthConfigured = Boolean(
-    process.env.GITHUB_TOKEN ||
-      (process.env.GITHUB_APP_ID && process.env.GITHUB_PRIVATE_KEY),
-  );
-
-  if (process.env.ENABLE_GITHUB_CHANNEL === "true" && githubWebhookSecret && githubAuthConfigured) {
-    Object.assign(adapters, {
-      github: createGitHubAdapter(),
-    });
-  }
-
-  const linearWebhookSecret = process.env.LINEAR_WEBHOOK_SECRET;
-  const linearAuthConfigured = Boolean(
-    process.env.LINEAR_API_KEY ||
-      process.env.LINEAR_ACCESS_TOKEN ||
-      (process.env.LINEAR_CLIENT_CREDENTIALS_CLIENT_ID &&
-        process.env.LINEAR_CLIENT_CREDENTIALS_CLIENT_SECRET) ||
-      (process.env.LINEAR_CLIENT_ID && process.env.LINEAR_CLIENT_SECRET),
-  );
-
-  if (linearWebhookSecret && linearAuthConfigured) {
-    const linearMode = process.env.LINEAR_CHANNEL_MODE ?? process.env.LINEAR_MODE;
-
-    Object.assign(adapters, {
-      linear: createLinearAdapter({
-        mode: linearMode === "agent-sessions" ? "agent-sessions" : "comments",
-      }),
-    });
-  }
-
-  return Object.keys(adapters).length > 0 ? { adapters } : undefined;
-}
-
-(orchestratorAgent as typeof orchestratorAgent & { channels?: unknown }).channels = createSupervisorChannelsConfig();
 
 export const supervisorAgent = withAgentModes(new Agent({
   id: "supervisor-agent",
@@ -82,6 +35,7 @@ export const supervisorAgent = withAgentModes(new Agent({
     supervisorToolPrompts,
   ),
   model: resolveRuntimeModel,
+  channels: buildAgentChannels(),
   memory: createAgentMemory(),
   workspace,
   defaultOptions: {

--- a/mastra-agents/src/agents/agent.ts
+++ b/mastra-agents/src/agents/agent.ts
@@ -21,7 +21,7 @@ import { createDelegationObservabilityOptions } from "./delegation-observability
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
-import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeSupervisorModel, withAgentModes } from "./shared.js";
+import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeModel, withAgentModes } from "./shared.js";
 import { validatorAgent } from "./validator-agent.js";
 
 function createSupervisorChannelsConfig() {
@@ -81,7 +81,7 @@ export const supervisorAgent = withAgentModes(new Agent({
     supervisorPolicyPrompts,
     supervisorToolPrompts,
   ),
-  model: resolveRuntimeSupervisorModel,
+  model: resolveRuntimeModel,
   memory: createAgentMemory(),
   workspace,
   defaultOptions: {

--- a/mastra-agents/src/agents/agent.ts
+++ b/mastra-agents/src/agents/agent.ts
@@ -13,9 +13,11 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { workspaceTools } from "../tools/workspace.js";
+import { workspace } from "../workspace.js";
 import { advisorAgent } from "./advisor-agent.js";
 import { orchestratorAgent } from "./orchestrator-agent.js";
 import { architectAgent } from "./architect-agent.js";
+import { createDelegationObservabilityOptions } from "./delegation-observability.js";
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
@@ -65,7 +67,7 @@ function createSupervisorChannelsConfig() {
   return Object.keys(adapters).length > 0 ? { adapters } : undefined;
 }
 
-orchestratorAgent.channels = createSupervisorChannelsConfig();
+(orchestratorAgent as typeof orchestratorAgent & { channels?: unknown }).channels = createSupervisorChannelsConfig();
 
 export const supervisorAgent = withAgentModes(new Agent({
   id: "supervisor-agent",
@@ -81,7 +83,14 @@ export const supervisorAgent = withAgentModes(new Agent({
   ),
   model: defaultSupervisorModel,
   memory: createAgentMemory(),
-  defaultOptions: agentDefaultOptions.supervisor,
+  workspace,
+  defaultOptions: {
+    ...agentDefaultOptions.supervisor,
+    delegation: createDelegationObservabilityOptions({
+      parentAgentId: "supervisor-agent",
+      parentAgentName: "Supervisor Lead",
+    }),
+  },
   agents: {
     scoutAgent,
     researcherAgent,

--- a/mastra-agents/src/agents/agent.ts
+++ b/mastra-agents/src/agents/agent.ts
@@ -75,7 +75,7 @@ export const supervisorAgent = withAgentModes(new Agent({
   description: supervisorAgentDescription,
   instructions: composeAgentInstructions(
     supervisorInstructionsPrompt,
-    supervisorModePrompts.balanced, // Active mode prompt injected into instruction string
+    supervisorModePrompts.base, // Active scope prompt injected into instruction string
     sharedPolicyPrompts.supervisor,
     sharedToolPrompts.supervisor,
     supervisorPolicyPrompts,
@@ -108,7 +108,7 @@ export const supervisorAgent = withAgentModes(new Agent({
     git_snapshot_query: workspaceTools.gitSnapshotQuery,
     capture_snapshot: workspaceTools.captureSnapshot,
   },
-}), agentModesFromPrompts(supervisorModePrompts));
+}), agentModesFromPrompts(supervisorModePrompts, "base"));
 
 export const mastraAgents = {
   orchestratorAgent,

--- a/mastra-agents/src/agents/agent.ts
+++ b/mastra-agents/src/agents/agent.ts
@@ -21,7 +21,7 @@ import { createDelegationObservabilityOptions } from "./delegation-observability
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
-import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultSupervisorModel, withAgentModes } from "./shared.js";
+import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeSupervisorModel, withAgentModes } from "./shared.js";
 import { validatorAgent } from "./validator-agent.js";
 
 function createSupervisorChannelsConfig() {
@@ -81,7 +81,7 @@ export const supervisorAgent = withAgentModes(new Agent({
     supervisorPolicyPrompts,
     supervisorToolPrompts,
   ),
-  model: defaultSupervisorModel,
+  model: resolveRuntimeSupervisorModel,
   memory: createAgentMemory(),
   workspace,
   defaultOptions: {

--- a/mastra-agents/src/agents/channels.test.js
+++ b/mastra-agents/src/agents/channels.test.js
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const packageRoot = path.resolve(import.meta.dirname, "../..");
+const bundleDir = path.join(packageRoot, ".cache/channels-test");
+const bundlePath = path.join(bundleDir, "channels.mjs");
+const esbuildBin = path.resolve(packageRoot, "../node_modules/.bin/esbuild");
+
+function buildChannelsBundle() {
+  rmSync(bundleDir, { recursive: true, force: true });
+  mkdirSync(bundleDir, { recursive: true });
+  execFileSync(esbuildBin, [
+    "src/agents/channels.ts",
+    "--bundle",
+    "--platform=node",
+    "--format=esm",
+    `--outfile=${bundlePath}`,
+    "--external:@chat-adapter/*",
+  ], { cwd: packageRoot, stdio: "pipe" });
+}
+
+function readChannelState(env) {
+  const script = `
+    import { Agent } from "@mastra/core/agent";
+    import { pathToFileURL } from "node:url";
+
+    const channels = await import(pathToFileURL(${JSON.stringify(bundlePath)}));
+    const channelConfig = channels.buildAgentChannels();
+    const agent = new Agent({
+      id: channels.publicChannelAgentId,
+      name: "Supervisor",
+      instructions: "test",
+      model: () => {
+        throw new Error("model should not be resolved during route inspection");
+      },
+      channels: channelConfig,
+    });
+    const routes = agent.getChannels()?.getWebhookRoutes().map((route) => ({
+      method: route.method,
+      path: route.path,
+    })) ?? [];
+    const apiRoutes = channels.channelWebhookApiRoutesForAgents({ orchestratorAgent: agent }).map((route) => ({
+      method: route.method,
+      path: route.path,
+      internal: route._mastraInternal,
+    }));
+    const linearAdapter = channelConfig?.adapters?.linear;
+    console.log(JSON.stringify({
+      enabled: channels.listEnabledChannelPlatforms(),
+      expected: channels.expectedChannelWebhookRoutes().map(({ method, path }) => ({ method, path })),
+      supervisorExpected: channels.expectedChannelWebhookRoutes("supervisor-agent").map(({ method, path }) => ({ method, path })),
+      apiRoutes,
+      routes,
+      status: channels.resolveAgentChannelStatus(),
+      linearAdapter: linearAdapter ? {
+        mode: linearAdapter.mode,
+        hasDefaultClient: Boolean(linearAdapter.defaultClient),
+        hasClientCredentials: Boolean(linearAdapter.clientCredentials),
+        hasOAuthClient: Boolean(linearAdapter.oauthClientId),
+      } : null,
+    }));
+    process.exit(0);
+  `;
+
+  const output = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(output);
+}
+
+test("channel status requires webhook secrets and auth before enabling adapters", () => {
+  buildChannelsBundle();
+  const state = readChannelState({
+    ENABLE_SLACK_CHANNEL: "true",
+    ENABLE_GITHUB_CHANNEL: "true",
+    SLACK_SIGNING_SECRET: "",
+    SLACK_BOT_TOKEN: "",
+    SLACK_CLIENT_ID: "",
+    SLACK_CLIENT_SECRET: "",
+    GITHUB_WEBHOOK_SECRET: "",
+    GITHUB_TOKEN: "",
+    GITHUB_APP_ID: "",
+    GITHUB_PRIVATE_KEY: "",
+    LINEAR_WEBHOOK_SECRET: "",
+    LINEAR_API_KEY: "",
+    LINEAR_ACCESS_TOKEN: "",
+    LINEAR_CLIENT_ID: "",
+    LINEAR_CLIENT_SECRET: "",
+    LINEAR_CLIENT_CREDENTIALS_CLIENT_ID: "",
+    LINEAR_CLIENT_CREDENTIALS_CLIENT_SECRET: "",
+  });
+
+  assert.deepEqual(state.enabled, []);
+  assert.equal(state.status.slack.enabled, false);
+  assert.equal(state.status.github.enabled, false);
+  assert.equal(state.status.linear.enabled, false);
+  assert.deepEqual(state.routes, []);
+});
+
+test("enabled channels generate supervisor webhook routes", () => {
+  buildChannelsBundle();
+  const state = readChannelState({
+    ENABLE_SLACK_CHANNEL: "true",
+    SLACK_SIGNING_SECRET: "slack-secret",
+    SLACK_BOT_TOKEN: "xoxb-test",
+    ENABLE_GITHUB_CHANNEL: "true",
+    GITHUB_WEBHOOK_SECRET: "github-secret",
+    GITHUB_TOKEN: "github-token",
+    LINEAR_WEBHOOK_SECRET: "linear-secret",
+    LINEAR_API_KEY: "linear-api-key",
+    LINEAR_CHANNEL_MODE: "comments",
+  });
+
+  assert.deepEqual(state.enabled, ["slack", "github", "linear"]);
+  assert.deepEqual(state.expected, [
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/slack/webhook" },
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/github/webhook" },
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/linear/webhook" },
+  ]);
+  assert.deepEqual(state.routes, state.expected);
+  assert.deepEqual(state.apiRoutes, [
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/slack/webhook", internal: true },
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/github/webhook", internal: true },
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/linear/webhook", internal: true },
+  ]);
+  assert.deepEqual(state.supervisorExpected, [
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/slack/webhook" },
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/github/webhook" },
+    { method: "POST", path: "/api/agents/supervisor-agent/channels/linear/webhook" },
+  ]);
+  assert.equal(state.status.linear.mode, "comments");
+});
+
+test("Linear multi-tenant OAuth credentials take precedence over API key fallback", () => {
+  buildChannelsBundle();
+  const state = readChannelState({
+    LINEAR_WEBHOOK_SECRET: "linear-secret",
+    LINEAR_API_KEY: "stale-local-api-key",
+    LINEAR_CLIENT_ID: "linear-client-id",
+    LINEAR_CLIENT_SECRET: "linear-client-secret",
+    LINEAR_CHANNEL_MODE: "agent-sessions",
+  });
+
+  assert.deepEqual(state.enabled, ["linear"]);
+  assert.equal(state.status.linear.mode, "agent-sessions");
+  assert.deepEqual(state.linearAdapter, {
+    mode: "agent-sessions",
+    hasDefaultClient: false,
+    hasClientCredentials: false,
+    hasOAuthClient: true,
+  });
+});

--- a/mastra-agents/src/agents/channels.ts
+++ b/mastra-agents/src/agents/channels.ts
@@ -1,0 +1,246 @@
+import { createLinearAdapter } from "@chat-adapter/linear";
+import { createGitHubAdapter } from "@chat-adapter/github";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createPostgresState } from "@chat-adapter/state-pg";
+
+export const publicChannelAgentId = "supervisor-agent";
+export const publicChannelAgentIds = ["supervisor-agent"] as const;
+export const channelPlatforms = ["slack", "github", "linear"] as const;
+const defaultPostgresUrl = "postgresql://mastra:mastra@mastra-postgres:5432/mastra";
+
+export type ChannelPlatform = (typeof channelPlatforms)[number];
+
+export interface AgentChannelsConfig {
+  envPrefix?: string;
+  slack?: {
+    enableKey?: string;
+    botTokenKey?: string;
+    signingSecretKey?: string;
+    clientIdKey?: string;
+    clientSecretKey?: string;
+  };
+  github?: {
+    enableKey?: string;
+    webhookSecretKey?: string;
+    tokenKey?: string;
+    appIdKey?: string;
+    privateKeyKey?: string;
+  };
+  linear?: {
+    webhookSecretKey?: string;
+    apiKeyKey?: string;
+    accessTokenKey?: string;
+    clientIdKey?: string;
+    clientSecretKey?: string;
+    encryptionKeyKey?: string;
+    clientCredentialsIdKey?: string;
+    clientCredentialsSecretKey?: string;
+    oauthScopesKey?: string;
+    modeKey?: string;
+    fallbackModeKey?: string;
+  };
+}
+
+export interface ChannelStatus {
+  enabled: boolean;
+  reason?: string;
+  mode?: string;
+}
+
+export type ChannelStatusMap = Record<ChannelPlatform, ChannelStatus>;
+
+function getEnv(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined;
+}
+
+function getLinearMode(config: AgentChannelsConfig = {}) {
+  const linearMode =
+    getEnv(config.linear?.modeKey ?? "LINEAR_CHANNEL_MODE") ??
+    getEnv(config.linear?.fallbackModeKey ?? "LINEAR_MODE");
+  return linearMode === "agent-sessions" ? "agent-sessions" : "comments";
+}
+
+function getLinearOAuthScopes(config: AgentChannelsConfig = {}) {
+  return (
+    getEnv(config.linear?.oauthScopesKey ?? "LINEAR_OAUTH_SCOPES") ??
+    "read,write,comments:create,issues:create,app:mentionable,app:assignable"
+  )
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+function getLinearClientCredentialsScopes(config: AgentChannelsConfig = {}) {
+  return (
+    getEnv("LINEAR_CLIENT_CREDENTIALS_SCOPES") ??
+    getLinearOAuthScopes(config).join(",")
+  )
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+function buildLinearAdapterConfig(config: AgentChannelsConfig = {}) {
+  const mode = getLinearMode(config);
+  const clientId = getEnv(config.linear?.clientIdKey ?? "LINEAR_CLIENT_ID");
+  const clientSecret = getEnv(config.linear?.clientSecretKey ?? "LINEAR_CLIENT_SECRET");
+  const clientCredentialsClientId = getEnv(
+    config.linear?.clientCredentialsIdKey ?? "LINEAR_CLIENT_CREDENTIALS_CLIENT_ID",
+  );
+  const clientCredentialsClientSecret = getEnv(
+    config.linear?.clientCredentialsSecretKey ?? "LINEAR_CLIENT_CREDENTIALS_CLIENT_SECRET",
+  );
+
+  if (clientId && clientSecret) {
+    return {
+      clientId,
+      clientSecret,
+      mode,
+    };
+  }
+
+  if (clientCredentialsClientId && clientCredentialsClientSecret) {
+    return {
+      clientCredentials: {
+        clientId: clientCredentialsClientId,
+        clientSecret: clientCredentialsClientSecret,
+        scopes: getLinearClientCredentialsScopes(config),
+      },
+      mode,
+    };
+  }
+
+  return { mode };
+}
+
+export function resolveAgentChannelStatus(config: AgentChannelsConfig = {}): ChannelStatusMap {
+  const slackEnable = getEnv(config.slack?.enableKey ?? "ENABLE_SLACK_CHANNEL");
+  const slackSigningSecret = getEnv(config.slack?.signingSecretKey ?? "SLACK_SIGNING_SECRET");
+  const slackAuthConfigured = Boolean(
+    getEnv(config.slack?.botTokenKey ?? "SLACK_BOT_TOKEN") ||
+      (getEnv(config.slack?.clientIdKey ?? "SLACK_CLIENT_ID") &&
+        getEnv(config.slack?.clientSecretKey ?? "SLACK_CLIENT_SECRET")),
+  );
+
+  const ghEnable = getEnv(config.github?.enableKey ?? "ENABLE_GITHUB_CHANNEL");
+  const ghWebhookSecret = getEnv(config.github?.webhookSecretKey ?? "GITHUB_WEBHOOK_SECRET");
+  const ghAuthConfigured = Boolean(
+    getEnv(config.github?.tokenKey ?? "GITHUB_TOKEN") ||
+      (getEnv(config.github?.appIdKey ?? "GITHUB_APP_ID") &&
+        getEnv(config.github?.privateKeyKey ?? "GITHUB_PRIVATE_KEY")),
+  );
+
+  const linearWebhookSecret = getEnv(config.linear?.webhookSecretKey ?? "LINEAR_WEBHOOK_SECRET");
+  const linearClientId = getEnv(config.linear?.clientIdKey ?? "LINEAR_CLIENT_ID");
+  const linearClientSecret = getEnv(config.linear?.clientSecretKey ?? "LINEAR_CLIENT_SECRET");
+  const linearAuthConfigured = Boolean(
+    (linearClientId && linearClientSecret) ||
+      getEnv(config.linear?.accessTokenKey ?? "LINEAR_ACCESS_TOKEN") ||
+      (getEnv(config.linear?.clientCredentialsIdKey ?? "LINEAR_CLIENT_CREDENTIALS_CLIENT_ID") &&
+        getEnv(config.linear?.clientCredentialsSecretKey ?? "LINEAR_CLIENT_CREDENTIALS_CLIENT_SECRET")) ||
+      getEnv(config.linear?.apiKeyKey ?? "LINEAR_API_KEY"),
+  );
+
+  return {
+    slack:
+      slackEnable !== "true"
+        ? { enabled: false, reason: "ENABLE_SLACK_CHANNEL is not true" }
+        : !slackSigningSecret
+          ? { enabled: false, reason: "SLACK_SIGNING_SECRET is not set" }
+          : !slackAuthConfigured
+            ? { enabled: false, reason: "Slack auth is not configured" }
+            : { enabled: true, mode: "webhook" },
+    github:
+      ghEnable !== "true"
+        ? { enabled: false, reason: "ENABLE_GITHUB_CHANNEL is not true" }
+        : !ghWebhookSecret
+          ? { enabled: false, reason: "GITHUB_WEBHOOK_SECRET is not set" }
+          : !ghAuthConfigured
+            ? { enabled: false, reason: "GitHub auth is not configured" }
+            : { enabled: true, mode: "webhook" },
+    linear:
+      !linearWebhookSecret
+        ? { enabled: false, reason: "LINEAR_WEBHOOK_SECRET is not set" }
+        : !linearAuthConfigured
+          ? { enabled: false, reason: "Linear auth is not configured" }
+          : { enabled: true, mode: getLinearMode(config) },
+  };
+}
+
+export function listEnabledChannelPlatforms(config: AgentChannelsConfig = {}) {
+  const status = resolveAgentChannelStatus(config);
+  return channelPlatforms.filter((platform) => status[platform].enabled);
+}
+
+export function expectedChannelWebhookRoutes(agentId = publicChannelAgentId, config: AgentChannelsConfig = {}) {
+  return listEnabledChannelPlatforms(config).map((platform) => ({
+    method: "POST",
+    path: `/api/agents/${agentId}/channels/${platform}/webhook`,
+    platform,
+  }));
+}
+
+export function listConfiguredChannelWebhookRoutes(routes: Array<{ method?: string; path?: string }> = []) {
+  return routes
+    .filter((route) => route.method === "POST" && route.path?.includes("/channels/") && route.path.endsWith("/webhook"))
+    .map((route) => ({ method: route.method ?? "POST", path: route.path ?? "" }));
+}
+
+export function channelWebhookApiRoutesForAgents(
+  agents: Record<string, { getChannels?: () => { getWebhookRoutes?: () => unknown[] } | null }>,
+) {
+  const seen = new Set<string>();
+  const routes: unknown[] = [];
+
+  for (const agent of Object.values(agents)) {
+    for (const route of agent.getChannels?.()?.getWebhookRoutes?.() ?? []) {
+      const routeKey = routeKeyFor(route);
+      if (seen.has(routeKey)) continue;
+      seen.add(routeKey);
+      routes.push(markMastraInternalRoute(route));
+    }
+  }
+
+  return routes;
+}
+
+function markMastraInternalRoute(route: unknown) {
+  if (!route || typeof route !== "object") return route;
+  return {
+    ...route,
+    _mastraInternal: true,
+  };
+}
+
+function routeKeyFor(route: unknown) {
+  if (!route || typeof route !== "object") return String(route);
+  const candidate = route as { method?: unknown; path?: unknown };
+  return `${String(candidate.method ?? "")} ${String(candidate.path ?? "")}`;
+}
+
+export function buildAgentChannels(config: AgentChannelsConfig = {}) {
+  const adapters: Record<string, unknown> = {};
+  const status = resolveAgentChannelStatus(config);
+
+  if (status.slack.enabled) {
+    adapters.slack = createSlackAdapter();
+  }
+
+  if (status.github.enabled) {
+    adapters.github = createGitHubAdapter();
+  }
+
+  if (status.linear.enabled) {
+    adapters.linear = createLinearAdapter(buildLinearAdapterConfig(config));
+  }
+
+  return Object.keys(adapters).length > 0
+    ? {
+      adapters,
+      state: createPostgresState({
+        url: process.env.POSTGRES_URL ?? process.env.DATABASE_URL ?? defaultPostgresUrl,
+        keyPrefix: process.env.MASTRA_CHANNEL_STATE_PREFIX ?? "mastra-agents-channels",
+      }),
+    }
+    : undefined;
+}

--- a/mastra-agents/src/agents/delegation-observability.d.ts
+++ b/mastra-agents/src/agents/delegation-observability.d.ts
@@ -1,0 +1,6 @@
+import type { DelegationConfig } from "@mastra/core/dist/agent/agent.types.js";
+
+export function createDelegationObservabilityOptions(options?: {
+  parentAgentId?: string;
+  parentAgentName?: string;
+}): DelegationConfig;

--- a/mastra-agents/src/agents/delegation-observability.js
+++ b/mastra-agents/src/agents/delegation-observability.js
@@ -1,0 +1,46 @@
+import {
+  delegationCompletePayloadFromContext,
+  delegationStartPayloadFromContext,
+  emitDelegationEvent,
+} from "../workflows/delegation-event.js";
+
+export function createDelegationObservabilityOptions(options = {}) {
+  const source = {
+    parentAgentId: options.parentAgentId,
+    parentAgentName: options.parentAgentName,
+  };
+  const activeDelegations = new Map();
+
+  return {
+    onDelegationStart: (context) => {
+      const payload = {
+        ...delegationStartPayloadFromContext({
+          ...context,
+          ...source,
+        }),
+        source: "delegation-hook",
+      };
+      if (context.toolCallId) {
+        activeDelegations.set(context.toolCallId, {
+          threadId: payload.threadId,
+          resourceId: payload.resourceId,
+        });
+      }
+      emitDelegationEvent(payload);
+    },
+    onDelegationComplete: (context) => {
+      const correlation = context.toolCallId ? activeDelegations.get(context.toolCallId) : undefined;
+      if (context.toolCallId) {
+        activeDelegations.delete(context.toolCallId);
+      }
+      emitDelegationEvent({
+        ...delegationCompletePayloadFromContext({
+          ...context,
+          ...correlation,
+          ...source,
+        }),
+        source: "delegation-hook",
+      });
+    },
+  };
+}

--- a/mastra-agents/src/agents/developer-agent.ts
+++ b/mastra-agents/src/agents/developer-agent.ts
@@ -11,11 +11,11 @@ import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { workspaceTools } from "../tools/workspace.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultAgentModel, withAgentModes } from "./shared.js";
-import { deepWikiMCP } from "../mcp/index.js";
+import { getDeepWikiTools } from "../mcp/index.js";
 
 // Initialize DeepWiki tools for developer agent
 // DeepWiki helps developer with understanding external codebases, fork planning, integration
-const deepWikiTools = await deepWikiMCP.listTools();
+const deepWikiTools = await getDeepWikiTools();
 
 export const developerAgent = withAgentModes(new Agent({
   id: "developer-agent",

--- a/mastra-agents/src/agents/harness-modes.ts
+++ b/mastra-agents/src/agents/harness-modes.ts
@@ -1,0 +1,307 @@
+import { orchestratorModePrompts } from "../prompts/agents/orchestrator.js";
+import { supervisorModePrompts } from "../prompts/agents/supervisor.js";
+import { sharedAgentModeNames, type AgentModePromptMap, type SharedAgentModeId } from "./shared.js";
+
+export const REQUEST_CONTEXT_HARNESS_MODE_KEY = "harnessMode";
+export const REQUEST_CONTEXT_HARNESS_MODE_ID_KEY = "harnessModeId";
+export const REQUEST_CONTEXT_ACTIVE_AGENT_ID_KEY = "activeAgentId";
+export const REQUEST_CONTEXT_LAST_SUBMITTED_HARNESS_MODE_ID_KEY = "lastSubmittedHarnessModeId";
+export const REQUEST_CONTEXT_HARDNESS_MODE_KEY = "hardnessMode";
+
+export type MastraAgentHarnessAgentId = "orchestrator" | "supervisor";
+export type SupervisorScopeId = "base" | "scope" | "spec" | "exec";
+export type OrchestratorModeId = "quick" | "precision" | "auto";
+export type MastraAgentHarnessLocalModeId = SupervisorScopeId | OrchestratorModeId;
+
+export type MastraAgentHarnessModeId =
+  | `supervisor.${SupervisorScopeId}`
+  | `orchestrator.${OrchestratorModeId}`;
+
+export type MastraAgentHarnessState = {
+  activeAgentId?: MastraAgentHarnessAgentId;
+  supervisorScope?: SupervisorScopeId;
+  orchestratorMode?: OrchestratorModeId;
+  modelId?: string;
+  workspaceSettings?: Record<string, unknown>;
+  toolSettings?: Record<string, unknown>;
+  runtimeSettings?: Record<string, unknown>;
+  harnessMode?: MastraAgentHarnessLocalModeId;
+  harnessModeId?: MastraAgentHarnessModeId;
+  lastSubmittedHarnessModeId?: MastraAgentHarnessModeId;
+  /** @deprecated Use harnessMode or harnessModeId. */
+  hardnessMode?: string;
+};
+
+type AgentModeDefinition = {
+  agentId: MastraAgentHarnessAgentId;
+  agentName: string;
+  modePrompts: AgentModePromptMap;
+};
+
+export type ResolvedMastraAgentHarnessMode = {
+  activeAgentId: MastraAgentHarnessAgentId;
+  agentName: string;
+  harnessMode: MastraAgentHarnessLocalModeId;
+  supervisorScope?: SupervisorScopeId;
+  orchestratorMode?: OrchestratorModeId;
+  harnessModeName: string;
+  harnessModeId: MastraAgentHarnessModeId;
+  modePrompt: string;
+};
+
+export type MastraAgentHarnessModeSpec = {
+  id: MastraAgentHarnessModeId;
+  agentId: MastraAgentHarnessAgentId;
+  harnessMode: MastraAgentHarnessLocalModeId;
+  name: string;
+  default: boolean;
+  color: string;
+};
+
+export const DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID = "orchestrator" satisfies MastraAgentHarnessAgentId;
+export const DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE = "auto" satisfies OrchestratorModeId;
+export const DEFAULT_MASTRA_AGENT_HARNESS_MODE_ID =
+  `${DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID}.${DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE}` as const;
+
+export const mastraAgentModeDefinitions = {
+  orchestrator: {
+    agentId: "orchestrator",
+    agentName: "Orchestrator",
+    modePrompts: orchestratorModePrompts,
+  },
+  supervisor: {
+    agentId: "supervisor",
+    agentName: "Supervisor Lead",
+    modePrompts: supervisorModePrompts,
+  },
+} as const satisfies Record<MastraAgentHarnessAgentId, AgentModeDefinition>;
+
+const agentAliasToAgentId = new Map<string, MastraAgentHarnessAgentId>([
+  ["orchestrator", "orchestrator"],
+  ["orchestrator-agent", "orchestrator"],
+  ["orchestratoragent", "orchestrator"],
+  ["supervisor", "supervisor"],
+  ["supervisor-agent", "supervisor"],
+  ["supervisoragent", "supervisor"],
+  ["supervisor-lead", "supervisor"],
+  ["supervisorlead", "supervisor"],
+]);
+
+const supervisorScopeAliases = new Map<string, SupervisorScopeId>([
+  ["base", "base"],
+  ["balance", "base"],
+  ["balanced", "base"],
+  ["scope", "scope"],
+  ["spec", "spec"],
+  ["plan", "spec"],
+  ["exec", "exec"],
+  ["execution", "exec"],
+  ["build", "exec"],
+  ["verify", "exec"],
+]);
+
+const orchestratorModeAliases = new Map<string, OrchestratorModeId>([
+  ["quick", "quick"],
+  ["precision", "precision"],
+  ["precise", "precision"],
+  ["auto", "auto"],
+  ["balanced", "auto"],
+  ["balance", "auto"],
+  ["build", "auto"],
+  ["scope", "precision"],
+  ["plan", "precision"],
+  ["verify", "precision"],
+]);
+
+export const mastraAgentHarnessModeSpecs: MastraAgentHarnessModeSpec[] = Object.values(mastraAgentModeDefinitions).flatMap(
+  (definition) =>
+    Object.entries(definition.modePrompts).map(([modeId]) => {
+      const harnessMode = modeId as MastraAgentHarnessLocalModeId;
+      const compositeModeId = `${definition.agentId}.${harnessMode}` as MastraAgentHarnessModeId;
+      return {
+        id: compositeModeId,
+        agentId: definition.agentId,
+        harnessMode,
+        name: `${definition.agentName} / ${sharedAgentModeNames[harnessMode]}`,
+        default: compositeModeId === DEFAULT_MASTRA_AGENT_HARNESS_MODE_ID,
+        color: harnessModeColor(harnessMode),
+      };
+    }),
+);
+
+const defaultModeId = (mastraAgentHarnessModeSpecs.find((mode) => mode.default) ?? mastraAgentHarnessModeSpecs[0]).id;
+
+export function defaultMastraAgentHarnessModeId(): MastraAgentHarnessModeId {
+  return defaultModeId;
+}
+
+export function isMastraAgentHarnessModeId(value: unknown): value is MastraAgentHarnessModeId {
+  return typeof value === "string" && mastraAgentHarnessModeSpecs.some((mode) => mode.id === value);
+}
+
+export function resolveMastraAgentHarnessMode({
+  agentId,
+  harnessMode,
+  hardnessMode,
+}: {
+  agentId?: string;
+  harnessMode?: string;
+  /** @deprecated Use harnessMode. */
+  hardnessMode?: string;
+}): ResolvedMastraAgentHarnessMode {
+  const requestedHarnessMode = cleanInput(harnessMode);
+  const requestedDeprecatedHardnessMode = cleanInput(hardnessMode);
+  const requestedMode = requestedHarnessMode ?? requestedDeprecatedHardnessMode;
+
+  if (requestedMode) {
+    const compositeModeId = parseCompositeModeId(requestedMode);
+    if (compositeModeId) {
+      return resolvedModeFromId(compositeModeId);
+    }
+
+    const activeAgentId = resolveAgentId(agentId) ?? DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID;
+    const localModeId = resolveLocalModeId(requestedMode, activeAgentId);
+    if (localModeId) {
+      return resolvedMode(activeAgentId, localModeId);
+    }
+
+    if (!requestedHarnessMode) {
+      const legacyAgentId = resolveAgentId(requestedMode);
+      if (legacyAgentId) {
+        return resolvedMode(legacyAgentId, defaultLocalModeForAgent(legacyAgentId));
+      }
+    }
+
+    throw new Error(
+      `Unknown harness mode "${requestedMode}". Expected a local mode (${allLocalModeIds().join(", ")}) or composite mode (${mastraAgentHarnessModeSpecs.map((mode) => mode.id).join(", ")}).`,
+    );
+  }
+
+  const activeAgentId = resolveAgentId(agentId);
+  if (!activeAgentId && agentId) {
+    throw new Error(`Unknown agentId "${agentId}". Expected one of: ${Object.keys(mastraAgentModeDefinitions).join(", ")}`);
+  }
+
+  const resolvedAgentId = activeAgentId ?? DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID;
+  return resolvedMode(resolvedAgentId, defaultLocalModeForAgent(resolvedAgentId));
+}
+
+export function resolveMastraAgentHarnessModeId({
+  agentId,
+  harnessMode,
+  hardnessMode,
+}: {
+  agentId?: string;
+  harnessMode?: string;
+  /** @deprecated Use harnessMode. */
+  hardnessMode?: string;
+}): MastraAgentHarnessModeId {
+  return resolveMastraAgentHarnessMode({ agentId, harnessMode, hardnessMode }).harnessModeId;
+}
+
+export function formatMastraAgentHarnessModePrompt(resolved: ResolvedMastraAgentHarnessMode): string {
+  return [
+    `<harness-mode id="${resolved.harnessModeId}" agent="${resolved.activeAgentId}" mode="${resolved.harnessMode}">`,
+    `Agent: ${resolved.agentName}`,
+    `Mode: ${resolved.harnessModeName}`,
+    resolved.modePrompt.trim(),
+    `</harness-mode>`,
+  ].join("\n");
+}
+
+function resolvedMode(activeAgentId: MastraAgentHarnessAgentId, harnessMode: MastraAgentHarnessLocalModeId): ResolvedMastraAgentHarnessMode {
+  const definition = mastraAgentModeDefinitions[activeAgentId];
+  const modePrompts = definition.modePrompts as AgentModePromptMap;
+  const modePrompt = modePrompts[harnessMode];
+  if (!modePrompt) {
+    const expected = Object.keys(modePrompts).join(", ");
+    throw new Error(`Agent "${activeAgentId}" does not support harness mode "${harnessMode}". Expected one of: ${expected}`);
+  }
+  return {
+    activeAgentId,
+    agentName: definition.agentName,
+    harnessMode,
+    supervisorScope: activeAgentId === "supervisor" ? harnessMode as SupervisorScopeId : undefined,
+    orchestratorMode: activeAgentId === "orchestrator" ? harnessMode as OrchestratorModeId : undefined,
+    harnessModeName: sharedAgentModeNames[harnessMode],
+    harnessModeId: `${activeAgentId}.${harnessMode}` as MastraAgentHarnessModeId,
+    modePrompt,
+  };
+}
+
+function resolvedModeFromId(harnessModeId: MastraAgentHarnessModeId): ResolvedMastraAgentHarnessMode {
+  const [agentId, localModeId] = harnessModeId.split(".") as [MastraAgentHarnessAgentId, MastraAgentHarnessLocalModeId];
+  return resolvedMode(agentId, localModeId);
+}
+
+function parseCompositeModeId(value: string): MastraAgentHarnessModeId | undefined {
+  const [agentPart, modePart, extra] = value.toLowerCase().replace(/_/g, "-").split(".");
+  if (!agentPart || !modePart || extra) return undefined;
+  const agentId = resolveAgentId(agentPart);
+  const modeId = agentId ? resolveLocalModeId(modePart, agentId) : undefined;
+  if (!agentId || !modeId) return undefined;
+  const harnessModeId = `${agentId}.${modeId}` as MastraAgentHarnessModeId;
+  return isMastraAgentHarnessModeId(harnessModeId) ? harnessModeId : undefined;
+}
+
+function resolveAgentId(value: string | undefined): MastraAgentHarnessAgentId | undefined {
+  const normalized = normalizeAlias(value);
+  return normalized ? agentAliasToAgentId.get(normalized) : undefined;
+}
+
+function resolveLocalModeId(value: string, agentId: MastraAgentHarnessAgentId): MastraAgentHarnessLocalModeId | undefined {
+  const normalized = normalizeAlias(value);
+  return agentId === "supervisor" ? supervisorScopeAliases.get(normalized) : orchestratorModeAliases.get(normalized);
+}
+
+function defaultLocalModeForAgent(agentId: MastraAgentHarnessAgentId): MastraAgentHarnessLocalModeId {
+  return agentId === "supervisor" ? "base" : DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE;
+}
+
+function cleanInput(value: string | undefined): string | undefined {
+  const clean = value?.trim();
+  return clean ? clean : undefined;
+}
+
+function normalizeAlias(value: string | undefined): string {
+  return value?.trim().toLowerCase().replace(/_/g, "-") ?? "";
+}
+
+function allLocalModeIds(): MastraAgentHarnessLocalModeId[] {
+  return Array.from(new Set(Object.values(mastraAgentModeDefinitions).flatMap((definition) => Object.keys(definition.modePrompts)))) as MastraAgentHarnessLocalModeId[];
+}
+
+function harnessModeColor(modeId: SharedAgentModeId): string {
+  switch (modeId) {
+    case "base":
+    case "balanced":
+      return "#2563eb";
+    case "scope":
+      return "#0891b2";
+    case "spec":
+    case "plan":
+      return "#7c3aed";
+    case "exec":
+    case "build":
+      return "#16a34a";
+    case "quick":
+      return "#0d9488";
+    case "precision":
+      return "#7c2d12";
+    case "auto":
+      return "#2563eb";
+    case "verify":
+    case "test":
+      return "#0f766e";
+    case "research":
+      return "#4f46e5";
+    case "brainstorm":
+      return "#d97706";
+    case "analysis":
+      return "#9333ea";
+    case "audit":
+      return "#dc2626";
+    case "debug":
+      return "#ea580c";
+  }
+}

--- a/mastra-agents/src/agents/harness-modes.ts
+++ b/mastra-agents/src/agents/harness-modes.ts
@@ -21,6 +21,7 @@ export type MastraAgentHarnessState = {
   activeAgentId?: MastraAgentHarnessAgentId;
   supervisorScope?: SupervisorScopeId;
   orchestratorMode?: OrchestratorModeId;
+  currentModelId?: string;
   modelId?: string;
   workspaceSettings?: Record<string, unknown>;
   toolSettings?: Record<string, unknown>;

--- a/mastra-agents/src/agents/harness.test.js
+++ b/mastra-agents/src/agents/harness.test.js
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const packageRoot = path.resolve(import.meta.dirname, "../..");
+const bundleDir = path.join(packageRoot, ".cache/harness-test");
+const bundlePath = path.join(bundleDir, "harness.mjs");
+const esbuildBin = path.resolve(packageRoot, "../node_modules/.bin/esbuild");
+
+function buildHarnessBundle() {
+  rmSync(bundleDir, { recursive: true, force: true });
+  mkdirSync(bundleDir, { recursive: true });
+  execFileSync(esbuildBin, [
+    "src/agents/harness-modes.ts",
+    "--bundle",
+    "--platform=node",
+    "--format=esm",
+    `--outfile=${bundlePath}`,
+    "--external:@mastra/*",
+    "--external:@chat-adapter/*",
+    "--external:zod",
+  ], { cwd: packageRoot, stdio: "pipe" });
+}
+
+function readHarnessState() {
+  const script = `
+    import { pathToFileURL } from "node:url";
+    const harness = await import(pathToFileURL(${JSON.stringify(bundlePath)}));
+    const resolve = (input) => {
+      const mode = harness.resolveMastraAgentHarnessMode(input);
+      return {
+        activeAgentId: mode.activeAgentId,
+        harnessMode: mode.harnessMode,
+        harnessModeId: mode.harnessModeId,
+        supervisorScope: mode.supervisorScope,
+        orchestratorMode: mode.orchestratorMode,
+      };
+    };
+    const rejects = (input) => {
+      try {
+        harness.resolveMastraAgentHarnessMode(input);
+        return false;
+      } catch {
+        return true;
+      }
+    };
+    console.log(JSON.stringify({
+      defaultModeId: harness.defaultMastraAgentHarnessModeId(),
+      modeIds: harness.mastraAgentHarnessModeSpecs.map((mode) => mode.id),
+      defaultResolved: resolve({}),
+      supervisorDefault: resolve({ agentId: "supervisor" }),
+      supervisorAliases: {
+        balanced: resolve({ agentId: "supervisor", harnessMode: "balanced" }),
+        plan: resolve({ agentId: "supervisor", harnessMode: "plan" }),
+        build: resolve({ agentId: "supervisor", harnessMode: "build" }),
+        verify: resolve({ agentId: "supervisor", harnessMode: "verify" }),
+      },
+      orchestratorAliases: {
+        quick: resolve({ harnessMode: "quick" }),
+        precision: resolve({ harnessMode: "precision" }),
+        auto: resolve({ harnessMode: "auto" }),
+        balanced: resolve({ agentId: "orchestrator", harnessMode: "balanced" }),
+        plan: resolve({ agentId: "orchestrator", harnessMode: "plan" }),
+      },
+      rejects: {
+        scoutScope: rejects({ harnessMode: "scout.scope" }),
+        scoutAgent: rejects({ agentId: "scout" }),
+      },
+    }));
+    process.exit(0);
+  `;
+  const output = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(output);
+}
+
+test("harness exposes only supervisor scopes and orchestrator modes", () => {
+  buildHarnessBundle();
+  const state = readHarnessState();
+
+  assert.equal(state.defaultModeId, "orchestrator.auto");
+  assert.deepEqual(state.modeIds, [
+    "orchestrator.quick",
+    "orchestrator.precision",
+    "orchestrator.auto",
+    "supervisor.base",
+    "supervisor.scope",
+    "supervisor.spec",
+    "supervisor.exec",
+  ]);
+});
+
+test("harness resolves canonical modes and compatibility aliases", () => {
+  buildHarnessBundle();
+  const state = readHarnessState();
+
+  assert.deepEqual(state.defaultResolved, {
+    activeAgentId: "orchestrator",
+    harnessMode: "auto",
+    harnessModeId: "orchestrator.auto",
+    orchestratorMode: "auto",
+  });
+  assert.deepEqual(state.supervisorDefault, {
+    activeAgentId: "supervisor",
+    harnessMode: "base",
+    harnessModeId: "supervisor.base",
+    supervisorScope: "base",
+  });
+
+  assert.equal(state.supervisorAliases.balanced.harnessModeId, "supervisor.base");
+  assert.equal(state.supervisorAliases.plan.harnessModeId, "supervisor.spec");
+  assert.equal(state.supervisorAliases.build.harnessModeId, "supervisor.exec");
+  assert.equal(state.supervisorAliases.verify.harnessModeId, "supervisor.exec");
+
+  assert.equal(state.orchestratorAliases.quick.harnessModeId, "orchestrator.quick");
+  assert.equal(state.orchestratorAliases.precision.harnessModeId, "orchestrator.precision");
+  assert.equal(state.orchestratorAliases.auto.harnessModeId, "orchestrator.auto");
+  assert.equal(state.orchestratorAliases.balanced.harnessModeId, "orchestrator.auto");
+  assert.equal(state.orchestratorAliases.plan.harnessModeId, "orchestrator.precision");
+});
+
+test("harness rejects specialist direct modes", () => {
+  buildHarnessBundle();
+  const state = readHarnessState();
+
+  assert.equal(state.rejects.scoutScope, true);
+  assert.equal(state.rejects.scoutAgent, true);
+});

--- a/mastra-agents/src/agents/harness.ts
+++ b/mastra-agents/src/agents/harness.ts
@@ -1,8 +1,10 @@
 import { Harness, type HarnessMode } from "@mastra/core/harness";
+import { z } from "zod";
 
 import { workspace } from "../workspace.js";
 import { orchestratorAgent } from "./orchestrator-agent.js";
 import { supervisorAgent } from "./agent.js";
+import { defaultSupervisorModel } from "./shared.js";
 import {
   DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID,
   DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
@@ -49,20 +51,58 @@ export const mastraAgentHarnessModes: HarnessMode<MastraAgentHarnessState>[] = m
   id: mode.id,
   name: mode.name,
   default: mode.default,
+  defaultModelId: defaultSupervisorModel,
   agent: harnessAgents[mode.agentId],
   color: mode.color,
 }));
+
+const mastraAgentHarnessStateSchema = z.object({
+  activeAgentId: z.enum(["orchestrator", "supervisor"]).optional(),
+  supervisorScope: z.enum(["base", "scope", "spec", "exec"]).optional(),
+  orchestratorMode: z.enum(["quick", "precision", "auto"]).optional(),
+  currentModelId: z.string().optional(),
+  modelId: z.string().optional(),
+  workspaceSettings: z.record(z.unknown()).optional(),
+  toolSettings: z.record(z.unknown()).optional(),
+  runtimeSettings: z.record(z.unknown()).optional(),
+  harnessMode: z.enum(["base", "scope", "spec", "exec", "quick", "precision", "auto"]).optional(),
+  harnessModeId: z.enum([
+    "supervisor.base",
+    "supervisor.scope",
+    "supervisor.spec",
+    "supervisor.exec",
+    "orchestrator.quick",
+    "orchestrator.precision",
+    "orchestrator.auto",
+  ]).optional(),
+  lastSubmittedHarnessModeId: z.enum([
+    "supervisor.base",
+    "supervisor.scope",
+    "supervisor.spec",
+    "supervisor.exec",
+    "orchestrator.quick",
+    "orchestrator.precision",
+    "orchestrator.auto",
+  ]).optional(),
+  hardnessMode: z.string().optional(),
+});
 
 export function createMastraAgentHarness(): Harness<MastraAgentHarnessState> {
   return new Harness<MastraAgentHarnessState>({
     id: "mastra-system-agents",
     workspace: workspace as any,
+    stateSchema: mastraAgentHarnessStateSchema,
     initialState: {
       activeAgentId: DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID,
       harnessMode: DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
       orchestratorMode: DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
       harnessModeId: defaultMastraAgentHarnessModeId(),
       hardnessMode: defaultMastraAgentHarnessModeId(),
+      currentModelId: defaultSupervisorModel,
+      modelId: defaultSupervisorModel,
+      workspaceSettings: {},
+      toolSettings: {},
+      runtimeSettings: {},
     },
     modes: mastraAgentHarnessModes,
   });

--- a/mastra-agents/src/agents/harness.ts
+++ b/mastra-agents/src/agents/harness.ts
@@ -1,262 +1,57 @@
 import { Harness, type HarnessMode } from "@mastra/core/harness";
 
-import { advisorModePrompts } from "../prompts/agents/advisor.js";
-import { architectModePrompts } from "../prompts/agents/architect.js";
-import { developerModePrompts } from "../prompts/agents/developer.js";
-import { researcherModePrompts } from "../prompts/agents/researcher.js";
-import { scoutModePrompts } from "../prompts/agents/scout.js";
-import { orchestratorModePrompts } from "../prompts/agents/orchestrator.js";
-import { supervisorModePrompts } from "../prompts/agents/supervisor.js";
-import { validatorModePrompts } from "../prompts/agents/validator.js";
 import { workspace } from "../workspace.js";
-import { advisorAgent } from "./advisor-agent.js";
 import { orchestratorAgent } from "./orchestrator-agent.js";
-import { architectAgent } from "./architect-agent.js";
-import { developerAgent } from "./developer-agent.js";
-import { researcherAgent } from "./researcher-agent.js";
-import { scoutAgent } from "./scout-agent.js";
-import { sharedAgentModeNames, type AgentModePromptMap, type SharedAgentModeId } from "./shared.js";
 import { supervisorAgent } from "./agent.js";
-import { validatorAgent } from "./validator-agent.js";
+import {
+  DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID,
+  DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
+  defaultMastraAgentHarnessModeId,
+  mastraAgentHarnessModeSpecs,
+  type MastraAgentHarnessAgentId,
+  type MastraAgentHarnessState,
+} from "./harness-modes.js";
 
-export const REQUEST_CONTEXT_HARNESS_MODE_KEY = "harnessMode";
-export const REQUEST_CONTEXT_HARNESS_MODE_ID_KEY = "harnessModeId";
-export const REQUEST_CONTEXT_ACTIVE_AGENT_ID_KEY = "activeAgentId";
-export const REQUEST_CONTEXT_LAST_SUBMITTED_HARNESS_MODE_ID_KEY = "lastSubmittedHarnessModeId";
-export const REQUEST_CONTEXT_HARDNESS_MODE_KEY = "hardnessMode";
+export {
+  DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID,
+  DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
+  DEFAULT_MASTRA_AGENT_HARNESS_MODE_ID,
+  REQUEST_CONTEXT_ACTIVE_AGENT_ID_KEY,
+  REQUEST_CONTEXT_HARDNESS_MODE_KEY,
+  REQUEST_CONTEXT_HARNESS_MODE_ID_KEY,
+  REQUEST_CONTEXT_HARNESS_MODE_KEY,
+  REQUEST_CONTEXT_LAST_SUBMITTED_HARNESS_MODE_ID_KEY,
+  defaultMastraAgentHarnessModeId,
+  formatMastraAgentHarnessModePrompt,
+  isMastraAgentHarnessModeId,
+  mastraAgentModeDefinitions,
+  resolveMastraAgentHarnessMode,
+  resolveMastraAgentHarnessModeId,
+} from "./harness-modes.js";
 
-export type MastraAgentHarnessAgentId =
-  | "orchestrator"
-  | "supervisor"
-  | "scout"
-  | "researcher"
-  | "architect"
-  | "advisor"
-  | "developer"
-  | "validator";
+export type {
+  MastraAgentHarnessAgentId,
+  MastraAgentHarnessLocalModeId,
+  MastraAgentHarnessModeId,
+  MastraAgentHarnessModeSpec,
+  MastraAgentHarnessState,
+  OrchestratorModeId,
+  ResolvedMastraAgentHarnessMode,
+  SupervisorScopeId,
+} from "./harness-modes.js";
 
-export type MastraAgentHarnessModeId = `${MastraAgentHarnessAgentId}.${SharedAgentModeId}`;
-
-export type MastraAgentHarnessState = {
-  activeAgentId?: MastraAgentHarnessAgentId;
-  harnessMode?: SharedAgentModeId;
-  harnessModeId?: MastraAgentHarnessModeId;
-  lastSubmittedHarnessModeId?: MastraAgentHarnessModeId;
-  /** @deprecated Use harnessMode or harnessModeId. */
-  hardnessMode?: string;
+const harnessAgents: Record<MastraAgentHarnessAgentId, HarnessMode<MastraAgentHarnessState>["agent"]> = {
+  orchestrator: orchestratorAgent,
+  supervisor: supervisorAgent,
 };
 
-type AgentModeDefinition = {
-  agentId: MastraAgentHarnessAgentId;
-  agentName: string;
-  modePrompts: AgentModePromptMap;
-  agent: HarnessMode<MastraAgentHarnessState>["agent"];
-};
-
-export type ResolvedMastraAgentHarnessMode = {
-  activeAgentId: MastraAgentHarnessAgentId;
-  agentName: string;
-  harnessMode: SharedAgentModeId;
-  harnessModeName: string;
-  harnessModeId: MastraAgentHarnessModeId;
-  modePrompt: string;
-};
-
-export const DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID = "orchestrator" satisfies MastraAgentHarnessAgentId;
-export const DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE = "balanced" satisfies SharedAgentModeId;
-export const DEFAULT_MASTRA_AGENT_HARNESS_MODE_ID =
-  `${DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID}.${DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE}` as const;
-
-export const mastraAgentModeDefinitions = {
-  orchestrator: {
-    agentId: "orchestrator",
-    agentName: "Orchestrator",
-    modePrompts: orchestratorModePrompts,
-    agent: orchestratorAgent,
-  },
-  supervisor: {
-    agentId: "supervisor",
-    agentName: "Supervisor Lead",
-    modePrompts: supervisorModePrompts,
-    agent: supervisorAgent,
-  },
-  scout: {
-    agentId: "scout",
-    agentName: "Scout",
-    modePrompts: scoutModePrompts,
-    agent: scoutAgent,
-  },
-  researcher: {
-    agentId: "researcher",
-    agentName: "Researcher",
-    modePrompts: researcherModePrompts,
-    agent: researcherAgent,
-  },
-  architect: {
-    agentId: "architect",
-    agentName: "Architect",
-    modePrompts: architectModePrompts,
-    agent: architectAgent,
-  },
-  advisor: {
-    agentId: "advisor",
-    agentName: "Advisor",
-    modePrompts: advisorModePrompts,
-    agent: advisorAgent,
-  },
-  developer: {
-    agentId: "developer",
-    agentName: "Developer",
-    modePrompts: developerModePrompts,
-    agent: developerAgent,
-  },
-  validator: {
-    agentId: "validator",
-    agentName: "Validator",
-    modePrompts: validatorModePrompts,
-    agent: validatorAgent,
-  },
-} as const satisfies Record<MastraAgentHarnessAgentId, AgentModeDefinition>;
-
-const agentAliasToAgentId = new Map<string, MastraAgentHarnessAgentId>([
-  ["orchestrator", "orchestrator"],
-  ["orchestrator-agent", "orchestrator"],
-  ["orchestratoragent", "orchestrator"],
-  ["supervisor", "supervisor"],
-  ["supervisor-agent", "supervisor"],
-  ["supervisoragent", "supervisor"],
-  ["supervisor-lead", "supervisor"],
-  ["supervisorlead", "supervisor"],
-  ["scout", "scout"],
-  ["scout-agent", "scout"],
-  ["scoutagent", "scout"],
-  ["researcher", "researcher"],
-  ["researcher-agent", "researcher"],
-  ["researcheragent", "researcher"],
-  ["architect", "architect"],
-  ["architect-agent", "architect"],
-  ["architectagent", "architect"],
-  ["advisor", "advisor"],
-  ["advisor-agent", "advisor"],
-  ["advisoragent", "advisor"],
-  ["developer", "developer"],
-  ["developer-agent", "developer"],
-  ["developeragent", "developer"],
-  ["validator", "validator"],
-  ["validator-agent", "validator"],
-  ["validatoragent", "validator"],
-]);
-
-const localModeAliases = new Map<string, SharedAgentModeId>([
-  ["balance", "balanced"],
-  ["balanced", "balanced"],
-  ["scope", "scope"],
-  ["plan", "plan"],
-  ["build", "build"],
-  ["verify", "verify"],
-  ["research", "research"],
-  ["brainstorm", "brainstorm"],
-  ["analysis", "analysis"],
-  ["analyze", "analysis"],
-  ["analyse", "analysis"],
-  ["test", "test"],
-  ["audit", "audit"],
-  ["debug", "debug"],
-]);
-
-export const mastraAgentHarnessModes: HarnessMode<MastraAgentHarnessState>[] = Object.values(mastraAgentModeDefinitions).flatMap(
-  (definition) =>
-    Object.entries(definition.modePrompts).map(([modeId]) => {
-      const harnessMode = modeId as SharedAgentModeId;
-      const compositeModeId = `${definition.agentId}.${harnessMode}` as MastraAgentHarnessModeId;
-      return {
-        id: compositeModeId,
-        name: `${definition.agentName} / ${sharedAgentModeNames[harnessMode]}`,
-        default: compositeModeId === DEFAULT_MASTRA_AGENT_HARNESS_MODE_ID,
-        agent: definition.agent,
-        color: harnessModeColor(harnessMode),
-      };
-    }),
-);
-
-const defaultModeId = (mastraAgentHarnessModes.find((mode) => mode.default) ?? mastraAgentHarnessModes[0]).id as MastraAgentHarnessModeId;
-
-export function defaultMastraAgentHarnessModeId(): MastraAgentHarnessModeId {
-  return defaultModeId;
-}
-
-export function isMastraAgentHarnessModeId(value: unknown): value is MastraAgentHarnessModeId {
-  return typeof value === "string" && mastraAgentHarnessModes.some((mode) => mode.id === value);
-}
-
-export function resolveMastraAgentHarnessMode({
-  agentId,
-  harnessMode,
-  hardnessMode,
-}: {
-  agentId?: string;
-  harnessMode?: string;
-  /** @deprecated Use harnessMode. */
-  hardnessMode?: string;
-}): ResolvedMastraAgentHarnessMode {
-  const requestedHarnessMode = cleanInput(harnessMode);
-  const requestedDeprecatedHardnessMode = cleanInput(hardnessMode);
-  const requestedMode = requestedHarnessMode ?? requestedDeprecatedHardnessMode;
-
-  if (requestedMode) {
-    const compositeModeId = parseCompositeModeId(requestedMode);
-    if (compositeModeId) {
-      return resolvedModeFromId(compositeModeId);
-    }
-
-    const localModeId = resolveLocalModeId(requestedMode);
-    if (localModeId) {
-      const activeAgentId = resolveAgentId(agentId) ?? DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID;
-      return resolvedMode(activeAgentId, localModeId);
-    }
-
-    if (!requestedHarnessMode) {
-      const legacyAgentId = resolveAgentId(requestedMode);
-      if (legacyAgentId) {
-        return resolvedMode(legacyAgentId, DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE);
-      }
-    }
-
-    throw new Error(
-      `Unknown harness mode "${requestedMode}". Expected a local mode (${allLocalModeIds().join(", ")}) or composite mode (${mastraAgentHarnessModes.map((mode) => mode.id).join(", ")}).`,
-    );
-  }
-
-  const activeAgentId = resolveAgentId(agentId);
-  if (!activeAgentId && agentId) {
-    throw new Error(`Unknown agentId "${agentId}". Expected one of: ${Object.keys(mastraAgentModeDefinitions).join(", ")}`);
-  }
-
-  return resolvedMode(activeAgentId ?? DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID, DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE);
-}
-
-export function resolveMastraAgentHarnessModeId({
-  agentId,
-  harnessMode,
-  hardnessMode,
-}: {
-  agentId?: string;
-  harnessMode?: string;
-  /** @deprecated Use harnessMode. */
-  hardnessMode?: string;
-}): MastraAgentHarnessModeId {
-  return resolveMastraAgentHarnessMode({ agentId, harnessMode, hardnessMode }).harnessModeId;
-}
-
-export function formatMastraAgentHarnessModePrompt(resolved: ResolvedMastraAgentHarnessMode): string {
-  return [
-    `<harness-mode id="${resolved.harnessModeId}" agent="${resolved.activeAgentId}" mode="${resolved.harnessMode}">`,
-    `Agent: ${resolved.agentName}`,
-    `Mode: ${resolved.harnessModeName}`,
-    resolved.modePrompt.trim(),
-    `</harness-mode>`,
-  ].join("\n");
-}
+export const mastraAgentHarnessModes: HarnessMode<MastraAgentHarnessState>[] = mastraAgentHarnessModeSpecs.map((mode) => ({
+  id: mode.id,
+  name: mode.name,
+  default: mode.default,
+  agent: harnessAgents[mode.agentId],
+  color: mode.color,
+}));
 
 export function createMastraAgentHarness(): Harness<MastraAgentHarnessState> {
   return new Harness<MastraAgentHarnessState>({
@@ -265,92 +60,12 @@ export function createMastraAgentHarness(): Harness<MastraAgentHarnessState> {
     initialState: {
       activeAgentId: DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID,
       harnessMode: DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
-      harnessModeId: defaultModeId,
-      hardnessMode: defaultModeId,
+      orchestratorMode: DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,
+      harnessModeId: defaultMastraAgentHarnessModeId(),
+      hardnessMode: defaultMastraAgentHarnessModeId(),
     },
     modes: mastraAgentHarnessModes,
   });
 }
 
 export const mastraAgentHarness = createMastraAgentHarness();
-
-function resolvedMode(activeAgentId: MastraAgentHarnessAgentId, harnessMode: SharedAgentModeId): ResolvedMastraAgentHarnessMode {
-  const definition = mastraAgentModeDefinitions[activeAgentId];
-  const modePrompts = definition.modePrompts as AgentModePromptMap;
-  const modePrompt = modePrompts[harnessMode];
-  if (!modePrompt) {
-    const expected = Object.keys(modePrompts).join(", ");
-    throw new Error(`Agent "${activeAgentId}" does not support harness mode "${harnessMode}". Expected one of: ${expected}`);
-  }
-  return {
-    activeAgentId,
-    agentName: definition.agentName,
-    harnessMode,
-    harnessModeName: sharedAgentModeNames[harnessMode],
-    harnessModeId: `${activeAgentId}.${harnessMode}`,
-    modePrompt,
-  };
-}
-
-function resolvedModeFromId(harnessModeId: MastraAgentHarnessModeId): ResolvedMastraAgentHarnessMode {
-  const [agentId, localModeId] = harnessModeId.split(".") as [MastraAgentHarnessAgentId, SharedAgentModeId];
-  return resolvedMode(agentId, localModeId);
-}
-
-function parseCompositeModeId(value: string): MastraAgentHarnessModeId | undefined {
-  const [agentPart, modePart, extra] = value.toLowerCase().replace(/_/g, "-").split(".");
-  if (!agentPart || !modePart || extra) return undefined;
-  const agentId = resolveAgentId(agentPart);
-  const modeId = resolveLocalModeId(modePart);
-  if (!agentId || !modeId) return undefined;
-  const harnessModeId = `${agentId}.${modeId}` as MastraAgentHarnessModeId;
-  return isMastraAgentHarnessModeId(harnessModeId) ? harnessModeId : undefined;
-}
-
-function resolveAgentId(value: string | undefined): MastraAgentHarnessAgentId | undefined {
-  const normalized = normalizeAlias(value);
-  return normalized ? agentAliasToAgentId.get(normalized) : undefined;
-}
-
-function resolveLocalModeId(value: string): SharedAgentModeId | undefined {
-  return localModeAliases.get(normalizeAlias(value));
-}
-
-function cleanInput(value: string | undefined): string | undefined {
-  const clean = value?.trim();
-  return clean ? clean : undefined;
-}
-
-function normalizeAlias(value: string | undefined): string {
-  return value?.trim().toLowerCase().replace(/_/g, "-") ?? "";
-}
-
-function allLocalModeIds(): SharedAgentModeId[] {
-  return Array.from(new Set(Object.keys(sharedAgentModeNames) as SharedAgentModeId[]));
-}
-
-function harnessModeColor(modeId: SharedAgentModeId): string {
-  switch (modeId) {
-    case "balanced":
-      return "#2563eb";
-    case "scope":
-      return "#0891b2";
-    case "plan":
-      return "#7c3aed";
-    case "build":
-      return "#16a34a";
-    case "verify":
-    case "test":
-      return "#0f766e";
-    case "research":
-      return "#4f46e5";
-    case "brainstorm":
-      return "#d97706";
-    case "analysis":
-      return "#9333ea";
-    case "audit":
-      return "#dc2626";
-    case "debug":
-      return "#ea580c";
-  }
-}

--- a/mastra-agents/src/agents/harness.ts
+++ b/mastra-agents/src/agents/harness.ts
@@ -8,6 +8,7 @@ import { scoutModePrompts } from "../prompts/agents/scout.js";
 import { orchestratorModePrompts } from "../prompts/agents/orchestrator.js";
 import { supervisorModePrompts } from "../prompts/agents/supervisor.js";
 import { validatorModePrompts } from "../prompts/agents/validator.js";
+import { workspace } from "../workspace.js";
 import { advisorAgent } from "./advisor-agent.js";
 import { orchestratorAgent } from "./orchestrator-agent.js";
 import { architectAgent } from "./architect-agent.js";
@@ -260,6 +261,7 @@ export function formatMastraAgentHarnessModePrompt(resolved: ResolvedMastraAgent
 export function createMastraAgentHarness(): Harness<MastraAgentHarnessState> {
   return new Harness<MastraAgentHarnessState>({
     id: "mastra-system-agents",
+    workspace: workspace as any,
     initialState: {
       activeAgentId: DEFAULT_MASTRA_AGENT_HARNESS_AGENT_ID,
       harnessMode: DEFAULT_MASTRA_AGENT_HARNESS_LOCAL_MODE,

--- a/mastra-agents/src/agents/orchestrator-agent.ts
+++ b/mastra-agents/src/agents/orchestrator-agent.ts
@@ -17,7 +17,7 @@ import { createDelegationObservabilityOptions } from "./delegation-observability
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
-import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultSupervisorModel, withAgentModes } from "./shared.js";
+import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeSupervisorModel, withAgentModes } from "./shared.js";
 import { validatorAgent } from "./validator-agent.js";
 
 export const orchestratorAgent = withAgentModes(new Agent({
@@ -32,7 +32,7 @@ export const orchestratorAgent = withAgentModes(new Agent({
     orchestratorPolicyPrompts,
     orchestratorToolPrompts,
   ),
-  model: defaultSupervisorModel,
+  model: resolveRuntimeSupervisorModel,
   memory: createAgentMemory(),
   workspace,
   defaultOptions: {

--- a/mastra-agents/src/agents/orchestrator-agent.ts
+++ b/mastra-agents/src/agents/orchestrator-agent.ts
@@ -10,8 +10,10 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { workspaceTools } from "../tools/workspace.js";
+import { workspace } from "../workspace.js";
 import { advisorAgent } from "./advisor-agent.js";
 import { architectAgent } from "./architect-agent.js";
+import { createDelegationObservabilityOptions } from "./delegation-observability.js";
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
@@ -32,7 +34,14 @@ export const orchestratorAgent = withAgentModes(new Agent({
   ),
   model: defaultSupervisorModel,
   memory: createAgentMemory(),
-  defaultOptions: agentDefaultOptions.orchestrator,
+  workspace,
+  defaultOptions: {
+    ...agentDefaultOptions.orchestrator,
+    delegation: createDelegationObservabilityOptions({
+      parentAgentId: "orchestrator-agent",
+      parentAgentName: "Orchestrator",
+    }),
+  },
   agents: {
     scoutAgent,
     researcherAgent,

--- a/mastra-agents/src/agents/orchestrator-agent.ts
+++ b/mastra-agents/src/agents/orchestrator-agent.ts
@@ -17,7 +17,7 @@ import { createDelegationObservabilityOptions } from "./delegation-observability
 import { developerAgent } from "./developer-agent.js";
 import { researcherAgent } from "./researcher-agent.js";
 import { scoutAgent } from "./scout-agent.js";
-import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeSupervisorModel, withAgentModes } from "./shared.js";
+import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, resolveRuntimeModel, withAgentModes } from "./shared.js";
 import { validatorAgent } from "./validator-agent.js";
 
 export const orchestratorAgent = withAgentModes(new Agent({
@@ -32,7 +32,7 @@ export const orchestratorAgent = withAgentModes(new Agent({
     orchestratorPolicyPrompts,
     orchestratorToolPrompts,
   ),
-  model: resolveRuntimeSupervisorModel,
+  model: resolveRuntimeModel,
   memory: createAgentMemory(),
   workspace,
   defaultOptions: {

--- a/mastra-agents/src/agents/orchestrator-agent.ts
+++ b/mastra-agents/src/agents/orchestrator-agent.ts
@@ -26,7 +26,7 @@ export const orchestratorAgent = withAgentModes(new Agent({
   description: orchestratorAgentDescription,
   instructions: composeAgentInstructions(
     orchestratorInstructionsPrompt,
-    orchestratorModePrompts.balanced,
+    orchestratorModePrompts.auto,
     sharedPolicyPrompts.supervisor,
     sharedToolPrompts.supervisor,
     orchestratorPolicyPrompts,
@@ -59,4 +59,4 @@ export const orchestratorAgent = withAgentModes(new Agent({
     git_snapshot_query: workspaceTools.gitSnapshotQuery,
     capture_snapshot: workspaceTools.captureSnapshot,
   },
-}), agentModesFromPrompts(orchestratorModePrompts));
+}), agentModesFromPrompts(orchestratorModePrompts, "auto"));

--- a/mastra-agents/src/agents/researcher-agent.ts
+++ b/mastra-agents/src/agents/researcher-agent.ts
@@ -10,11 +10,11 @@ import {
 import { sharedPolicyPrompts } from "../prompts/policy.js";
 import { sharedToolPrompts } from "../prompts/tools.js";
 import { agentDefaultOptions, agentModesFromPrompts, composeAgentInstructions, createAgentMemory, defaultAgentModel, withAgentModes } from "./shared.js";
-import { deepWikiMCP } from "../mcp/index.js";
+import { getDeepWikiTools } from "../mcp/index.js";
 
 // Initialize DeepWiki tools for researcher agent
 // DeepWiki is primary for researcher - used for repo analysis, research, benchmarking
-const deepWikiTools = await deepWikiMCP.listTools();
+const deepWikiTools = await getDeepWikiTools();
 
 export const researcherAgent = withAgentModes(new Agent({
   id: "researcher-agent",

--- a/mastra-agents/src/agents/shared.ts
+++ b/mastra-agents/src/agents/shared.ts
@@ -1,5 +1,7 @@
 import { Memory } from "@mastra/memory";
 import { PostgresStore } from "@mastra/pg";
+import type { RequestContext } from "@mastra/core/request-context";
+import type { MastraModelConfig } from "@mastra/core/llm";
 
 export const defaultMiniMaxModel = "minimax-coding-plan/MiniMax-M2.7";
 function optionalEnv(name: string) {
@@ -18,6 +20,20 @@ export const defaultSupervisorModel =
   optionalEnv("MASTRA_SUBAGENT_MODEL") ??
   optionalEnv("MASTRA_MODEL") ??
   defaultMiniMaxModel;
+
+export function resolveRuntimeSupervisorModel({
+  requestContext,
+}: {
+  requestContext: RequestContext;
+}): MastraModelConfig {
+  return (
+    stringContextValue(requestContext, "modelId") ??
+    stringRecordContextValue(requestContext, "acp", "modelId") ??
+    stringRecordContextValue(requestContext, "harness", "state", "currentModelId") ??
+    stringRecordContextValue(requestContext, "harness", "state", "modelId") ??
+    defaultSupervisorModel
+  );
+}
 
 const defaultToolCallConcurrency = 15;
 
@@ -136,6 +152,24 @@ export function composeAgentInstructions(
     "# Runtime Policy And Tooling",
     ...runtimePrompts,
   ].join("\n\n");
+}
+
+function stringContextValue(requestContext: RequestContext, key: string): string | undefined {
+  const value = requestContext.get(key);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringRecordContextValue(requestContext: RequestContext, key: string, ...path: string[]): string | undefined {
+  let value: unknown = requestContext.get(key);
+  for (const segment of path) {
+    if (!isRecord(value)) return undefined;
+    value = value[segment];
+  }
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function withAgentModes<TAgent extends object>(

--- a/mastra-agents/src/agents/shared.ts
+++ b/mastra-agents/src/agents/shared.ts
@@ -28,11 +28,17 @@ export type AgentModeMetadata = {
 };
 
 export const sharedAgentModeNames = {
+  base: "Base",
   balanced: "Balanced",
   scope: "Scope",
+  spec: "Spec",
+  exec: "Execution",
   plan: "Plan",
   build: "Build",
   verify: "Verify",
+  quick: "Quick",
+  precision: "Precision",
+  auto: "Auto",
   research: "Research",
   brainstorm: "Brainstorm",
   analysis: "Analysis",

--- a/mastra-agents/src/agents/shared.ts
+++ b/mastra-agents/src/agents/shared.ts
@@ -21,7 +21,7 @@ export const defaultSupervisorModel =
   optionalEnv("MASTRA_MODEL") ??
   defaultMiniMaxModel;
 
-export function resolveRuntimeSupervisorModel({
+export function resolveRuntimeModel({
   requestContext,
 }: {
   requestContext: RequestContext;

--- a/mastra-agents/src/mastra/index.ts
+++ b/mastra-agents/src/mastra/index.ts
@@ -3,6 +3,7 @@ import { SpanType } from "@mastra/core/observability";
 import { FilesystemStore, MastraCompositeStore } from "@mastra/core/storage";
 import { DuckDBStore } from "@mastra/duckdb";
 import { MastraEditor } from "@mastra/editor";
+import { MCPServer } from "@mastra/mcp";
 import {
   DefaultExporter,
   Observability,
@@ -13,6 +14,7 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 
 import { mastraAgents } from "../agents/agent.js";
+import { workspaceTools } from "../tools/workspace.js";
 import { daytonaWorkflows } from "../workflows/daytona.js";
 import { asyncAgentJobWorkflows } from "../workflows/async-agent-job.js";
 import { workspaceWorkflows } from "../workflows/workspace.js";
@@ -63,6 +65,22 @@ const studioPort = Number(
 const studioProtocol =
   process.env.MASTRA_SERVER_STUDIO_PROTOCOL === "https" ? "https" : "http";
 
+const workflows = {
+  ...daytonaWorkflows,
+  ...asyncAgentJobWorkflows,
+  ...workspaceWorkflows,
+};
+
+const projectMCPServer = new MCPServer({
+  id: "project-mcp-server",
+  name: "Project MCP Server",
+  version: "0.1.0",
+  description: "Exposes Mastra agents, tools, and workflows to external MCP clients.",
+  tools: workspaceTools,
+  agents: mastraAgents,
+  workflows,
+});
+
 function localCorsOriginsForPort(port: string | undefined) {
   if (!port) return [];
   return [`http://localhost:${port}`, `http://127.0.0.1:${port}`];
@@ -91,13 +109,10 @@ function configuredCorsOrigins() {
 
 export const mastra = new Mastra({
   agents: mastraAgents,
-  workflows: {
-    ...daytonaWorkflows,
-    ...asyncAgentJobWorkflows,
-    ...workspaceWorkflows,
-  },
+  workflows,
   storage,
   editor,
+  mcpServers: { project: projectMCPServer },
   observability: new Observability({
     configs: {
       default: {

--- a/mastra-agents/src/mastra/index.ts
+++ b/mastra-agents/src/mastra/index.ts
@@ -12,12 +12,15 @@ import {
 import { PostgresStore } from "@mastra/pg";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
+import type { ApiRoute } from "@mastra/core/server";
 
 import { mastraAgents } from "../agents/agent.js";
+import { channelWebhookApiRoutesForAgents } from "../agents/channels.js";
 import { workspaceTools } from "../tools/workspace.js";
 import { daytonaWorkflows } from "../workflows/daytona.js";
 import { asyncAgentJobWorkflows } from "../workflows/async-agent-job.js";
 import { workspaceWorkflows } from "../workflows/workspace.js";
+import { ProxyGateway } from "../models/proxy-gateway.js";
 import { resolveWorkspacePath, workspace } from "../workspace.js";
 
 const postgresStorage = new PostgresStore({
@@ -50,6 +53,7 @@ const storage = new MastraCompositeStore({
     observability: observabilityStorage.observability,
   },
 });
+
 const editor = new MastraEditor();
 
 const serverPort = Number(
@@ -70,6 +74,78 @@ const workflows = {
   ...asyncAgentJobWorkflows,
   ...workspaceWorkflows,
 };
+const channelApiRoutes = channelWebhookApiRoutesForAgents(mastraAgents);
+
+type LinearOAuthAdapter = {
+  handleOAuthCallback: (
+    request: Request,
+    options: { redirectUri: string },
+  ) => Promise<{ organizationId: string; installation: unknown }>;
+  isMultiTenantMode?: () => boolean;
+  setInstallation?: (organizationId: string, installation: unknown) => Promise<void>;
+};
+
+function isLinearOAuthAdapter(adapter: unknown): adapter is LinearOAuthAdapter {
+  return Boolean(
+    adapter &&
+      typeof adapter === "object" &&
+      "handleOAuthCallback" in adapter &&
+      typeof (adapter as { handleOAuthCallback?: unknown }).handleOAuthCallback === "function",
+  );
+}
+
+const linearCallbackApiRoute = {
+  path: "/api/linear/callback",
+  method: "GET",
+  _mastraInternal: true,
+  requiresAuth: false,
+  createHandler: async ({ mastra }) => {
+    return async (c) => {
+      const redirectUri = process.env.LINEAR_REDIRECT_URI?.trim();
+      if (!redirectUri) {
+        return c.json({ error: "LINEAR_REDIRECT_URI is not configured" }, 400);
+      }
+      if (!c.req.query("code") && !c.req.query("error")) {
+        return c.json({ error: "Missing Linear OAuth code" }, 400);
+      }
+
+      const linearAdapters: LinearOAuthAdapter[] = [];
+      for (const agent of Object.values(mastraAgents)) {
+        const channels = agent.getChannels?.();
+        if (!channels) continue;
+        if (!channels.sdk) {
+          await channels.initialize?.(mastra);
+        }
+
+        const adapter = channels.adapters?.linear;
+        if (isLinearOAuthAdapter(adapter)) {
+          linearAdapters.push(adapter);
+        }
+      }
+
+      const primaryAdapter =
+        linearAdapters.find((adapter) => adapter.isMultiTenantMode?.()) ?? linearAdapters[0];
+      if (!primaryAdapter) {
+        return c.json({ error: "Linear OAuth adapter is not enabled" }, 503);
+      }
+
+      const result = await primaryAdapter.handleOAuthCallback(c.req.raw, {
+        redirectUri,
+      });
+
+      await Promise.all(
+        linearAdapters
+          .filter((adapter) => adapter !== primaryAdapter && adapter.setInstallation)
+          .map((adapter) => adapter.setInstallation?.(result.organizationId, result.installation)),
+      );
+
+      return c.json({
+        installed: true,
+        organizationId: result.organizationId,
+      });
+    };
+  },
+} satisfies ApiRoute;
 
 const projectMCPServer = new MCPServer({
   id: "project-mcp-server",
@@ -109,6 +185,9 @@ function configuredCorsOrigins() {
 
 export const mastra = new Mastra({
   agents: mastraAgents,
+  gateways: {
+    proxy: new ProxyGateway(),
+  },
   workflows,
   storage,
   editor,
@@ -150,6 +229,7 @@ export const mastra = new Mastra({
               "MASTRA_OPENAI_API_KEY",
               "MASTRA_ANTHROPIC_API_KEY",
               "MASTRA_MINIMAX_API_KEY",
+              "PROXY_API_KEY",
               "CLI_PROXY_API_KEY",
               "CLI_PROXY_STACK_API_KEY",
               "GH_TOKEN",
@@ -169,6 +249,7 @@ export const mastra = new Mastra({
   server: {
     host: process.env.MASTRA_SERVER_HOST ?? "0.0.0.0",
     port: serverPort,
+    apiRoutes: [...channelApiRoutes, linearCallbackApiRoute],
     studioHost: process.env.MASTRA_SERVER_STUDIO_HOST ?? "localhost",
     studioProtocol,
     studioPort,

--- a/mastra-agents/src/mcp/index.ts
+++ b/mastra-agents/src/mcp/index.ts
@@ -18,7 +18,7 @@ import { MCPClient } from "@mastra/mcp";
  * - Feature engineering
  * - Reverse engineering
  */
-export const deepWikiMCP = new MCPClient({
+const deepWikiMCP = new MCPClient({
   id: "deepwiki-mcp-client",
   servers: {
     deepwiki: {

--- a/mastra-agents/src/models/proxy-gateway.ts
+++ b/mastra-agents/src/models/proxy-gateway.ts
@@ -1,0 +1,119 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { MastraModelGateway, type GatewayLanguageModel, type ProviderConfig } from "@mastra/core/llm";
+
+// Hosted CLIProxyAPI-compatible endpoint. Upstream docs/reference:
+// https://github.com/router-for-me/CLIProxyAPI
+// https://deepwiki.com/router-for-me/CLIProxyAPI
+const defaultProxyBaseUrl = "https://aa.renaissancelab.org/v1";
+const fallbackModels = [
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
+  "gpt-5.2",
+];
+
+export class ProxyGateway extends MastraModelGateway {
+  readonly id = "proxy";
+  readonly name = "OpenAI-Compatible Proxy";
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    return {
+      openai: {
+        name: "Proxy OpenAI-compatible",
+        models: await this.fetchModelIds(),
+        apiKeyEnvVar: ["PROXY_API_KEY", "CLI_PROXY_API_KEY", "CLI_PROXY_STACK_API_KEY"],
+        gateway: this.id,
+        url: this.baseUrl(),
+        docUrl: "https://help.router-for.me/configuration/thinking",
+      },
+    };
+  }
+
+  buildUrl(): string {
+    return this.baseUrl();
+  }
+
+  async getApiKey(): Promise<string> {
+    const apiKey = proxyApiKey();
+    if (!apiKey) {
+      throw new Error("Proxy API key is missing. Set PROXY_API_KEY.");
+    }
+    return apiKey;
+  }
+
+  resolveLanguageModel({
+    modelId,
+    providerId,
+    apiKey,
+    headers,
+  }: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
+    headers?: Record<string, string>;
+  }): GatewayLanguageModel {
+    return createOpenAICompatible({
+      name: providerId,
+      apiKey,
+      baseURL: this.baseUrl(),
+      headers,
+      supportsStructuredOutputs: true,
+    }).chatModel(modelId);
+  }
+
+  serializeForSpan() {
+    return {
+      id: this.id,
+      name: this.name,
+      baseUrl: this.baseUrl(),
+    };
+  }
+
+  private baseUrl(): string {
+    return (
+      optionalEnv("PROXY_BASE_URL") ??
+      optionalEnv("CLI_PROXY_BASE_URL") ??
+      defaultProxyBaseUrl
+    ).replace(/\/+$/, "");
+  }
+
+  private async fetchModelIds(): Promise<string[]> {
+    const apiKey = proxyApiKey();
+    if (!apiKey) return fallbackModels;
+
+    try {
+      const response = await fetch(`${this.baseUrl()}/models`, {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      });
+      if (!response.ok) return fallbackModels;
+      const body = await response.json() as { data?: Array<{ id?: unknown; name?: unknown; model?: unknown }> };
+      const models = (body.data ?? [])
+        .map((model) => stringValue(model.id) ?? stringValue(model.name) ?? stringValue(model.model))
+        .filter((model): model is string => Boolean(model));
+      return models.length > 0 ? models : fallbackModels;
+    } catch {
+      return fallbackModels;
+    }
+  }
+}
+
+function proxyApiKey(): string | undefined {
+  return (
+    optionalEnv("PROXY_API_KEY") ??
+    optionalEnv("CLI_PROXY_API_KEY") ??
+    optionalEnv("CLI_PROXY_STACK_API_KEY")
+  );
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/mastra-agents/src/prompts/agents/orchestrator.ts
+++ b/mastra-agents/src/prompts/agents/orchestrator.ts
@@ -2,26 +2,18 @@ export const orchestratorAgentDescription =
   "Orchestrator agent that coordinates specialist Mastra agents to deliver verified coding outcomes within user scope.";
 
 export const orchestratorModePrompts = {
-  balanced: `Orchestrator Balanced mode:
-- Preserve scope while moving directly toward a completed coding outcome.
-- Prefer concrete progress, bounded delegation, and direct evidence.
-- Keep ownership of implementation judgment, verification, and final synthesis.`,
-  scope: `Orchestrator Scope mode:
-- Identify requested outcome, allowed boundary, and completion evidence.
-- Separate requested work from adjacent improvements and non-goals.
-- Escalate only when missing decisions change scope, behavior, risk, or authority.`,
-  plan: `Orchestrator Plan mode:
-- Build the shortest reliable execution path from intent to verified result.
-- Define bounded delegation briefs with objective, scope, anchors, and evidence threshold.
-- Do not present planning output as completed implementation.`,
-  build: `Orchestrator Build mode:
-- Execute or delegate the smallest complete implementation slice inside boundary.
-- Treat worker output as provisional until inspected against files, diffs, and command evidence.
-- Repair in bounded loops when evidence shows gaps.`,
-  verify: `Orchestrator Verify mode:
-- Audit claims against direct artifacts, targeted checks, and snapshot evidence.
-- Distinguish completed evidence from assumptions, risks, and blockers.
-- Finalize only when the requested objective is satisfied within scope.`,
+  quick: `Orchestrator Quick mode:
+- Move through the shortest reliable path to a useful coding outcome.
+- Prefer direct inspection and direct edits over delegation when the task is narrow.
+- Keep evidence lightweight but concrete enough to support the final answer.`,
+  precision: `Orchestrator Precision mode:
+- Slow down for stronger inspection, clearer boundaries, and higher-confidence verification.
+- Use bounded delegation only when it improves evidence quality or reduces risk.
+- Treat worker claims as provisional until checked against artifacts, diffs, commands, or source text.`,
+  auto: `Orchestrator Auto mode:
+- Own the end-to-end path from intent to verified result with balanced autonomy.
+- Choose quick direct work or precision-style evidence collection based on risk and scope.
+- Delegate bounded work when it materially advances implementation or verification.`,
 } as const;
 
 export const orchestratorInstructionsPrompt = `You are Orchestrator, a coding-agent orchestrator operating through the Pi harness.

--- a/mastra-agents/src/prompts/agents/supervisor.ts
+++ b/mastra-agents/src/prompts/agents/supervisor.ts
@@ -3,23 +3,22 @@ export const supervisorAgentDescription =
 
 // Mode prompts are emitted for Supervisor Lead only when the Harness mode changes.
 export const supervisorModePrompts = {
-  balanced: `Supervisor Lead Balanced mode:
+  base: `Supervisor Lead Base:
 - Orchestrate the work pragmatically across scoping, planning, building, and verification.
 - Delegate only when a specialist can advance a bounded part of the task.
 - Keep ownership of the final answer, evidence quality, and next action.`,
-  scope: `Supervisor Lead Scope mode:
+  scope: `Supervisor Lead Scope:
 - Identify the smallest useful slice, non-goals, assumptions, and evidence needed.
 - Route discovery to the right specialist before committing to implementation.
 - Stop for a decision when product scope or write boundaries are unclear.`,
-  plan: `Supervisor Lead Plan mode:
+  spec: `Supervisor Lead Spec:
 - Convert the scoped slice into a concrete execution plan with boundaries and verification.
 - Use specialists to sharpen contracts, risks, and acceptance criteria.
 - Do not present implementation as complete while still planning.`,
-  build: `Supervisor Lead Build mode:
+  exec: `Supervisor Lead Exec:
 - Drive implementation through the appropriate specialist agents while preserving the approved boundary.
 - Keep build progress tied to concrete files, behavior, and evidence.
-- Escalate if implementation requires a new scope or architecture decision.`,
-  verify: `Supervisor Lead Verify mode:
+- Escalate if implementation requires a new scope or architecture decision.
 - Audit the completed or claimed work before final synthesis.
 - Require evidence from tests, inspected diffs, snapshot turn/session diffs, tool output, or explicit verification gaps.
 - When a specialist claims it changed code, require snapshot-backed audit evidence unless snapshots are unavailable and that gap is stated.

--- a/mastra-agents/src/workflows/async-agent-job.ts
+++ b/mastra-agents/src/workflows/async-agent-job.ts
@@ -145,6 +145,8 @@ export const runAsyncAgentJobStep = createStep({
         [REQUEST_CONTEXT_HARNESS_MODE_KEY]: resolvedMode.harnessMode,
         [REQUEST_CONTEXT_HARNESS_MODE_ID_KEY]: resolvedMode.harnessModeId,
         [REQUEST_CONTEXT_HARDNESS_MODE_KEY]: resolvedMode.harnessModeId,
+        ...(resolvedMode.supervisorScope ? { supervisorScope: resolvedMode.supervisorScope } : {}),
+        ...(resolvedMode.orchestratorMode ? { orchestratorMode: resolvedMode.orchestratorMode } : {}),
         ...(inputData.input_args && Object.keys(inputData.input_args).length > 0 ? { input_args: inputData.input_args } : {}),
         snapshotRepoPath: initialSnapshot.snapshotRepoPath,
         snapshot: initialSnapshot.snapshot,
@@ -551,6 +553,8 @@ async function streamHarnessMessage({
       activeAgentId: resolvedMode.activeAgentId,
       harnessMode: resolvedMode.harnessMode,
       harnessModeId: resolvedMode.harnessModeId,
+      supervisorScope: resolvedMode.supervisorScope,
+      orchestratorMode: resolvedMode.orchestratorMode,
       hardnessMode: resolvedMode.harnessModeId,
     });
     const shouldSubmitModePrompt = await shouldSubmitHarnessModePrompt({

--- a/mastra-agents/src/workflows/async-agent-job.ts
+++ b/mastra-agents/src/workflows/async-agent-job.ts
@@ -23,7 +23,7 @@ import {
 import { captureTurnSnapshot, initializeSessionSnapshot, type SnapshotCapture } from "../tools/snapshots.js";
 import { resolveWorkspacePath } from "../workspace.js";
 import { setSessionId } from "../session.js";
-import { delegationPayloadFromEvent } from "./delegation-event.js";
+import { delegationPayloadFromEvent, subscribeDelegationEvents } from "./delegation-event.js";
 
 const inputArgsSchema = z.record(z.string()).optional();
 const modePromptTrackerStore = new PostgresStore({
@@ -529,6 +529,16 @@ async function streamHarnessMessage({
 
   const onAbort = () => harness.abort();
   abortSignal?.addEventListener("abort", onAbort, { once: true });
+  const unsubscribeDelegationEvents = subscribeDelegationEvents((payload) => {
+    if (!isCurrentRunDelegationPayload(payload, threadId, resourceId)) {
+      return;
+    }
+
+    emitChunk({
+      type: "delegation-event",
+      payload,
+    });
+  });
 
   try {
     await harness.init();
@@ -579,8 +589,21 @@ async function streamHarnessMessage({
   } finally {
     await writeQueue;
     abortSignal?.removeEventListener("abort", onAbort);
+    unsubscribeDelegationEvents();
     unsubscribe();
   }
+}
+
+function isCurrentRunDelegationPayload(
+  payload: unknown,
+  threadId: string,
+  resourceId: string,
+): payload is Record<string, unknown> {
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  return payload.threadId === threadId && payload.resourceId === resourceId;
 }
 
 function requestContextFromRecord(
@@ -639,4 +662,3 @@ function safePathPart(value: string): string {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-

--- a/mastra-agents/src/workflows/async-agent-job.ts
+++ b/mastra-agents/src/workflows/async-agent-job.ts
@@ -23,6 +23,7 @@ import {
 import { captureTurnSnapshot, initializeSessionSnapshot, type SnapshotCapture } from "../tools/snapshots.js";
 import { resolveWorkspacePath } from "../workspace.js";
 import { setSessionId } from "../session.js";
+import { delegationPayloadFromEvent } from "./delegation-event.js";
 
 const inputArgsSchema = z.record(z.string()).optional();
 const modePromptTrackerStore = new PostgresStore({
@@ -510,6 +511,14 @@ async function streamHarnessMessage({
       return;
     }
 
+    if (event.type === "delegation_start" || event.type === "delegation_complete") {
+      emitChunk({
+        type: "delegation-event",
+        payload: delegationPayloadFromEvent(event),
+      });
+      return;
+    }
+
     if (event.type === "error") {
       emitChunk({
         type: "error",
@@ -630,3 +639,4 @@ function safePathPart(value: string): string {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+

--- a/mastra-agents/src/workflows/delegation-event.d.ts
+++ b/mastra-agents/src/workflows/delegation-event.d.ts
@@ -1,0 +1,24 @@
+export type DelegationEventPayload = Record<string, unknown> & {
+  phase?: string;
+  delegationId?: string;
+  delegatedName?: string;
+  delegatedAgentId?: string;
+  prompt?: unknown;
+  response?: unknown;
+  error?: unknown;
+  success?: boolean;
+  durationMs?: number;
+  runId?: string;
+  agentRunId?: string;
+  threadId?: string;
+  resourceId?: string;
+  timestamp?: number;
+};
+
+export function subscribeDelegationEvents(
+  sink: (payload: DelegationEventPayload) => void,
+): () => boolean;
+export function emitDelegationEvent(payload: DelegationEventPayload): void;
+export function delegationPayloadFromEvent(event: unknown): DelegationEventPayload;
+export function delegationStartPayloadFromContext(context: Record<string, unknown>): DelegationEventPayload;
+export function delegationCompletePayloadFromContext(context: Record<string, unknown>): DelegationEventPayload;

--- a/mastra-agents/src/workflows/delegation-event.js
+++ b/mastra-agents/src/workflows/delegation-event.js
@@ -1,0 +1,32 @@
+export function delegationPayloadFromEvent(event) {
+  const payload = isRecord(event?.payload) ? event.payload : event;
+  const phase = typeof event?.type === 'string' ? event.type : 'delegation';
+  return {
+    phase,
+    delegationId: stringFromUnknown(payload.delegationId) ?? stringFromUnknown(payload.id),
+    delegatedName: stringFromUnknown(payload.delegatedName) ?? stringFromUnknown(payload.agentName) ?? stringFromUnknown(payload.targetAgentName),
+    delegatedAgentId: stringFromUnknown(payload.delegatedAgentId) ?? stringFromUnknown(payload.agentId) ?? stringFromUnknown(payload.targetAgentId),
+    prompt: structuredFromUnknown(payload.prompt ?? payload.query ?? payload.input),
+    response: structuredFromUnknown(payload.response ?? payload.result ?? payload.output),
+    error: structuredFromUnknown(payload.error),
+    success: booleanFromUnknown(payload.success),
+    durationMs: numberFromUnknown(payload.durationMs ?? payload.duration),
+    runId: stringFromUnknown(payload.runId),
+    agentRunId: stringFromUnknown(payload.agentRunId),
+    threadId: stringFromUnknown(payload.threadId),
+    resourceId: stringFromUnknown(payload.resourceId),
+    timestamp: Date.now(),
+    raw: payload,
+  };
+}
+
+function structuredFromUnknown(value) {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (value instanceof Error) return { name: value.name, message: value.message, stack: value.stack };
+  try { JSON.stringify(value); return value; } catch { return String(value); }
+}
+const stringFromUnknown = (v) => (typeof v === 'string' && v.length > 0 ? v : undefined);
+const numberFromUnknown = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+const booleanFromUnknown = (v) => (typeof v === 'boolean' ? v : undefined);
+const isRecord = (v) => typeof v === 'object' && !!v && !Array.isArray(v);

--- a/mastra-agents/src/workflows/delegation-event.js
+++ b/mastra-agents/src/workflows/delegation-event.js
@@ -1,3 +1,16 @@
+const delegationEventSinks = new Set();
+
+export function subscribeDelegationEvents(sink) {
+  delegationEventSinks.add(sink);
+  return () => delegationEventSinks.delete(sink);
+}
+
+export function emitDelegationEvent(payload) {
+  for (const sink of delegationEventSinks) {
+    sink(payload);
+  }
+}
+
 export function delegationPayloadFromEvent(event) {
   const payload = isRecord(event?.payload) ? event.payload : event;
   const phase = typeof event?.type === 'string' ? event.type : 'delegation';
@@ -17,6 +30,48 @@ export function delegationPayloadFromEvent(event) {
     resourceId: stringFromUnknown(payload.resourceId),
     timestamp: Date.now(),
     raw: payload,
+  };
+}
+
+export function delegationStartPayloadFromContext(context) {
+  return {
+    phase: 'delegation_start',
+    delegationId: stringFromUnknown(context.toolCallId),
+    delegatedName: stringFromUnknown(context.primitiveId),
+    delegatedAgentId: stringFromUnknown(context.primitiveId),
+    prompt: structuredFromUnknown(context.prompt),
+    runId: stringFromUnknown(context.runId),
+    agentRunId: stringFromUnknown(context.parentAgentId),
+    threadId: stringFromUnknown(context.threadId),
+    resourceId: stringFromUnknown(context.resourceId),
+    parentAgentId: stringFromUnknown(context.parentAgentId),
+    parentAgentName: stringFromUnknown(context.parentAgentName),
+    iteration: numberFromUnknown(context.iteration),
+    timestamp: Date.now(),
+    raw: context,
+  };
+}
+
+export function delegationCompletePayloadFromContext(context) {
+  return {
+    phase: 'delegation_complete',
+    delegationId: stringFromUnknown(context.toolCallId),
+    delegatedName: stringFromUnknown(context.primitiveId),
+    delegatedAgentId: stringFromUnknown(context.primitiveId),
+    prompt: structuredFromUnknown(context.prompt),
+    response: structuredFromUnknown(context.result),
+    error: structuredFromUnknown(context.error),
+    success: booleanFromUnknown(context.success),
+    durationMs: numberFromUnknown(context.duration),
+    runId: stringFromUnknown(context.runId),
+    agentRunId: stringFromUnknown(context.parentAgentId),
+    threadId: stringFromUnknown(context.threadId),
+    resourceId: stringFromUnknown(context.resourceId),
+    parentAgentId: stringFromUnknown(context.parentAgentId),
+    parentAgentName: stringFromUnknown(context.parentAgentName),
+    iteration: numberFromUnknown(context.iteration),
+    timestamp: Date.now(),
+    raw: context,
   };
 }
 

--- a/mastra-agents/src/workflows/workspace.ts
+++ b/mastra-agents/src/workflows/workspace.ts
@@ -51,6 +51,7 @@ const workspaceSmokeStep = createStep({
 
 const workspaceSmokeWorkflow = createWorkflow({
   id: "workspace-smoke-workflow",
+  description: "Run a smoke test against the workspace sandbox to verify tooling and environment.",
   inputSchema: z.object({}),
   outputSchema: z.object({
     status: z.enum(["ok", "error"]),

--- a/mastra-agents/src/workspace.ts
+++ b/mastra-agents/src/workspace.ts
@@ -1,4 +1,4 @@
-import { LocalFilesystem, LocalSandbox, Workspace, WORKSPACE_TOOLS } from "@mastra/core/workspace";
+import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
 
 import { DaytonaAgentsDaytonaSandbox } from "./daytona/mastra-sandbox.js";
 import {
@@ -161,12 +161,6 @@ export const workspace = new Workspace({
   ...createWorkspaceFilesystemConfig(),
   tools: {
     enabled: false,
-    [WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]: { enabled: true, name: "list_files" },
-    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { enabled: true, name: "read_file" },
-    [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: { enabled: true, name: "write_file" },
-    [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]: { enabled: true, name: "edit_file" },
-    [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { enabled: true, name: "grep" },
-    [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: { enabled: true, name: "bash" },
   },
   onMount: ({ filesystem, mountPath, sandbox }) => {
     if (filesystem.provider !== "local") {

--- a/mastra-agents/src/workspace.ts
+++ b/mastra-agents/src/workspace.ts
@@ -1,4 +1,4 @@
-import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
+import { LocalFilesystem, LocalSandbox, Workspace, WORKSPACE_TOOLS } from "@mastra/core/workspace";
 
 import { DaytonaAgentsDaytonaSandbox } from "./daytona/mastra-sandbox.js";
 import {
@@ -161,6 +161,12 @@ export const workspace = new Workspace({
   ...createWorkspaceFilesystemConfig(),
   tools: {
     enabled: false,
+    [WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]: { enabled: true },
+    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { enabled: true },
+    [WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT]: { enabled: true },
+    [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { enabled: true },
+    [WORKSPACE_TOOLS.SEARCH.SEARCH]: { enabled: true },
+    [WORKSPACE_TOOLS.LSP.LSP_INSPECT]: { enabled: true },
   },
   onMount: ({ filesystem, mountPath, sandbox }) => {
     if (filesystem.provider !== "local") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.21.0",
+        "@ai-sdk/openai-compatible": "1.0.39",
         "@chat-adapter/github": "^4.27.0",
         "@chat-adapter/linear": "^4.27.0",
         "@chat-adapter/slack": "^4.27.0",
+        "@chat-adapter/state-pg": "^4.27.0",
         "@daytona/sdk": "0.169.0",
-        "@mastra/core": "1.28.0",
+        "@mastra/core": "1.32.1",
         "@mastra/daytona": "0.3.0",
         "@mastra/duckdb": "1.2.0",
         "@mastra/editor": "0.7.19",
@@ -41,11 +43,99 @@
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
-        "mastra": "1.6.3",
+        "mastra": "1.8.1",
         "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22.13.0"
+      }
+    },
+    "mastra-agents/node_modules/@a2a-js/sdk": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.13.tgz",
+      "integrity": "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "mastra-agents/node_modules/@mastra/core": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@mastra/core/-/core-1.32.1.tgz",
+      "integrity": "sha512-6ynJNZ9GMkLs11c9D4Ui9Z0eOP8GsAqPeMVhlnxExcdTls0ufFQSXFgwzBqtS97fot9IOA/fxDLvvW83fnsP0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@a2a-js/sdk": "~0.3.13",
+        "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.23",
+        "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.23",
+        "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.1",
+        "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.8",
+        "@ai-sdk/ui-utils-v5": "npm:@ai-sdk/ui-utils@1.2.11",
+        "@isaacs/ttlcache": "^2.1.4",
+        "@lukeed/uuid": "^2.0.1",
+        "@mastra/schema-compat": "1.2.9",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@sindresorhus/slugify": "^2.2.1",
+        "@standard-schema/spec": "^1.1.0",
+        "ajv": "^8.18.0",
+        "chat": "^4.24.0",
+        "croner": "^10.0.1",
+        "dotenv": "^17.3.1",
+        "execa": "^9.6.1",
+        "gray-matter": "^4.0.3",
+        "hono": "^4.12.8",
+        "hono-openapi": "^1.3.0",
+        "ignore": "^7.0.5",
+        "js-tiktoken": "^1.0.21",
+        "json-schema": "^0.4.0",
+        "lru-cache": "^11.2.7",
+        "p-map": "^7.0.4",
+        "p-retry": "^7.1.1",
+        "picomatch": "^4.0.3",
+        "radash": "^12.1.1",
+        "tokenx": "^1.3.0",
+        "ws": "^8.20.0",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "mastra-agents/node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "mastra-code": {
@@ -96,19 +186,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@a2a-js/sdk/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -677,7 +754,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.39.tgz",
       "integrity": "sha512-001hdQPPXxYBWrz5d+eAmBVYmwzsB+guIey1DFXi1ZEE5H3j7fRrhPpX55MdM9Fle2DS7WZ8b3qkumCIWE92YQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
         "@ai-sdk/provider-utils": "3.0.25"
@@ -694,7 +770,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
       "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -707,7 +782,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
       "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
         "@standard-schema/spec": "^1.0.0",
@@ -2192,9 +2266,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2317,9 +2391,9 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2328,7 +2402,7 @@
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -2504,9 +2578,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3011,19 +3085,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
-    "node_modules/@browserbasehq/stagehand/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
@@ -3072,6 +3133,16 @@
         "@slack/socket-mode": "^2.0.5",
         "@slack/web-api": "^7.14.0",
         "chat": "4.27.0"
+      }
+    },
+    "node_modules/@chat-adapter/state-pg": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@chat-adapter/state-pg/-/state-pg-4.27.0.tgz",
+      "integrity": "sha512-6mOXpt1jJ+ZG5VHEY5Fb5T9/V3XNB7q8TrhTU+u0Sqn9wA8ql0/2Wn6hkW5kif5eYCZW8jXmx/jmWr3jxRT53w==",
+      "license": "MIT",
+      "dependencies": {
+        "chat": "4.27.0",
+        "pg": "^8.20.0"
       }
     },
     "node_modules/@clack/core": {
@@ -3922,10 +3993,9 @@
       }
     },
     "node_modules/@hono/node-ws": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-ws/-/node-ws-1.3.0.tgz",
-      "integrity": "sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-ws/-/node-ws-1.3.1.tgz",
+      "integrity": "sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3935,7 +4005,7 @@
         "node": ">=18.14.1"
       },
       "peerDependencies": {
-        "@hono/node-server": "^1.19.2",
+        "@hono/node-server": "^1.19.11",
         "hono": "^4.6.0"
       }
     },
@@ -4506,9 +4576,9 @@
       }
     },
     "node_modules/@mastra/deployer": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@mastra/deployer/-/deployer-1.29.0.tgz",
-      "integrity": "sha512-6pgzkJbzg/4h7Igz1AFIMMBuG9LegbUbgeSCEBf+qXBIphtYKwENtkCjrjk/1+Y1CEZi9w++VYK+XnfwUPD0kA==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@mastra/deployer/-/deployer-1.32.1.tgz",
+      "integrity": "sha512-7y79RQVkwwfFJ1b6WVnBiXWhF4wc3dF2dHGN69Uejld2D+/TqOKCBq7RP/SO3iOWWEc01UCt5OAbXwpbEIV3mA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4516,7 +4586,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@babel/traverse": "^7.29.0",
         "@hono/node-ws": "^1.3.0",
-        "@mastra/server": "1.29.0",
+        "@mastra/server": "1.32.1",
         "@optimize-lodash/rollup-plugin": "^5.1.0",
         "@rollup/plugin-alias": "6.0.0",
         "@rollup/plugin-commonjs": "29.0.2",
@@ -4538,7 +4608,7 @@
         "rollup-plugin-esbuild": "^6.2.1",
         "strip-json-comments": "^5.0.3",
         "tinyglobby": "^0.2.16",
-        "typescript-paths": "^1.5.1",
+        "typescript-paths": "^1.5.2",
         "ws": "^8.20.0"
       },
       "engines": {
@@ -4744,9 +4814,9 @@
       }
     },
     "node_modules/@mastra/server": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@mastra/server/-/server-1.29.0.tgz",
-      "integrity": "sha512-7MP/MxIIuWbPuL4zjg2t46cw8/g8RHgZS9vKb9FIriDL4hXu+p3RlZVh6xw9PHnL1zFnZC0WQTcHln9AIFkIcg==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@mastra/server/-/server-1.32.1.tgz",
+      "integrity": "sha512-CybYeWN2Ga+MRx2+PouMQ5ne0B9M63YtiY3XOs5RnYYifkq6k3Wv9uaDvHoLbW4wWllCUwRMeV3WEOQLGPW13g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6303,9 +6373,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -6317,9 +6387,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -6331,9 +6401,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -6345,9 +6415,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -6359,9 +6429,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -6373,9 +6443,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -6387,9 +6457,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -6401,9 +6471,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -6415,9 +6485,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -6429,9 +6499,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -6443,9 +6513,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
@@ -6457,9 +6527,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
@@ -6471,9 +6541,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
@@ -6485,9 +6555,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -6499,9 +6569,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -6513,9 +6583,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -6527,9 +6597,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -6541,9 +6611,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -6555,9 +6625,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -6569,9 +6639,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
       "cpu": [
         "x64"
       ],
@@ -6583,9 +6653,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -6597,9 +6667,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -6611,9 +6681,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -6625,9 +6695,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -6639,9 +6709,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -8751,9 +8821,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9978,6 +10048,25 @@
         "node": ">= 14"
       }
     },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10422,9 +10511,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "dev": true,
       "license": "ISC"
     },
@@ -13116,15 +13205,15 @@
       "optional": true
     },
     "node_modules/mastra": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/mastra/-/mastra-1.6.3.tgz",
-      "integrity": "sha512-HE1FbsVuOFvHCV15nzTo9vr7+xhs+OfQwUcWkRWqiBx4Ilc41jmla/uHGS+lc9GA6AdRpEYwrfCMLkMUigUnNQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/mastra/-/mastra-1.8.1.tgz",
+      "integrity": "sha512-pjkA54aJWn19DEOR22f3js7/73zzFN6nQBs0PfzGKnvtaAUuhSuzFEo9Z1AHD3t7dSTp140Iqr41F8hb4Z0Qyw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@expo/devcert": "^1.2.1",
-        "@mastra/deployer": "^1.28.0",
+        "@mastra/deployer": "^1.32.1",
         "@mastra/loggers": "^1.1.1",
         "archiver": "^7.0.1",
         "commander": "^14.0.3",
@@ -13136,7 +13225,6 @@
         "openapi-fetch": "^0.17.0",
         "picocolors": "^1.1.1",
         "posthog-node": "5.17.2",
-        "prettier": "^3.8.3",
         "semver": "^7.7.4",
         "serve": "^14.2.6",
         "serve-handler": "^6.1.7",
@@ -14409,19 +14497,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/node-simctl/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/node-simctl/node_modules/which": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -15222,22 +15297,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -15963,9 +16022,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15979,31 +16038,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -17280,9 +17339,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -17515,6 +17574,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {


### PR DESCRIPTION
### Motivation

RT88-70 needs one complete PR for workspace ownership cleanup, orchestration-layer delegation hooks, ACP-visible delegated activity, and the Palmer Linear channel path for supervisor-agent.

### Description

- Keeps the workspace/orchestration cleanup from the existing RT88-70 branch, including delegation hook wiring and ACP-visible delegated activity.
- Adds supervisor-owned Mastra Channels wiring for the Palmer Linear app actor using the official Chat SDK Linear adapter.
- Keeps Palmer lean: `supervisor-agent` owns the Linear webhook; no separate Chat SDK app and no custom OAuth subsystem.
- Adds the Linear OAuth callback route that hands the callback to Chat SDK `handleOAuthCallback()` and stores the resulting installation.
- Uses official `@chat-adapter/state-pg` for durable Chat SDK channel state so Linear OAuth installations persist across Mastra restarts.
- Adds the proxy model gateway and canonical `proxy/openai/gpt-5.5` configuration, removing the `rl/` model-prefix surface.
- Adds operator docs for Palmer Linear setup, proxy model API config, and Linear install URL generation.
- Adds the DeepWiki/package-first project rule to avoid reimplementing upstream package features.

### Testing

- `npm test -- src/agents/channels.test.js` pass: 14/14
- `npm run build` pass
- Manual Linear integration:
  - supervisor Linear webhook reachable: unsigned request returns `400 Missing webhook signature`
  - orchestrator Linear webhook disabled for Palmer: returns `404`
  - fresh Linear OAuth app-actor install saved for RT88 organization
  - `@palmer` in RT88 issue replies through `supervisor-agent`
  - OAuth install persisted after Mastra restart; Palmer replied: “Confirmed — the Linear OAuth install persisted after the Mastra server restart.”
- Proxy smoke test:
  - `PROXY_BASE_URL /models` returns `gpt-5.5`
  - direct completion against upstream `gpt-5.5` returned `proxy-ok`

### Notes

`.env` is ignored and was not committed. Runtime secrets remain local/deployment-only.
