### PR TITLE
Formulate Docker sandbox compose dev stack

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,7 @@ services:
         required: false
     environment:
       NODE_ENV: development
+      MASTRA_SKIP_DOTENV: "true"
       MASTRA_SERVER_HOST: 0.0.0.0
       MASTRA_SERVER_PORT: ${MASTRA_SERVER_PORT:-4111}
       MASTRA_SERVER_STUDIO_HOST: ${MASTRA_SERVER_STUDIO_HOST:-localhost}
@@ -59,7 +60,7 @@ services:
 
   mastra-sandbox:
     image: ${MASTRA_DOCKER_SANDBOX_IMAGE:-ghcr.io/eugenechan00/daytona-agents/snapshot-mastra-agents:dev}
-    command: ["sleep", "infinity"]
+    entrypoint: ["sleep", "infinity"]
     environment:
       SERENA_PROJECT: /workspace
       SERENA_CONTEXT: codex

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,137 @@
+# compose.yml — Mastra-System local dev stack.
+#
+# This file intentionally does not start the Daytona control plane. The default
+# sandbox image is built in the daytona-agents repo, but it is only an agent
+# execution image artifact.
+#
+# Services:
+#   mastra-server    — Mastra dev server + Studio (`npm run dev`)
+#   mastra-sandbox   — Agent execution container (DockerSandbox reconnects by label)
+#   mastra-postgres  — Storage for Mastra Memory + control state
+#   webhook-server   — Webhook relay for GitHub/Linear/Slack
+#   cloudflare-webhook-tunnel — Optional public webhook tunnel; enable with
+#                               --profile public-webhook and CLOUDFLARED_TUNNEL_TOKEN
+#
+# The sandbox container has the `mastra.sandbox.id` label set.
+# DockerSandbox in workspace.ts reconnects to it by matching that label.
+#
+# Usage: docker compose up
+
+name: mastra-system
+
+services:
+  mastra-server:
+    build:
+      context: .
+      dockerfile: docker/mastra-server.Dockerfile
+    command: ["npm", "run", "dev"]
+    working_dir: /app/mastra-agents
+    restart: unless-stopped
+    depends_on:
+      mastra-postgres:
+        condition: service_healthy
+      mastra-sandbox:
+        condition: service_started
+    env_file:
+      - path: .env
+        required: false
+      - path: mastra-agents/.env
+        required: false
+    environment:
+      NODE_ENV: development
+      MASTRA_SERVER_HOST: 0.0.0.0
+      MASTRA_SERVER_PORT: ${MASTRA_SERVER_PORT:-4111}
+      MASTRA_SERVER_STUDIO_HOST: ${MASTRA_SERVER_STUDIO_HOST:-localhost}
+      MASTRA_SERVER_STUDIO_PORT: ${MASTRA_SERVER_STUDIO_PORT:-4111}
+      MASTRA_WORKSPACE_SANDBOX: docker
+      MASTRA_DOCKER_SANDBOX_ID: mastra-agents-coding
+      MASTRA_DOCKER_SANDBOX_NETWORK: mastra-system_default
+      MASTRA_WORKSPACE_ROOT: ${HOST_WORKSPACE_ROOT:-/container/shared/workspace/projects/mastra-system}
+      DATABASE_URL: postgresql://mastra:mastra@mastra-postgres:5432/mastra
+    ports:
+      - "${MASTRA_SERVER_HOST_PORT:-4111}:4111"
+    volumes:
+      - ${HOST_WORKSPACE_ROOT:-.}:/app
+      - mastra-server-node-modules:/app/node_modules
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - default
+
+  mastra-sandbox:
+    image: ${MASTRA_DOCKER_SANDBOX_IMAGE:-ghcr.io/eugenechan00/daytona-agents/snapshot-mastra-agents:dev}
+    command: ["sleep", "infinity"]
+    environment:
+      SERENA_PROJECT: /workspace
+      SERENA_CONTEXT: codex
+      SERENA_MCP_PORT: "8084"
+      CODE_REVIEW_GRAPH_REPO: /workspace
+      CODE_REVIEW_GRAPH_MCP_PORT: "8085"
+      AGENT_SERVICES_AUTOSTART: "false"
+      LOCAL_MCP_AUTOSTART: "false"
+      JUPYTER_AUTOSTART: "false"
+      PASEO_AUTOSTART: "false"
+      # Postgres reachable via Docker DNS on the shared network
+      DATABASE_URL: postgresql://mastra:mastra@mastra-postgres:5432/mastra
+    volumes:
+      - ${HOST_WORKSPACE_ROOT:-.}:/workspace
+      - /container/shared:/shared
+    networks:
+      - default
+    labels:
+      mastra.sandbox: "true"
+      mastra.sandbox.id: "mastra-agents-coding"
+    restart: unless-stopped
+
+  mastra-postgres:
+    image: ${POSTGRES_IMAGE:-postgres:16-alpine}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-mastra}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mastra}
+      POSTGRES_DB: ${POSTGRES_DB:-mastra}
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    volumes:
+      - mastra-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", 'pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  webhook-server:
+    build:
+      context: .
+      dockerfile: webhook-server/Dockerfile
+    restart: unless-stopped
+    environment:
+      WEBHOOK_SERVER_HOST: ${WEBHOOK_SERVER_HOST:-0.0.0.0}
+      WEBHOOK_SERVER_PORT: ${WEBHOOK_SERVER_PORT:-8080}
+      MASTRA_UPSTREAM_URL: ${WEBHOOK_MASTRA_UPSTREAM_URL:-http://mastra-server:4111}
+      WEBHOOK_FORWARD_TIMEOUT_MS: ${WEBHOOK_FORWARD_TIMEOUT_MS:-30000}
+    depends_on:
+      - mastra-server
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.WEBHOOK_SERVER_PORT||8080)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cloudflare-webhook-tunnel:
+    profiles: ["public-webhook"]
+    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:latest}
+    restart: unless-stopped
+    depends_on:
+      - webhook-server
+    command:
+      - tunnel
+      - --no-autoupdate
+      - run
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARED_TUNNEL_TOKEN:-}
+      TUNNEL_METRICS: ${CLOUDFLARED_METRICS:-0.0.0.0:2000}
+      TUNNEL_LOGLEVEL: ${CLOUDFLARED_LOGLEVEL:-info}
+
+volumes:
+  mastra-server-node-modules:
+  mastra-postgres-data:

--- a/compose.yml
+++ b/compose.yml
@@ -91,7 +91,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mastra}
       POSTGRES_DB: ${POSTGRES_DB:-mastra}
     ports:
-      - "${POSTGRES_HOST_PORT:-5432}:5432"
+      - "${POSTGRES_HOST_PORT:-5433}:5432"
     volumes:
       - mastra-postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/mastra-server.Dockerfile
+++ b/docker/mastra-server.Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    openssh-client \
+    procps \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy package files first for layer caching
+COPY mastra-agents/package.json /app/mastra-agents/package.json
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
+
+WORKDIR /app
+RUN npm ci
+
+COPY mastra-agents /app/mastra-agents
+COPY mastra-code /app/mastra-code
+COPY paseo /app/paseo
+
+WORKDIR /app/mastra-agents
+RUN npm run build
+
+ENV NODE_ENV=production
+ENV MASTRA_SERVER_HOST=0.0.0.0
+ENV MASTRA_SERVER_PORT=4111
+ENV DATABASE_URL=postgresql://mastra:mastra@mastra-postgres:5432/mastra
+ENV MASTRA_WORKSPACE_SANDBOX=docker
+
+EXPOSE 4111
+
+CMD ["npm", "run", "start", "--", "--dir", ".mastra/output"]

--- a/mastra-agents/README.md
+++ b/mastra-agents/README.md
@@ -121,7 +121,7 @@ From the Docker host, the default endpoints are:
 
 ```text
 http://localhost:4111
-postgresql://mastra:mastra@localhost:5432/mastra
+postgresql://mastra:mastra@localhost:5433/mastra
 ```
 
 Set `MASTRA_SERVER_HOST_PORT` or `POSTGRES_HOST_PORT` if either host port is already in use.

--- a/mastra-agents/README.md
+++ b/mastra-agents/README.md
@@ -91,13 +91,43 @@ The Mastra server registers the hosted OpenAI-compatible proxy as a custom model
 
 The proxy expects the upstream model name without the gateway/provider namespace, for example `gpt-5.5`. ACP thinking levels use CLIProxy's model suffix shape, for example `proxy/openai/gpt-5.5` with `High` thinking is sent through Mastra as `proxy/openai/gpt-5.5(high)` and reaches the proxy as `gpt-5.5(high)`.
 
-## Webhook Server With Cloudflare Tunnel
+## Compose Dev Stack
 
-The stack in `compose.webhooks.yml` runs:
+The stack in top-level `compose.yml` runs:
 
+- `mastra-server`: Mastra dev server and Studio via `npm run dev`, exposed on port `4111` by default.
+- `mastra-sandbox`: the DockerSandbox execution container. It uses the prebuilt `daytona-agents` snapshot image as a coding image artifact; it does not start Daytona services.
 - `mastra-postgres`: Postgres storage for Mastra memory, workflows, and control-plane state.
-- `webhook-server`: a small raw-body HTTP proxy that forwards webhook requests to the Mastra server already running on the Docker host.
-- `cloudflare-webhook-tunnel`: a Cloudflare Tunnel connector forwarding public HTTPS traffic to `webhook-server`.
+- `webhook-server`: a small raw-body HTTP proxy that forwards webhook requests to `mastra-server` over the Compose network.
+- `cloudflare-webhook-tunnel`: an optional Cloudflare Tunnel connector forwarding public HTTPS traffic to `webhook-server`.
+
+The stack intentionally does not run the Daytona control plane. Daytona remains a reference/source repo for the sandbox image and PTY/computer-use research, not a service in this Compose graph.
+
+Start the local stack:
+
+```bash
+docker compose --env-file mastra-agents/.env up -d --build
+```
+
+The deployed internal Docker network endpoints are:
+
+```text
+http://mastra-server:4111
+http://webhook-server:8080
+postgresql://mastra:mastra@mastra-postgres:5432/mastra
+```
+
+From the Docker host, the default endpoints are:
+
+```text
+http://localhost:4111
+postgresql://mastra:mastra@localhost:5432/mastra
+```
+
+Set `MASTRA_SERVER_HOST_PORT` or `POSTGRES_HOST_PORT` if either host port is already in use.
+Set `WEBHOOK_MASTRA_UPSTREAM_URL` only when the webhook relay should forward somewhere other than the Compose-managed `mastra-server`.
+
+## Public Webhook Tunnel
 
 Create a remotely managed Cloudflare Tunnel in Cloudflare Zero Trust, copy its connector token into `CLOUDFLARED_TUNNEL_TOKEN`, and configure a public hostname for the tunnel with this service target:
 
@@ -105,30 +135,10 @@ Create a remotely managed Cloudflare Tunnel in Cloudflare Zero Trust, copy its c
 http://webhook-server:8080
 ```
 
-The deployed internal Docker network endpoint is:
-
-```text
-http://webhook-server:8080
-```
-
-By default the proxy forwards to host Mastra at:
-
-```text
-http://host.docker.internal:4111
-```
-
-If Docker cannot reach `host.docker.internal` from this workspace, set `MASTRA_UPSTREAM_URL` to the workspace container IP, for example `http://172.30.10.102:4111`.
-
-The stack exposes Postgres on the Docker host at:
-
-```text
-postgresql://mastra:mastra@localhost:5432/mastra
-```
-
-Then start the webhook stack:
+Start the stack with the public tunnel profile:
 
 ```bash
-docker compose -f compose.webhooks.yml --env-file mastra-agents/.env up -d --build
+docker compose --env-file mastra-agents/.env --profile public-webhook up -d --build
 ```
 
 Use the deployed public hostname for platform webhooks:

--- a/mastra-agents/src/docker-sandbox-config.ts
+++ b/mastra-agents/src/docker-sandbox-config.ts
@@ -1,0 +1,93 @@
+/**
+ * Docker sandbox configuration for Mastra-System.
+ *
+ * When running with Docker Compose, the sandbox container is started by
+ * `compose.yml` with all infrastructure config (image, volumes, env,
+ * network, labels) already applied. `DockerSandbox` reconnects to it by
+ * matching the `mastra.sandbox.id` label — no YAML config file needed.
+ *
+ * The env var overrides below serve as escape hatches for non-Compose
+ * scenarios (CI, bare `docker run`, etc.).
+ */
+
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** Sandbox runtime env defaults — matches the Compose env_file values. */
+const sandboxRuntimeEnv = {
+  SERENA_PROJECT: "/workspace",
+  SERENA_CONTEXT: "codex",
+  SERENA_MCP_PORT: "8084",
+  CODE_REVIEW_GRAPH_REPO: "/workspace",
+  CODE_REVIEW_GRAPH_MCP_PORT: "8085",
+  AGENT_SERVICES_AUTOSTART: "false",
+  LOCAL_MCP_AUTOSTART: "false",
+  JUPYTER_AUTOSTART: "false",
+  JUPYTER_HOST: "127.0.0.1",
+  JUPYTER_PORT: "8888",
+  JUPYTER_WORKDIR: "/workspace",
+  PASEO_AUTOSTART: "false",
+  PASEO_HOME: "/home/daytona/.paseo",
+  PASEO_LISTEN: "0.0.0.0:16767",
+  PASEO_HOST: "127.0.0.1:16767",
+  PASEO_HOSTNAMES: "localhost,127.0.0.1,.localhost,.proxy.localhost",
+  PASEO_RELAY_ENABLED: "true",
+  PASEO_MCP_ENABLED: "true",
+  PASEO_INJECT_MCP_ENABLED: "true",
+} as const;
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/** Resolve bind mounts for the Docker sandbox. */
+export function resolveDockerBindMounts(): Record<string, string> {
+  const mounts: Record<string, string> = {};
+
+  const workspaceRoot = readEnv("MASTRA_WORKSPACE_ROOT") ?? path.resolve(process.cwd(), "../..");
+  mounts[workspaceRoot] = "/workspace";
+
+  // Host /container/shared is mounted as /shared in the sandbox.
+  // The image already includes agents via brew tap + git clone — no .agents bind mount needed.
+  if (existsSync("/container/shared")) {
+    mounts["/container/shared"] = "/shared";
+  }
+
+  const extraMountsRaw = readEnv("MASTRA_DOCKER_SANDBOX_EXTRA_MOUNTS");
+  if (extraMountsRaw) {
+    for (const entry of extraMountsRaw.split(",")) {
+      const [host, container] = entry.trim().split(":", 2);
+      if (host && container) {
+        mounts[host] = container;
+      }
+    }
+  }
+
+  return mounts;
+}
+
+/** Resolve runtime env for the Docker sandbox. */
+export function resolveDockerSandboxRuntimeEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const [name, fallback] of Object.entries(sandboxRuntimeEnv)) {
+    env[name] = readEnv(name) ?? fallback;
+  }
+
+  // Pass DATABASE_URL so agents inside the sandbox can reach Postgres
+  const databaseUrl = readEnv("DATABASE_URL") ?? "postgresql://mastra:mastra@mastra-postgres:5432/mastra";
+  env.DATABASE_URL = databaseUrl;
+
+  return env;
+}
+
+/** Default sandbox ID — matches the `mastra.sandbox.id` label in compose.yml. */
+export const defaultDockerSandboxId = "mastra-agents-coding";
+
+/** Default sandbox image — a prebuilt coding image artifact, not Daytona services. */
+export const defaultDockerSandboxImage = "ghcr.io/eugenechan00/daytona-agents/snapshot-mastra-agents:dev";
+
+/** Default Docker network — matches the Compose project network. */
+export const defaultDockerSandboxNetwork = "mastra-system_default";


### PR DESCRIPTION
## Summary

- Add top-level Mastra-System Compose dev stack with mastra-server, mastra-sandbox, mastra-postgres, and webhook-server
- Run Mastra server/Studio via npm run dev on port 4111 and connect it to the Compose-managed DockerSandbox container
- Keep Daytona out of the Compose service graph; the daytona-agents image is only the sandbox image artifact
- Keep public Cloudflare webhook tunnel as an explicit opt-in profile
- Move host Postgres publish port to 5433 to avoid the existing mastra-code-postgres owner on 5432

## Verification

- docker compose --env-file mastra-agents/.env -f compose.yml build
- docker compose --env-file mastra-agents/.env -f compose.yml up -d
- curl -I http://localhost:4111/ returned 200 OK
- curl http://localhost:4111/api/agents returned agent JSON
- mastra-postgres pg_isready succeeded

## Notes

The public webhook tunnel still needs a separate follow-up pass for the public hostname/profile path. This PR leaves the public-webhook profile off by default.