### PR TITLE
Preserve full reasoning text and make tool content optional with increased stringify limits

### DIFF
--- a/mastra-agents/acp/event-mapper.ts
+++ b/mastra-agents/acp/event-mapper.ts
@@ -1,4 +1,4 @@
-import type { SessionUpdate, ToolCallUpdate } from '@agentclientprotocol/sdk';
+import type { SessionUpdate, ToolCallContent, ToolCallUpdate } from '@agentclientprotocol/sdk';
 
 export function inferToolKind(name?: string): ToolCallUpdate['kind'] {
   if (!name) return 'other';
@@ -9,14 +9,24 @@ export function inferToolKind(name?: string): ToolCallUpdate['kind'] {
   return 'other';
 }
 
+
+function optionalContentText(...values: unknown[]): ToolCallContent[] | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return [{ type: 'content', content: { type: 'text', text: value } } as ToolCallContent];
+    }
+  }
+  return undefined;
+}
+
 export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
   if (!isRecord(chunk)) return [];
   const type = str(chunk.type);
   if (type === 'text-delta') return [{ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: textFrom(chunk) } }];
   if (type === 'reasoning-delta' || type === 'reasoning') return [{ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: textFrom(chunk) }, _meta: { mastra: { reasoning: chunk } } }];
-  if (type === 'finish') return chunk.usage ? [{ sessionUpdate:'usage_update', used: num(chunk.usage,'totalTokens') ?? 0, size: num(chunk.usage,'totalTokens') ?? 0 }] : [];
+  if (type === 'finish') return chunk.usage ? [{ sessionUpdate: 'usage_update', used: num(chunk.usage, 'totalTokens') ?? 0, size: num(chunk.usage, 'totalTokens') ?? 0 }] : [];
 
-  if (type === "delegation-event") {
+  if (type === 'delegation-event') {
     const payload = isRecord(chunk.payload) ? chunk.payload : {};
     const fallbackIdParts = [
       idPart(payload.delegationId),
@@ -27,26 +37,19 @@ export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
       idPart(payload.phase),
       idPart(payload.delegatedAgentId) ?? idPart(payload.delegatedName),
     ].filter(Boolean);
-    const fallbackId = fallbackIdParts.length > 0 ? `delegation:${fallbackIdParts.join(":")}` : `delegation:${Date.now()}`;
-    const phase = str(payload.phase) ?? "delegation";
-    const status = phase === "delegation_complete" ? (payload.success === false ? "failed" : "completed") : "in_progress";
-    const summary = {
-      target: payload.delegatedAgentId ?? payload.delegatedName,
-      prompt: payload.prompt,
-      response: payload.response,
-      error: payload.error,
-      success: payload.success,
-      durationMs: payload.durationMs,
-    };
+    const fallbackId = fallbackIdParts.length > 0 ? `delegation:${fallbackIdParts.join(':')}` : `delegation:${Date.now()}`;
+    const phase = str(payload.phase) ?? 'delegation';
+    const status = phase === 'delegation_complete' ? (payload.success === false ? 'failed' : 'completed') : 'in_progress';
+
     return [{
-      sessionUpdate: "tool_call_update",
+      sessionUpdate: 'tool_call_update',
       toolCallId: str(payload.delegationId) ?? fallbackId,
       status,
-      title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? "delegation",
-      kind: "other",
+      title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? 'delegation',
+      kind: 'other',
       rawInput: payload.prompt,
       rawOutput: payload.response ?? payload.error,
-      content: [{ type: "content", content: { type: "text", text: JSON.stringify(summary) } }],
+      content: optionalContentText(str(payload.response), str(payload.error)),
       _meta: { mastra: chunk },
     }];
   }
@@ -54,6 +57,7 @@ export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
   if (type?.startsWith('tool-')) {
     const p = isRecord(chunk.payload) ? chunk.payload : chunk;
     const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : (type === 'tool-call-input-streaming-start' ? 'in_progress' : 'pending');
+
     const update: ToolCallUpdate & { sessionUpdate: 'tool_call_update' } = {
       sessionUpdate: 'tool_call_update',
       toolCallId: str(p.toolCallId) ?? str(p.id) ?? 'unknown',
@@ -62,9 +66,10 @@ export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
       kind: inferToolKind(str(p.toolName) ?? str(p.name)),
       rawInput: p.args,
       rawOutput: p.error ?? p.result,
-      content: [{ type: 'content', content: { type: 'text', text: JSON.stringify({ args:p.args, result:p.result, error:p.error }) } }],
+      content: optionalContentText(str(p.result), str(p.error), str(p.delta), str(p.text)),
       _meta: { mastra: chunk },
     };
+
     return [update];
   }
   return [];

--- a/mastra-agents/src/adapters/channels/stream-bridge.ts
+++ b/mastra-agents/src/adapters/channels/stream-bridge.ts
@@ -1,6 +1,6 @@
 import type { StreamChunk } from "chat";
 
-import { summarizeForChannel, stringifyForChannel, stripToolPrefix } from "./text-format.js";
+import { stringifyForChannel, stripToolPrefix } from "./text-format.js";
 
 type MastraChunk = {
   type?: string;
@@ -34,7 +34,7 @@ export function mastraChunkToChatStreamChunk(chunk: MastraChunk): StreamChunk | 
 
   if (chunk.type === "reasoning-delta") {
     const text = typeof payload.text === "string" ? payload.text : "Thinking...";
-    return { type: "markdown_text", text: summarizeForChannel(text, 220) };
+    return { type: "markdown_text", text };
   }
 
   if (chunk.type === "tool-call") {
@@ -42,7 +42,7 @@ export function mastraChunkToChatStreamChunk(chunk: MastraChunk): StreamChunk | 
       type: "task_update",
       id: toolChunkId(payload),
       title: toolChunkTitle(payload),
-      details: summarizeForChannel(payload.args ?? {}, 500),
+      details: stringifyForChannel(payload.args ?? {}, 2000),
       status: "in_progress",
     };
   }
@@ -53,7 +53,7 @@ export function mastraChunkToChatStreamChunk(chunk: MastraChunk): StreamChunk | 
       type: "task_update",
       id: toolChunkId(payload),
       title: toolChunkTitle(payload),
-      output: stringifyForChannel(payload.result, isError ? 1200 : 1800),
+      output: stringifyForChannel(payload.result, isError ? 2000 : 4000),
       status: isError ? "error" : "complete",
     };
   }
@@ -63,7 +63,7 @@ export function mastraChunkToChatStreamChunk(chunk: MastraChunk): StreamChunk | 
       type: "task_update",
       id: toolChunkId(payload),
       title: toolChunkTitle(payload),
-      output: stringifyForChannel(payload.error, 1200),
+      output: stringifyForChannel(payload.error, 2000),
       status: "error",
     };
   }
@@ -92,7 +92,7 @@ export async function* bridgeMastraStreamToChatChunks(chunks: AsyncIterable<Mast
     if (!mapped) continue;
 
     if (mapped.type === "task_update" && pendingReasoning) {
-      yield { type: "markdown_text", text: summarizeForChannel(pendingReasoning, 220) };
+      yield { type: "markdown_text", text: pendingReasoning };
       pendingReasoning = "";
     }
 


### PR DESCRIPTION
### Motivation
- Ensure tool call content is only attached when there is meaningful text and avoid embedding JSON summaries in content.
- Preserve full reasoning text sent to channels instead of truncating or summarizing it.
- Increase stringification limits for tool details and outputs to surface more context in channel messages.
- Align types to include `ToolCallContent` for more accurate content shaping.

### Description
- Added an `optionalContentText` helper to produce `ToolCallContent` only when a non-empty string is available and used it for delegation and tool updates instead of JSON-stringifying full summaries.
- Updated imports and types to include `ToolCallContent` and adjusted `mapMastraChunkToUpdates` to set `content` via `optionalContentText` for `delegation-event` and `tool-*` chunks.
- Removed summarization of reasoning in `mastraChunkToChatStreamChunk` so `reasoning-delta` now yields the full text, and pending reasoning is emitted verbatim when a task update is produced.
- Replaced some uses of `summarizeForChannel` with `stringifyForChannel` and increased allowed lengths for `details` and `output` (`details` to 2000, `output` to 2000/4000 depending on error state) and removed the unused `summarizeForChannel` import.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and it completed successfully.
- Executed the test suite with `pnpm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7027c574832aa1b459b615ebd005)