### PR TITLE
Expose ACP fork session support in Mastra ACP adapter

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -65,6 +65,7 @@ services:
   mastra-sandbox:
     image: ${MASTRA_DOCKER_SANDBOX_IMAGE:-ghcr.io/eugenechan00/daytona-agents/snapshot-mastra-agents:dev}
     entrypoint: ["sleep", "infinity"]
+    working_dir: /workspace
     environment:
       SERENA_PROJECT: /workspace
       SERENA_CONTEXT: codex

--- a/compose.yml
+++ b/compose.yml
@@ -47,12 +47,16 @@ services:
       MASTRA_WORKSPACE_SANDBOX: docker
       MASTRA_DOCKER_SANDBOX_ID: mastra-agents-coding
       MASTRA_DOCKER_SANDBOX_NETWORK: mastra-system_default
-      MASTRA_WORKSPACE_ROOT: ${HOST_WORKSPACE_ROOT:-/container/shared/workspace/projects/mastra-system}
+      MASTRA_DOCKER_SANDBOX_HOST_WORKSPACE_ROOT: ${HOST_WORKSPACE_ROOT:-/container/shared/workspace/projects/mastra-system}
+      MASTRA_WORKSPACE_ROOT: /app
+      MASTRA_WORKSPACE_COMMAND_CWD: /app
+      MASTRA_WORKSPACE_ACCESS_ROOTS: /app,/root,/shared/workspace
       DATABASE_URL: postgresql://mastra:mastra@mastra-postgres:5432/mastra
     ports:
       - "${MASTRA_SERVER_HOST_PORT:-4111}:4111"
     volumes:
       - ${HOST_WORKSPACE_ROOT:-.}:/app
+      - /container/shared/workspace:/shared/workspace
       - mastra-server-node-modules:/app/node_modules
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
@@ -75,7 +79,7 @@ services:
       DATABASE_URL: postgresql://mastra:mastra@mastra-postgres:5432/mastra
     volumes:
       - ${HOST_WORKSPACE_ROOT:-.}:/workspace
-      - /container/shared:/shared
+      - /container/shared/workspace:/shared/workspace
     networks:
       - default
     labels:

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -25,11 +25,11 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
         authMethods: [],
       };
     },
-    async newSession(_params: NewSessionRequest): Promise<NewSessionResponse> {
+    async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
       const config = await runtimeConfig();
       const session = store.create({
         agentId: options.agentId,
-        cwd: options.cwd,
+        cwd: params.cwd ?? options.cwd,
         resourceId: options.defaultResourceId,
         threadId: options.defaultThreadId,
         defaultModeId: config.defaultModeId,

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -1,7 +1,7 @@
 import type { AgentSideConnection, ForkSessionRequest, ForkSessionResponse, InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModelRequest, SetSessionModelResponse } from '@agentclientprotocol/sdk';
 import { randomUUID } from 'node:crypto';
 import { buildConfigOptions, loadAcpRuntimeConfig, modeDefinitionForSession, modelOptionsForSession, normalizeModeId, normalizeModelId, type AcpRuntimeConfig } from './config-options.js';
-import { mapMastraChunkToUpdates } from './event-mapper.js';
+import { createMastraChunkMapper } from './event-mapper.js';
 import { cloneMastraThread } from './memory-client.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
@@ -87,6 +87,7 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
       const content = (last && 'text' in last) ? last.text : '';
       const ac = new AbortController();
       session.abortController = ac; store.update(session);
+      const mapMastraChunkToUpdates = createMastraChunkMapper();
       for await (const chunk of streamMastraAgent(options.mastraBaseUrl, session.agentId, buildPromptPayload(session, content, config), ac.signal)) {
         for (const update of mapMastraChunkToUpdates(chunk)) {
           await conn.sessionUpdate({ sessionId: session.sessionId, update });

--- a/mastra-agents/acp/adapter.ts
+++ b/mastra-agents/acp/adapter.ts
@@ -1,6 +1,8 @@
-import type { AgentSideConnection, InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModelRequest, SetSessionModelResponse } from '@agentclientprotocol/sdk';
+import type { AgentSideConnection, ForkSessionRequest, ForkSessionResponse, InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModelRequest, SetSessionModelResponse } from '@agentclientprotocol/sdk';
+import { randomUUID } from 'node:crypto';
 import { buildConfigOptions, loadAcpRuntimeConfig, modeDefinitionForSession, modelOptionsForSession, normalizeModeId, normalizeModelId, type AcpRuntimeConfig } from './config-options.js';
 import { mapMastraChunkToUpdates } from './event-mapper.js';
+import { cloneMastraThread } from './memory-client.js';
 import { streamMastraAgent } from './mastra-stream.js';
 import { MastraAcpSessionStore } from './session-store.js';
 import type { ACPAgent, MastraAcpAgentOptions, MastraAcpSession } from './types.js';
@@ -17,6 +19,7 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
         agentCapabilities: {
           loadSession: false,
           promptCapabilities: { image: false, audio: false, embeddedContext: false },
+          sessionCapabilities: { fork: {} },
         },
         agentInfo: { name: 'Mastra ACP Agent', version: '0.1.0' },
         authMethods: [],
@@ -34,6 +37,47 @@ export function createMastraAcpAgentHandler(conn: AgentSideConnection, options: 
       });
       await conn.sessionUpdate({ sessionId: session.sessionId, update: { sessionUpdate: 'available_commands_update', availableCommands: getSlashCommands() } });
       return sessionStateResponse(session, config);
+    },
+    async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
+      const config = await runtimeConfig();
+      const parent = store.get(params.sessionId);
+      if (!parent) throw new Error(`Unknown session: ${params.sessionId}`);
+      if (params.cwd !== parent.cwd) {
+        throw new Error(`Cannot fork session ${params.sessionId}: cwd mismatch`);
+      }
+
+      const childSessionId = randomUUID();
+      const childThreadId = `acp:${childSessionId}:${parent.agentId}`;
+      const createdAt = new Date().toISOString();
+      const clonedThread = await cloneMastraThread({
+        baseUrl: options.mastraBaseUrl,
+        agentId: parent.agentId,
+        sourceThreadId: parent.threadId,
+        newThreadId: childThreadId,
+        resourceId: parent.resourceId,
+        metadata: {
+          acp: {
+            fork: {
+              parentSessionId: parent.sessionId,
+              childSessionId,
+              parentThreadId: parent.threadId,
+              createdAt,
+              agentId: parent.agentId,
+            },
+          },
+        },
+      });
+
+      if (clonedThread.id !== childThreadId) {
+        throw new Error(`Mastra memory clone returned unexpected thread id: ${clonedThread.id}`);
+      }
+      if (clonedThread.resourceId !== parent.resourceId) {
+        throw new Error(`Mastra memory clone returned unexpected resource id: ${clonedThread.resourceId}`);
+      }
+
+      const child = store.fork(parent, { sessionId: childSessionId, threadId: clonedThread.id });
+      await conn.sessionUpdate({ sessionId: child.sessionId, update: { sessionUpdate: 'available_commands_update', availableCommands: getSlashCommands() } });
+      return sessionStateResponse(child, config);
     },
     async prompt(params: PromptRequest): Promise<PromptResponse> {
       const config = await runtimeConfig();

--- a/mastra-agents/acp/config-options.ts
+++ b/mastra-agents/acp/config-options.ts
@@ -37,6 +37,8 @@ const modeAliases = new Map<string, SupervisorModeId>([
 type SupervisorModeId = 'base' | 'scope' | 'spec' | 'exec';
 
 const configCache = new Map<string, Promise<AcpRuntimeConfig>>();
+const rawOpenAiGpt55ModelIds = new Set(['gpt-5.5', 'openai/gpt-5.5']);
+const proxyOpenAiGpt55ModelId = 'proxy/openai/gpt-5.5';
 
 export function runtimeAgentIdFromAgentId(agentId: string | undefined): AcpRuntimeAgentId {
   const normalized = agentId?.trim().toLowerCase().replace(/_/g, '-') ?? '';
@@ -64,7 +66,7 @@ export function normalizeModeId(value: unknown, config: AcpRuntimeConfig): strin
 }
 
 export function normalizeModelId(value: unknown, config: AcpRuntimeConfig): string {
-  return typeof value === 'string' && value.trim() ? value.trim() : config.defaultModelId;
+  return typeof value === 'string' && value.trim() ? canonicalModelId(value) : config.defaultModelId;
 }
 
 export function modeDefinitionForSession(session: MastraAcpSession, config: AcpRuntimeConfig): AcpModeDefinition {
@@ -131,10 +133,15 @@ async function modelIdFromMastraAgentApi(agentId: string | undefined, mastraBase
     const provider = typeof agentConfig.provider === 'string' ? agentConfig.provider.trim() : '';
     const modelId = typeof agentConfig.modelId === 'string' ? agentConfig.modelId.trim() : '';
     if (!modelId) return undefined;
-    return provider && !modelId.startsWith(`${provider}/`) ? `${provider}/${modelId}` : modelId;
+    return canonicalModelId(provider && !modelId.startsWith(`${provider}/`) ? `${provider}/${modelId}` : modelId);
   } catch {
     return undefined;
   }
+}
+
+function canonicalModelId(value: string): string {
+  const modelId = value.trim();
+  return rawOpenAiGpt55ModelIds.has(modelId) ? proxyOpenAiGpt55ModelId : modelId;
 }
 
 function fallbackRuntimeConfig(agentId: AcpRuntimeAgentId, apiModelId?: string): AcpRuntimeConfig {
@@ -214,7 +221,7 @@ function configuredModelEnvValues(agentId: AcpRuntimeAgentId): string[] {
 
 function unique(values: Array<string | undefined>): string[] {
   return values
-    .map((value) => value?.trim())
+    .map((value) => value === undefined ? undefined : canonicalModelId(value))
     .filter((value): value is string => Boolean(value))
     .filter((value, index, all) => all.indexOf(value) === index);
 }

--- a/mastra-agents/acp/event-mapper.ts
+++ b/mastra-agents/acp/event-mapper.ts
@@ -5,10 +5,17 @@ export type MastraChunkMapper = (chunk: unknown) => SessionUpdate[];
 type MastraChunkMapperState = {
   startedToolCallIds: Set<string>;
   inputTextByToolCallId: Map<string, string>;
+  titleByToolCallId: Map<string, string>;
+  kindByToolCallId: Map<string, ToolCall['kind']>;
 };
 
 export function createMastraChunkMapper(): MastraChunkMapper {
-  const state: MastraChunkMapperState = { startedToolCallIds: new Set(), inputTextByToolCallId: new Map() };
+  const state: MastraChunkMapperState = {
+    startedToolCallIds: new Set(),
+    inputTextByToolCallId: new Map(),
+    titleByToolCallId: new Map(),
+    kindByToolCallId: new Map(),
+  };
   return (chunk) => mapMastraChunkToUpdates(chunk, state);
 }
 
@@ -92,13 +99,16 @@ export function mapMastraChunkToUpdates(chunk: unknown, state?: MastraChunkMappe
   if (type?.startsWith('tool-')) {
     const p = isRecord(chunk.payload) ? chunk.payload : chunk;
     const toolCallId = str(p.toolCallId) ?? str(p.id) ?? 'unknown';
-    const title = str(p.toolName) ?? str(p.name) ?? 'tool';
+    const explicitTitle = str(p.toolName) ?? str(p.name);
+    const title = explicitTitle ?? state?.titleByToolCallId.get(toolCallId) ?? 'tool';
     const kind = inferToolKind(title);
     let content = type === 'tool-output'
       ? contentFromToolOutput(p.output)
       : optionalContent(p.result, p.error, p.delta, p.text, p.args);
     let rawInput = p.args ?? p.input;
     const rawOutput = p.error ?? p.result ?? p.output;
+
+    if (type === 'tool-call-input-streaming-end') return [];
 
     if (type === 'tool-call-delta') {
       const nextInputText = accumulatedInputText(state, toolCallId, str(p.argsTextDelta) ?? str(p.delta) ?? str(p.text));
@@ -120,14 +130,20 @@ export function mapMastraChunkToUpdates(chunk: unknown, state?: MastraChunkMappe
       })];
     }
 
-    const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : 'pending';
+    const status = type === 'tool-result'
+      ? 'completed'
+      : type === 'tool-error'
+        ? 'failed'
+        : type === 'tool-call' && state?.startedToolCallIds.has(toolCallId)
+          ? 'in_progress'
+          : 'pending';
 
     const update: ToolCallUpdate & { sessionUpdate: 'tool_call_update' } = {
       sessionUpdate: 'tool_call_update',
       toolCallId,
       status,
-      title,
-      kind,
+      ...(explicitTitle ? { title } : {}),
+      ...(explicitTitle ? { kind } : state?.kindByToolCallId.has(toolCallId) ? { kind: state.kindByToolCallId.get(toolCallId)! } : {}),
       rawInput,
       rawOutput,
       content,
@@ -166,7 +182,7 @@ export function mapMastraChunkToUpdates(chunk: unknown, state?: MastraChunkMappe
 }
 
 function startToolCall(state: MastraChunkMapperState | undefined, update: ToolCall & { sessionUpdate: 'tool_call' }): SessionUpdate {
-  state?.startedToolCallIds.add(update.toolCallId);
+  rememberToolCall(state, update);
   return update;
 }
 
@@ -175,10 +191,17 @@ function withStartedToolCall(
   initial: ToolCall & { sessionUpdate: 'tool_call' },
   update: ToolCallUpdate & { sessionUpdate: 'tool_call_update' },
 ): SessionUpdate[] {
-  if (!state) return [initial];
+  if (!state) return [initial, update];
   if (state.startedToolCallIds.has(initial.toolCallId)) return [update];
-  state.startedToolCallIds.add(initial.toolCallId);
+  rememberToolCall(state, initial);
   return [initial, update];
+}
+
+function rememberToolCall(state: MastraChunkMapperState | undefined, update: ToolCall & { sessionUpdate: 'tool_call' }): void {
+  if (!state) return;
+  state.startedToolCallIds.add(update.toolCallId);
+  if (update.title) state.titleByToolCallId.set(update.toolCallId, update.title);
+  if (update.kind) state.kindByToolCallId.set(update.toolCallId, update.kind);
 }
 
 function contentFromToolOutput(output: unknown): ToolCallContent[] | undefined {

--- a/mastra-agents/acp/event-mapper.ts
+++ b/mastra-agents/acp/event-mapper.ts
@@ -1,25 +1,42 @@
-import type { SessionUpdate, ToolCallContent, ToolCallUpdate } from '@agentclientprotocol/sdk';
+import type { SessionUpdate, ToolCall, ToolCallContent, ToolCallUpdate } from '@agentclientprotocol/sdk';
 
-export function inferToolKind(name?: string): ToolCallUpdate['kind'] {
+export type MastraChunkMapper = (chunk: unknown) => SessionUpdate[];
+
+type MastraChunkMapperState = {
+  startedToolCallIds: Set<string>;
+  inputTextByToolCallId: Map<string, string>;
+};
+
+export function createMastraChunkMapper(): MastraChunkMapper {
+  const state: MastraChunkMapperState = { startedToolCallIds: new Set(), inputTextByToolCallId: new Map() };
+  return (chunk) => mapMastraChunkToUpdates(chunk, state);
+}
+
+export function inferToolKind(name?: string): ToolCall['kind'] {
   if (!name) return 'other';
+  if (name.startsWith('agent-') || name.includes('delegate')) return 'think';
   if (name === 'workspace.read-file') return 'read';
   if (name === 'workspace.write-file' || name === 'workspace.replace-in-file') return 'edit';
   if (name === 'workspace.list-files') return 'search';
+  if (name.includes('grep') || name.includes('search') || name.includes('list')) return 'search';
+  if (name.includes('read')) return 'read';
+  if (name.includes('write') || name.includes('replace') || name.includes('edit')) return 'edit';
   if (name.includes('shell') || name.includes('sandbox')) return 'execute';
   return 'other';
 }
 
 
-function optionalContentText(...values: unknown[]): ToolCallContent[] | undefined {
+function optionalContent(...values: unknown[]): ToolCallContent[] | undefined {
   for (const value of values) {
-    if (typeof value === 'string' && value.trim().length > 0) {
-      return [{ type: 'content', content: { type: 'text', text: value } } as ToolCallContent];
+    const text = toolContentText(value);
+    if (text) {
+      return [{ type: 'content', content: { type: 'text', text } } as ToolCallContent];
     }
   }
   return undefined;
 }
 
-export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
+export function mapMastraChunkToUpdates(chunk: unknown, state?: MastraChunkMapperState): SessionUpdate[] {
   if (!isRecord(chunk)) return [];
   const type = str(chunk.type);
   if (type === 'text-delta') return [{ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: textFrom(chunk) } }];
@@ -39,40 +56,182 @@ export function mapMastraChunkToUpdates(chunk: unknown): SessionUpdate[] {
     ].filter(Boolean);
     const fallbackId = fallbackIdParts.length > 0 ? `delegation:${fallbackIdParts.join(':')}` : `delegation:${Date.now()}`;
     const phase = str(payload.phase) ?? 'delegation';
-    const status = phase === 'delegation_complete' ? (payload.success === false ? 'failed' : 'completed') : 'in_progress';
-
-    return [{
-      sessionUpdate: 'tool_call_update',
-      toolCallId: str(payload.delegationId) ?? fallbackId,
-      status,
-      title: str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? 'delegation',
-      kind: 'other',
+    const toolCallId = str(payload.delegationId) ?? fallbackId;
+    const title = str(payload.delegatedName) ?? str(payload.delegatedAgentId) ?? 'delegation';
+    const content = optionalContent(payload.response, payload.error, payload.prompt);
+    const base = {
+      toolCallId,
+      title,
+      kind: 'think',
       rawInput: payload.prompt,
       rawOutput: payload.response ?? payload.error,
-      content: optionalContentText(str(payload.response), str(payload.error)),
+      content,
       _meta: { mastra: chunk },
-    }];
+    } satisfies Partial<ToolCall>;
+
+    if (phase !== 'delegation_complete') {
+      return [startToolCall(state, {
+        ...base,
+        status: 'in_progress',
+        sessionUpdate: 'tool_call',
+      })];
+    }
+
+    const status = payload.success === false ? 'failed' : 'completed';
+    return withStartedToolCall(state, {
+      sessionUpdate: 'tool_call',
+      status: 'in_progress',
+      ...base,
+    }, {
+      sessionUpdate: 'tool_call_update',
+      status,
+      ...base,
+    });
   }
 
   if (type?.startsWith('tool-')) {
     const p = isRecord(chunk.payload) ? chunk.payload : chunk;
-    const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : (type === 'tool-call-input-streaming-start' ? 'in_progress' : 'pending');
+    const toolCallId = str(p.toolCallId) ?? str(p.id) ?? 'unknown';
+    const title = str(p.toolName) ?? str(p.name) ?? 'tool';
+    const kind = inferToolKind(title);
+    let content = type === 'tool-output'
+      ? contentFromToolOutput(p.output)
+      : optionalContent(p.result, p.error, p.delta, p.text, p.args);
+    let rawInput = p.args ?? p.input;
+    const rawOutput = p.error ?? p.result ?? p.output;
+
+    if (type === 'tool-call-delta') {
+      const nextInputText = accumulatedInputText(state, toolCallId, str(p.argsTextDelta) ?? str(p.delta) ?? str(p.text));
+      rawInput = rawInput ?? nextInputText;
+      content = content ?? contentFromInputText(nextInputText);
+    }
+
+    if (type === 'tool-call-input-streaming-start') {
+      return [startToolCall(state, {
+        sessionUpdate: 'tool_call',
+        toolCallId,
+        status: 'in_progress',
+        title,
+        kind,
+        rawInput,
+        rawOutput,
+        content,
+        _meta: { mastra: chunk },
+      })];
+    }
+
+    const status = type === 'tool-result' ? 'completed' : type === 'tool-error' ? 'failed' : 'pending';
 
     const update: ToolCallUpdate & { sessionUpdate: 'tool_call_update' } = {
       sessionUpdate: 'tool_call_update',
-      toolCallId: str(p.toolCallId) ?? str(p.id) ?? 'unknown',
+      toolCallId,
       status,
-      title: str(p.toolName) ?? str(p.name) ?? 'tool',
-      kind: inferToolKind(str(p.toolName) ?? str(p.name)),
-      rawInput: p.args,
-      rawOutput: p.error ?? p.result,
-      content: optionalContentText(str(p.result), str(p.error), str(p.delta), str(p.text)),
+      title,
+      kind,
+      rawInput,
+      rawOutput,
+      content,
       _meta: { mastra: chunk },
     };
+
+    if (type === 'tool-call') {
+      return withStartedToolCall(state, {
+        sessionUpdate: 'tool_call',
+        toolCallId,
+        title,
+        kind,
+        status: 'pending',
+        rawInput,
+        rawOutput,
+        content,
+        _meta: { mastra: chunk },
+      }, update);
+    }
+
+    if (type === 'tool-result' || type === 'tool-error') {
+      return withStartedToolCall(state, {
+        sessionUpdate: 'tool_call',
+        toolCallId,
+        title,
+        kind,
+        status: 'pending',
+        rawInput,
+        _meta: { mastra: chunk },
+      }, update);
+    }
 
     return [update];
   }
   return [];
+}
+
+function startToolCall(state: MastraChunkMapperState | undefined, update: ToolCall & { sessionUpdate: 'tool_call' }): SessionUpdate {
+  state?.startedToolCallIds.add(update.toolCallId);
+  return update;
+}
+
+function withStartedToolCall(
+  state: MastraChunkMapperState | undefined,
+  initial: ToolCall & { sessionUpdate: 'tool_call' },
+  update: ToolCallUpdate & { sessionUpdate: 'tool_call_update' },
+): SessionUpdate[] {
+  if (!state) return [initial];
+  if (state.startedToolCallIds.has(initial.toolCallId)) return [update];
+  state.startedToolCallIds.add(initial.toolCallId);
+  return [initial, update];
+}
+
+function contentFromToolOutput(output: unknown): ToolCallContent[] | undefined {
+  if (!isRecord(output)) return optionalContent(output);
+  const outputType = str(output.type);
+  const payload = isRecord(output.payload) ? output.payload : {};
+  if (outputType === 'text-delta') return optionalContent(payload.text);
+  if (outputType === 'tool-result') return optionalContent(payload.result);
+  if (outputType === 'tool-error' || outputType === 'error') return optionalContent(payload.error, payload.message);
+  return undefined;
+}
+
+function accumulatedInputText(
+  state: MastraChunkMapperState | undefined,
+  toolCallId: string,
+  delta: string | undefined,
+): string | undefined {
+  if (!delta) return state?.inputTextByToolCallId.get(toolCallId);
+  if (!state) return delta;
+  const text = `${state.inputTextByToolCallId.get(toolCallId) ?? ''}${delta}`;
+  state.inputTextByToolCallId.set(toolCallId, text);
+  return text;
+}
+
+function contentFromInputText(inputText: string | undefined): ToolCallContent[] | undefined {
+  if (!inputText) return undefined;
+  try {
+    const parsed = JSON.parse(inputText);
+    if (isRecord(parsed)) {
+      return optionalContent(parsed.prompt, parsed.query, parsed.input, parsed.command, parsed.path) ?? optionalContent(inputText);
+    }
+  } catch {
+    // Partial streamed JSON is still useful as progress text.
+  }
+  return optionalContent(inputText);
+}
+
+function toolContentText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value.trim().length > 0 ? value : undefined;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (!isRecord(value)) return undefined;
+
+  for (const key of ['text', 'message', 'objective', 'result', 'output', 'response', 'error', 'prompt', 'query', 'command', 'path']) {
+    const nested = toolContentText(value[key]);
+    if (nested) return nested;
+  }
+
+  try {
+    const text = JSON.stringify(value, null, 2);
+    return text.length > 12000 ? `${text.slice(0, 12000)}\n...` : text;
+  } catch {
+    return String(value);
+  }
 }
 
 const isRecord = (v: unknown): v is Record<string, any> => typeof v === 'object' && !!v;

--- a/mastra-agents/acp/memory-client.ts
+++ b/mastra-agents/acp/memory-client.ts
@@ -1,0 +1,68 @@
+type CloneThreadResponse = {
+  thread?: {
+    id?: unknown;
+    resourceId?: unknown;
+    metadata?: Record<string, unknown>;
+  };
+  clonedMessages?: unknown[];
+};
+
+export type CloneMastraThreadParams = {
+  baseUrl?: string;
+  agentId: string;
+  sourceThreadId: string;
+  newThreadId: string;
+  resourceId: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ClonedMastraThread = {
+  id: string;
+  resourceId: string;
+  metadata?: Record<string, unknown>;
+};
+
+export async function cloneMastraThread(params: CloneMastraThreadParams): Promise<ClonedMastraThread> {
+  const url = new URL(
+    `/api/memory/threads/${encodeURIComponent(params.sourceThreadId)}/clone`,
+    normalizeBaseUrl(params.baseUrl),
+  );
+  url.searchParams.set('agentId', params.agentId);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        newThreadId: params.newThreadId,
+        resourceId: params.resourceId,
+        metadata: params.metadata,
+      }),
+    });
+  } catch (error) {
+    throw new Error(`Mastra memory clone request failed for ${url}: ${errorMessage(error)}`);
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Mastra memory clone failed for ${url}: ${response.status} ${response.statusText}${body ? ` - ${body.slice(0, 500)}` : ''}`);
+  }
+
+  const result = await response.json() as CloneThreadResponse;
+  const id = typeof result.thread?.id === 'string' ? result.thread.id : undefined;
+  const resourceId = typeof result.thread?.resourceId === 'string' ? result.thread.resourceId : undefined;
+  if (!id || !resourceId) {
+    throw new Error('Mastra memory clone response did not include thread.id and thread.resourceId');
+  }
+
+  return { id, resourceId, metadata: result.thread?.metadata };
+}
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  return (baseUrl ?? 'http://localhost:4111').replace(/\/+$/, '');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/mastra-agents/acp/session-store.ts
+++ b/mastra-agents/acp/session-store.ts
@@ -31,6 +31,30 @@ export class MastraAcpSessionStore {
     return session;
   }
 
+  fork(parent: MastraAcpSession, params: {
+    sessionId?: string;
+    threadId: string;
+  }): MastraAcpSession {
+    const sessionId = params.sessionId ?? randomUUID();
+    const now = new Date().toISOString();
+    const session: MastraAcpSession = {
+      sessionId,
+      agentId: parent.agentId,
+      cwd: parent.cwd,
+      resourceId: parent.resourceId,
+      threadId: params.threadId,
+      modeId: parent.modeId,
+      modelId: parent.modelId,
+      thinkingOptionId: parent.thinkingOptionId,
+      forkedFromSessionId: parent.sessionId,
+      forkedFromThreadId: parent.threadId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.sessions.set(sessionId, session);
+    return session;
+  }
+
   get(sessionId: string): MastraAcpSession | undefined { return this.sessions.get(sessionId); }
   update(session: MastraAcpSession): void { session.updatedAt = new Date().toISOString(); this.sessions.set(session.sessionId, session); }
   delete(sessionId: string): void { this.sessions.delete(sessionId); }

--- a/mastra-agents/acp/types.ts
+++ b/mastra-agents/acp/types.ts
@@ -17,6 +17,8 @@ export interface MastraAcpSession {
   modeId?: string;
   modelId?: string;
   thinkingOptionId?: string;
+  forkedFromSessionId?: string;
+  forkedFromThreadId?: string;
   abortController?: AbortController;
   createdAt: string;
   updatedAt: string;

--- a/mastra-agents/package.json
+++ b/mastra-agents/package.json
@@ -27,6 +27,7 @@
     "@daytona/sdk": "0.169.0",
     "@mastra/core": "1.32.1",
     "@mastra/daytona": "0.3.0",
+    "@mastra/docker": "^0.1.0",
     "@mastra/duckdb": "1.2.0",
     "@mastra/editor": "0.7.19",
     "@mastra/evals": "1.2.1",

--- a/mastra-agents/src/docker-sandbox-config.ts
+++ b/mastra-agents/src/docker-sandbox-config.ts
@@ -46,7 +46,9 @@ function readEnv(name: string): string | undefined {
 export function resolveDockerBindMounts(): Record<string, string> {
   const mounts: Record<string, string> = {};
 
-  const workspaceRoot = readEnv("MASTRA_WORKSPACE_ROOT") ?? path.resolve(process.cwd(), "../..");
+  const workspaceRoot = readEnv("MASTRA_DOCKER_SANDBOX_HOST_WORKSPACE_ROOT")
+    ?? readEnv("MASTRA_WORKSPACE_ROOT")
+    ?? path.resolve(process.cwd(), "../..");
   mounts[workspaceRoot] = "/workspace";
 
   // Host /container/shared/workspace is mounted as /shared/workspace in the

--- a/mastra-agents/src/docker-sandbox-config.ts
+++ b/mastra-agents/src/docker-sandbox-config.ts
@@ -49,10 +49,11 @@ export function resolveDockerBindMounts(): Record<string, string> {
   const workspaceRoot = readEnv("MASTRA_WORKSPACE_ROOT") ?? path.resolve(process.cwd(), "../..");
   mounts[workspaceRoot] = "/workspace";
 
-  // Host /container/shared is mounted as /shared in the sandbox.
-  // The image already includes agents via brew tap + git clone — no .agents bind mount needed.
-  if (existsSync("/container/shared")) {
-    mounts["/container/shared"] = "/shared";
+  // Host /container/shared/workspace is mounted as /shared/workspace in the
+  // sandbox. The image already includes agents via brew tap + git clone — no
+  // .agents bind mount needed.
+  if (existsSync("/container/shared/workspace")) {
+    mounts["/container/shared/workspace"] = "/shared/workspace";
   }
 
   const extraMountsRaw = readEnv("MASTRA_DOCKER_SANDBOX_EXTRA_MOUNTS");

--- a/mastra-agents/src/workspace-paths.ts
+++ b/mastra-agents/src/workspace-paths.ts
@@ -25,7 +25,7 @@ export const workspaceRoot = resolveConfiguredPath(
 );
 
 export const workspaceCommandCwd = resolveConfiguredPath(
-  process.env.MASTRA_WORKSPACE_COMMAND_CWD ?? process.cwd(),
+  process.env.MASTRA_WORKSPACE_COMMAND_CWD?.trim() || workspaceRoot,
 );
 
 function splitPathList(value: string | undefined): string[] {

--- a/mastra-agents/src/workspace.test.js
+++ b/mastra-agents/src/workspace.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const packageRoot = path.resolve(import.meta.dirname, "..");
+const bundleDir = path.join(packageRoot, ".cache/workspace-test");
+const workspaceBundlePath = path.join(bundleDir, "workspace.mjs");
+const dockerConfigBundlePath = path.join(bundleDir, "docker-sandbox-config.mjs");
+const esbuildBin = path.resolve(packageRoot, "../node_modules/.bin/esbuild");
+
+function buildBundle(entry, outfile) {
+  execFileSync(esbuildBin, [
+    entry,
+    "--bundle",
+    "--platform=node",
+    "--format=esm",
+    `--outfile=${outfile}`,
+    "--external:@mastra/*",
+    "--external:@daytona/*",
+    "--external:zod",
+  ], { cwd: packageRoot, stdio: "pipe" });
+}
+
+function buildWorkspaceBundles() {
+  rmSync(bundleDir, { recursive: true, force: true });
+  mkdirSync(bundleDir, { recursive: true });
+  buildBundle("src/workspace.ts", workspaceBundlePath);
+  buildBundle("src/docker-sandbox-config.ts", dockerConfigBundlePath);
+}
+
+test("workspace docker sandbox env resolves to DockerSandbox provider", () => {
+  buildWorkspaceBundles();
+  const script = `
+    process.env.MASTRA_WORKSPACE_SANDBOX = "docker";
+    process.env.MASTRA_DOCKER_SANDBOX_HOST_WORKSPACE_ROOT = "/host/checkout";
+    process.env.MASTRA_WORKSPACE_ROOT = "/app";
+    const workspace = await import(${JSON.stringify(workspaceBundlePath)});
+    console.log(JSON.stringify({
+      workspaceSandboxProvider: workspace.workspaceSandboxProvider,
+      codingSandboxProvider: workspace.codingSandbox.provider,
+    }));
+  `;
+
+  const output = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const state = JSON.parse(output);
+
+  assert.equal(state.workspaceSandboxProvider, "docker");
+  assert.equal(state.codingSandboxProvider, "docker");
+});
+
+test("docker bind mounts prefer host workspace root for container workspace", () => {
+  buildWorkspaceBundles();
+  const script = `
+    process.env.MASTRA_DOCKER_SANDBOX_HOST_WORKSPACE_ROOT = "/host/checkout";
+    process.env.MASTRA_WORKSPACE_ROOT = "/app";
+    const config = await import(${JSON.stringify(dockerConfigBundlePath)});
+    console.log(JSON.stringify(config.resolveDockerBindMounts()));
+  `;
+
+  const output = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const mounts = JSON.parse(output);
+
+  assert.equal(mounts["/host/checkout"], "/workspace");
+  assert.equal(mounts["/app"], undefined);
+});

--- a/mastra-agents/src/workspace.ts
+++ b/mastra-agents/src/workspace.ts
@@ -9,7 +9,6 @@ import {
 } from "./daytona/sandbox-config.js";
 import {
   allowedWorkspaceRootsDescription,
-  isWorkspaceRootExposed,
   resolveConfiguredPath,
   workspaceAccessRoots,
   workspaceCommandCwd,
@@ -21,7 +20,7 @@ const defaultSnapshot =
   "daytona-agents/snapshot-coding-base:local";
 const allowedLanguages = ["typescript", "javascript", "python"] as const;
 const allowedLocalIsolation = ["none", "seatbelt", "bwrap"] as const;
-const localSandboxAliases = new Set(["local", "current", "host"]);
+const localSandboxAliases = new Set(["local", "current", "host", "docker"]);
 const daytonaSandboxAliases = new Set(["daytona", "remote"]);
 
 type DaytonaWorkspaceLanguage = (typeof allowedLanguages)[number];
@@ -139,6 +138,7 @@ function createDaytonaSandbox() {
 function createLocalFilesystem(root: string) {
   return new LocalFilesystem({
     basePath: root,
+    allowedPaths: workspaceAccessRoots.filter((accessRoot) => accessRoot !== root),
     // @mastra/core's symlink containment check treats "/" as a special case
     // poorly, so when the access root is the current sandbox root, rely on the
     // surrounding Daytona sandbox boundary rather than LocalFilesystem's
@@ -148,16 +148,11 @@ function createLocalFilesystem(root: string) {
 }
 
 function createWorkspaceFilesystemConfig() {
-  if (isWorkspaceRootExposed()) {
-    return {
-      filesystem: createLocalFilesystem(workspaceAccessRoots[0]!),
-    };
-  }
-
+  // Use a single filesystem rooted at workspaceRoot so built-in Mastra
+  // workspace tools resolve relative paths the same way our custom tools do.
+  // Extra access roots remain available through LocalFilesystem.allowedPaths.
   return {
-    mounts: Object.fromEntries(
-      workspaceAccessRoots.map((root) => [root, createLocalFilesystem(root)]),
-    ),
+    filesystem: createLocalFilesystem(workspaceRoot),
   };
 }
 

--- a/mastra-agents/src/workspace.ts
+++ b/mastra-agents/src/workspace.ts
@@ -1,12 +1,20 @@
 import { existsSync } from "node:fs";
 
 import { LocalFilesystem, LocalSandbox, Workspace, WORKSPACE_TOOLS } from "@mastra/core/workspace";
+import { DockerSandbox } from "@mastra/docker";
 
 import { DaytonaAgentsDaytonaSandbox } from "./daytona/mastra-sandbox.js";
 import {
   resolveDaytonaVolumeMounts,
   resolveSandboxRuntimeEnv,
 } from "./daytona/sandbox-config.js";
+import {
+  defaultDockerSandboxId,
+  defaultDockerSandboxImage,
+  defaultDockerSandboxNetwork,
+  resolveDockerBindMounts,
+  resolveDockerSandboxRuntimeEnv,
+} from "./docker-sandbox-config.js";
 import {
   allowedWorkspaceRootsDescription,
   resolveConfiguredPath,
@@ -20,12 +28,13 @@ const defaultSnapshot =
   "daytona-agents/snapshot-coding-base:local";
 const allowedLanguages = ["typescript", "javascript", "python"] as const;
 const allowedLocalIsolation = ["none", "seatbelt", "bwrap"] as const;
-const localSandboxAliases = new Set(["local", "current", "host", "docker"]);
+const localSandboxAliases = new Set(["local", "current", "host"]);
+const dockerSandboxAliases = new Set(["docker"]);
 const daytonaSandboxAliases = new Set(["daytona", "remote"]);
 
 type DaytonaWorkspaceLanguage = (typeof allowedLanguages)[number];
 type WorkspaceLocalIsolation = (typeof allowedLocalIsolation)[number];
-type WorkspaceSandboxProvider = "local" | "daytona";
+type WorkspaceSandboxProvider = "local" | "docker" | "daytona";
 
 function resolveBooleanEnv(value: string | undefined, fallback: boolean) {
   if (value === undefined || value === "") {
@@ -57,6 +66,10 @@ function resolveWorkspaceSandboxProvider(value: string | undefined): WorkspaceSa
 
   if (normalizedValue !== undefined && localSandboxAliases.has(normalizedValue)) {
     return "local";
+  }
+
+  if (normalizedValue !== undefined && dockerSandboxAliases.has(normalizedValue)) {
+    return "docker";
   }
 
   if (normalizedValue !== undefined && daytonaSandboxAliases.has(normalizedValue)) {
@@ -102,6 +115,18 @@ function createLocalSandbox() {
     },
     instructions: ({ defaultInstructions }) =>
       `${defaultInstructions} This is the current sandbox environment. Shell commands and file tools are scoped to the configured workspace roots when local native isolation is available: ${allowedWorkspaceRootsDescription()}.`,
+  });
+}
+
+function createDockerSandbox() {
+  return new DockerSandbox({
+    id: process.env.MASTRA_DOCKER_SANDBOX_ID ?? defaultDockerSandboxId,
+    image: process.env.MASTRA_DOCKER_SANDBOX_IMAGE ?? defaultDockerSandboxImage,
+    volumes: resolveDockerBindMounts(),
+    network: process.env.MASTRA_DOCKER_SANDBOX_NETWORK ?? defaultDockerSandboxNetwork,
+    workingDir: process.env.MASTRA_DOCKER_SANDBOX_WORKING_DIR ?? "/workspace",
+    env: resolveDockerSandboxRuntimeEnv(),
+    timeout: resolveNumberEnv(process.env.MASTRA_WORKSPACE_COMMAND_TIMEOUT_MS) ?? 300_000,
   });
 }
 
@@ -166,7 +191,9 @@ export const workspaceSandboxProvider = resolveWorkspaceSandboxProvider(
 
 export const codingSandbox = workspaceSandboxProvider === "local"
   ? createLocalSandbox()
-  : createDaytonaSandbox();
+  : workspaceSandboxProvider === "docker"
+    ? createDockerSandbox()
+    : createDaytonaSandbox();
 
 export const workspace = new Workspace({
   id: "daytona-agents",
@@ -192,7 +219,7 @@ export const workspace = new Workspace({
       return undefined;
     }
 
-    if (sandbox?.provider === "local") {
+    if (sandbox?.provider === "local" || sandbox?.provider === "docker") {
       return { success: true, mountPath };
     }
 

--- a/mastra-agents/test/acp/adapter.test.js
+++ b/mastra-agents/test/acp/adapter.test.js
@@ -321,7 +321,7 @@ test("ACP runtime config prefers explicit env model over API metadata fallback",
 
   assert.equal(config.defaultModelId, "proxy/openai/gpt-5.5");
   assert.equal(config.models[0], "proxy/openai/gpt-5.5");
-  assert.ok(config.models.includes("openai/gpt-5.5"));
+  assert.equal(config.models.includes("openai/gpt-5.5"), false);
 });
 
 test("ACP prompt surfaces Mastra stream error chunks", async (t) => {

--- a/mastra-agents/test/acp/adapter.test.js
+++ b/mastra-agents/test/acp/adapter.test.js
@@ -16,6 +16,76 @@ function optionValue(configOptions, id) {
   return configOptions.find((option) => option.id === id)?.currentValue;
 }
 
+function sseOk() {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"type":"text-delta","text":"ok"}\n\ndata: [DONE]\n\n'));
+        controller.close();
+      },
+    }),
+    { status: 200, statusText: "OK" },
+  );
+}
+
+function jsonOk(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function installForkFetchMock(t, { cloneThreadId, cloneResourceId = "resource-1", failClone = false } = {}) {
+  const requests = [];
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (url, init = {}) => {
+    const href = String(url);
+    requests.push({ url: href, init });
+
+    if (href.includes("/api/agents/")) {
+      return jsonOk({ provider: "provider", modelId: "model" });
+    }
+
+    if (href.includes("/api/memory/threads/") && href.includes("/clone")) {
+      if (failClone) return new Response("clone unavailable", { status: 503, statusText: "Unavailable" });
+      const body = JSON.parse(init.body);
+      return jsonOk({
+        thread: {
+          id: cloneThreadId ?? body.newThreadId,
+          resourceId: cloneResourceId,
+          metadata: body.metadata,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        clonedMessages: [],
+      });
+    }
+
+    if (href.includes("/api/agents/") && href.includes("/stream")) {
+      return sseOk();
+    }
+
+    return sseOk();
+  };
+  return requests;
+}
+
+test("ACP initialize advertises fork session capability", async () => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+  });
+
+  const result = await agent.initialize({ protocolVersion: 1 });
+
+  assert.deepEqual(result.agentCapabilities.sessionCapabilities, { fork: {} });
+});
+
 test("ACP session config exposes complete canonical mode and model defaults", async () => {
   const conn = new FakeConnection();
   const agent = createMastraAcpAgentHandler(conn, {
@@ -29,6 +99,143 @@ test("ACP session config exposes complete canonical mode and model defaults", as
   assert.equal(optionValue(session.configOptions, "mode"), "base");
   assert.equal(optionValue(session.configOptions, "model"), session.models.currentModelId);
   assert.deepEqual(session.configOptions.map((option) => option.id), ["mode", "model", "thinking"]);
+});
+
+test("ACP fork clones parent memory thread and child prompt uses cloned thread", async (t) => {
+  const requests = installForkFetchMock(t);
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+    defaultResourceId: "resource-1",
+    defaultThreadId: "parent-thread",
+  });
+  const parent = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+  await agent.setSessionConfigOption({ sessionId: parent.sessionId, configId: "mode", value: "exec" });
+  await agent.setSessionConfigOption({ sessionId: parent.sessionId, configId: "thinking", value: "high" });
+
+  const child = await agent.unstable_forkSession({
+    sessionId: parent.sessionId,
+    cwd: "/workspace",
+    mcpServers: [],
+  });
+
+  assert.notEqual(child.sessionId, parent.sessionId);
+  assert.equal(optionValue(child.configOptions, "mode"), "exec");
+  assert.equal(optionValue(child.configOptions, "thinking"), "high");
+
+  const cloneRequest = requests.find((request) => request.url.includes("/api/memory/threads/parent-thread/clone"));
+  assert.ok(cloneRequest);
+  assert.equal(cloneRequest.url, "http://mastra.test/api/memory/threads/parent-thread/clone?agentId=supervisor-agent");
+
+  const cloneBody = JSON.parse(cloneRequest.init.body);
+  assert.equal(cloneBody.resourceId, "resource-1");
+  assert.match(cloneBody.newThreadId, /^acp:.+:supervisor-agent$/);
+  assert.equal(cloneBody.metadata.acp.fork.parentSessionId, parent.sessionId);
+  assert.equal(cloneBody.metadata.acp.fork.childSessionId, child.sessionId);
+  assert.equal(cloneBody.metadata.acp.fork.parentThreadId, "parent-thread");
+  assert.equal(cloneBody.metadata.acp.fork.agentId, "supervisor-agent");
+
+  let childPromptRequest;
+  let parentPromptRequest;
+  globalThis.fetch = async (url, init = {}) => {
+    const href = String(url);
+    if (href.includes("/api/agents/") && href.includes("/stream")) {
+      const body = JSON.parse(init.body);
+      if (body.requestContext.acp.sessionId === child.sessionId) childPromptRequest = body;
+      if (body.requestContext.acp.sessionId === parent.sessionId) parentPromptRequest = body;
+      return sseOk();
+    }
+    return jsonOk({ provider: "provider", modelId: "model" });
+  };
+
+  await agent.prompt({ sessionId: child.sessionId, prompt: [{ type: "text", text: "child" }] });
+  await agent.prompt({ sessionId: parent.sessionId, prompt: [{ type: "text", text: "parent" }] });
+
+  assert.equal(childPromptRequest.memory.thread, cloneBody.newThreadId);
+  assert.equal(childPromptRequest.memory.resource, "resource-1");
+  assert.equal(parentPromptRequest.memory.thread, "parent-thread");
+  assert.equal(parentPromptRequest.memory.resource, "resource-1");
+});
+
+test("ACP fork rejects unknown parent session", async () => {
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+  });
+
+  await assert.rejects(
+    agent.unstable_forkSession({ sessionId: "missing", cwd: "/workspace", mcpServers: [] }),
+    /Unknown session: missing/,
+  );
+});
+
+test("ACP fork rejects cwd mismatch before cloning", async (t) => {
+  const requests = installForkFetchMock(t);
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const parent = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  await assert.rejects(
+    agent.unstable_forkSession({ sessionId: parent.sessionId, cwd: "/other", mcpServers: [] }),
+    /cwd mismatch/,
+  );
+  assert.equal(requests.some((request) => request.url.includes("/clone")), false);
+});
+
+test("ACP fork rejects clone response thread mismatch", async (t) => {
+  installForkFetchMock(t, { cloneThreadId: "wrong-thread" });
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const parent = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  await assert.rejects(
+    agent.unstable_forkSession({ sessionId: parent.sessionId, cwd: "/workspace", mcpServers: [] }),
+    /unexpected thread id: wrong-thread/,
+  );
+});
+
+test("ACP fork rejects clone response resource mismatch", async (t) => {
+  installForkFetchMock(t, { cloneResourceId: "wrong-resource" });
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+    defaultResourceId: "resource-1",
+  });
+  const parent = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  await assert.rejects(
+    agent.unstable_forkSession({ sessionId: parent.sessionId, cwd: "/workspace", mcpServers: [] }),
+    /unexpected resource id: wrong-resource/,
+  );
+});
+
+test("ACP fork surfaces clone endpoint failures", async (t) => {
+  installForkFetchMock(t, { failClone: true });
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/workspace",
+    mastraBaseUrl: "http://mastra.test",
+  });
+  const parent = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  await assert.rejects(
+    agent.unstable_forkSession({ sessionId: parent.sessionId, cwd: "/workspace", mcpServers: [] }),
+    /Mastra memory clone failed.*503 Unavailable/,
+  );
 });
 
 test("ACP mode config mutation returns full state and keeps legacy mode surface in sync", async () => {

--- a/mastra-agents/test/acp/adapter.test.js
+++ b/mastra-agents/test/acp/adapter.test.js
@@ -159,6 +159,28 @@ test("ACP fork clones parent memory thread and child prompt uses cloned thread",
   assert.equal(parentPromptRequest.memory.resource, "resource-1");
 });
 
+test("ACP fork validates against new session cwd instead of adapter default", async (t) => {
+  const requests = installForkFetchMock(t);
+  const conn = new FakeConnection();
+  const agent = createMastraAcpAgentHandler(conn, {
+    agentId: "supervisor-agent",
+    cwd: "/app",
+    mastraBaseUrl: "http://mastra.test",
+    defaultResourceId: "resource-1",
+    defaultThreadId: "parent-thread",
+  });
+  const parent = await agent.newSession({ cwd: "/workspace", mcpServers: [] });
+
+  const child = await agent.unstable_forkSession({
+    sessionId: parent.sessionId,
+    cwd: "/workspace",
+    mcpServers: [],
+  });
+
+  assert.notEqual(child.sessionId, parent.sessionId);
+  assert.equal(requests.some((request) => request.url.includes("/api/memory/threads/parent-thread/clone")), true);
+});
+
 test("ACP fork rejects unknown parent session", async () => {
   const conn = new FakeConnection();
   const agent = createMastraAcpAgentHandler(conn, {

--- a/mastra-agents/test/acp/delegation-observability.spec.js
+++ b/mastra-agents/test/acp/delegation-observability.spec.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { mapMastraChunkToUpdates } from '../../../compiled/mastra-agents/acp/event-mapper.js';
+import { createMastraChunkMapper, mapMastraChunkToUpdates } from '../../../compiled/mastra-agents/acp/event-mapper.js';
 import { createDelegationObservabilityOptions } from '../../src/agents/delegation-observability.js';
 import { delegationPayloadFromEvent, subscribeDelegationEvents } from '../../src/workflows/delegation-event.js';
 
@@ -26,6 +26,62 @@ test('delegation event mapper fallback IDs remain unique', () => {
   const one = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: 1 } })[0];
   const two = mapMastraChunkToUpdates({ type: 'delegation-event', payload: { delegatedName: 'scout-agent', phase: 'delegation_start', timestamp: 2 } })[0];
   assert.notEqual(one.toolCallId, two.toolCallId);
+});
+
+test('ACP mapper emits initial tool_call before tool updates for agent calls', () => {
+  const mapChunk = createMastraChunkMapper();
+  const start = mapChunk({
+    type: 'tool-call-input-streaming-start',
+    payload: { toolCallId: 'call-agent-1', toolName: 'agent-scoutAgent' },
+  });
+  const call = mapChunk({
+    type: 'tool-call',
+    payload: { toolCallId: 'call-agent-1', toolName: 'agent-scoutAgent', args: { prompt: 'Inspect the ACP mapper' } },
+  });
+  const result = mapChunk({
+    type: 'tool-result',
+    payload: { toolCallId: 'call-agent-1', toolName: 'agent-scoutAgent', result: { text: 'mapMastraChunkToUpdates' } },
+  });
+
+  assert.equal(start[0].sessionUpdate, 'tool_call');
+  assert.equal(start[0].kind, 'think');
+  assert.equal(call[0].sessionUpdate, 'tool_call_update');
+  assert.deepEqual(call[0].rawInput, { prompt: 'Inspect the ACP mapper' });
+  assert.equal(call[0].content[0].content.text, 'Inspect the ACP mapper');
+  assert.equal(result[0].sessionUpdate, 'tool_call_update');
+  assert.equal(result[0].status, 'completed');
+  assert.equal(result[0].content[0].content.text, 'mapMastraChunkToUpdates');
+});
+
+test('ACP delegation events create a visible tool call and complete it with output', () => {
+  const mapChunk = createMastraChunkMapper();
+  const start = mapChunk({
+    type: 'delegation-event',
+    payload: {
+      phase: 'delegation_start',
+      delegationId: 'delegation-1',
+      delegatedName: 'Scout',
+      prompt: { objective: 'inspect' },
+    },
+  });
+  const complete = mapChunk({
+    type: 'delegation-event',
+    payload: {
+      phase: 'delegation_complete',
+      delegationId: 'delegation-1',
+      delegatedName: 'Scout',
+      response: { text: 'found evidence' },
+      success: true,
+    },
+  });
+
+  assert.equal(start[0].sessionUpdate, 'tool_call');
+  assert.equal(start[0].toolCallId, 'delegation-1');
+  assert.equal(start[0].kind, 'think');
+  assert.equal(start[0].content[0].content.text, 'inspect');
+  assert.equal(complete[0].sessionUpdate, 'tool_call_update');
+  assert.equal(complete[0].status, 'completed');
+  assert.equal(complete[0].content[0].content.text, 'found evidence');
 });
 
 test('orchestration delegation hooks emit ACP-visible start and complete payloads', () => {

--- a/mastra-agents/test/acp/delegation-observability.spec.js
+++ b/mastra-agents/test/acp/delegation-observability.spec.js
@@ -40,17 +40,53 @@ test('ACP mapper emits initial tool_call before tool updates for agent calls', (
   });
   const result = mapChunk({
     type: 'tool-result',
-    payload: { toolCallId: 'call-agent-1', toolName: 'agent-scoutAgent', result: { text: 'mapMastraChunkToUpdates' } },
+    payload: { toolCallId: 'call-agent-1', result: { text: 'mapMastraChunkToUpdates' } },
   });
 
   assert.equal(start[0].sessionUpdate, 'tool_call');
   assert.equal(start[0].kind, 'think');
   assert.equal(call[0].sessionUpdate, 'tool_call_update');
+  assert.equal(call[0].status, 'in_progress');
   assert.deepEqual(call[0].rawInput, { prompt: 'Inspect the ACP mapper' });
   assert.equal(call[0].content[0].content.text, 'Inspect the ACP mapper');
   assert.equal(result[0].sessionUpdate, 'tool_call_update');
   assert.equal(result[0].status, 'completed');
+  assert.equal('title' in result[0], false);
   assert.equal(result[0].content[0].content.text, 'mapMastraChunkToUpdates');
+});
+
+test('ACP mapper ignores tool input streaming end without moving status backwards', () => {
+  const mapChunk = createMastraChunkMapper();
+  mapChunk({
+    type: 'tool-call-input-streaming-start',
+    payload: { toolCallId: 'call-1', toolName: 'git_snapshot_query' },
+  });
+
+  const end = mapChunk({
+    type: 'tool-call-input-streaming-end',
+    payload: { toolCallId: 'call-1' },
+  });
+  const call = mapChunk({
+    type: 'tool-call',
+    payload: { toolCallId: 'call-1', toolName: 'git_snapshot_query', args: { query: 'changed files' } },
+  });
+
+  assert.deepEqual(end, []);
+  assert.equal(call[0].sessionUpdate, 'tool_call_update');
+  assert.equal(call[0].status, 'in_progress');
+  assert.equal(call[0].title, 'git_snapshot_query');
+});
+
+test('stateless ACP mapper emits both initial and terminal tool updates', () => {
+  const result = mapMastraChunkToUpdates({
+    type: 'tool-result',
+    payload: { toolCallId: 'call-stateless', result: { text: 'done' } },
+  });
+
+  assert.equal(result.length, 2);
+  assert.equal(result[0].sessionUpdate, 'tool_call');
+  assert.equal(result[1].sessionUpdate, 'tool_call_update');
+  assert.equal(result[1].status, 'completed');
 });
 
 test('ACP delegation events create a visible tool call and complete it with output', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@daytona/sdk": "0.169.0",
         "@mastra/core": "1.32.1",
         "@mastra/daytona": "0.3.0",
+        "@mastra/docker": "^0.1.0",
         "@mastra/duckdb": "1.2.0",
         "@mastra/editor": "0.7.19",
         "@mastra/evals": "1.2.1",
@@ -39,7 +40,7 @@
         "zod": "3.25.76"
       },
       "bin": {
-        "mastra-agents-acp": "src/acp/stdio.js"
+        "mastra-agents-acp": "compiled/mastra-agents/acp/stdio.js"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -2730,6 +2731,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@browserbasehq/sdk": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.10.0.tgz",
@@ -4617,6 +4624,21 @@
       "peerDependencies": {
         "@mastra/core": ">=1.0.0-0 <2.0.0-0",
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/docker": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mastra/docker/-/docker-0.1.0.tgz",
+      "integrity": "sha512-FTCh1Lv4S3BXEyb+wqJLD8lij49mq/a4Y7qVTn/oZKq6FUJ0TBjbx9iGuuFzmlxeiXMEGxm7HF1aibJOXVdnaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dockerode": "^4.0.9"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@mastra/core": ">=1.12.0-0 <2.0.0-0"
       }
     },
     "node_modules/@mastra/duckdb": {
@@ -8611,6 +8633,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -8842,6 +8873,21 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -8855,6 +8901,31 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bluebird": {
@@ -9018,6 +9089,15 @@
       },
       "engines": {
         "node": ">=6.14.2"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bun-types": {
@@ -10023,6 +10103,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -10323,6 +10417,133 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
       "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
+      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dockerode/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dockerode/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -11651,6 +11872,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -14281,6 +14508,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -14334,6 +14567,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -16755,6 +16995,12 @@
       ],
       "license": "Apache-2.0"
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -16769,6 +17015,23 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "zod": "3.25.76"
       },
       "bin": {
-        "mastra-agents-acp": "compiled/mastra-agents/acp/stdio.js"
+        "mastra-agents-acp": "../compiled/mastra-agents/acp/stdio.js"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",


### PR DESCRIPTION
## Summary
- advertise ACP session fork capability and implement unstable_forkSession by cloning Mastra memory threads
- add ACP tool/delegation lifecycle mapping so clients see initial tool_call events before updates
- align delegated agent workspace root handling with the configured workspace root
- cover fork/session/tool mapping behavior with ACP tests

## Notes
- Created from the committed branch state against main.
- Local uncommitted workspace edits are not included in this PR.

## Test plan
- npm test --workspace mastra-agents *(currently fails in existing channel stream formatting expectations; ACP fork tests pass)*