### PR TITLE
refactor: isolate host runtime boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,16 @@ applies_to: ["**/*"]
 - Let every Cortex, Flux, and Zen top-level mode invoke the native AgentController `subagent` tool with Cortex, Flux, or Zen as the selected leaf role. Delegated runs must not receive the `subagent` tool, so recursion remains bounded. Keep Factory worker delegation as a separate runtime concern.
 - Prefer supported Mastra agents, tools, workspaces, browser, background-task, approval, AgentController mount, and `MastraTUI` extension APIs before adding toolkit-owned infrastructure or patching upstream source. Treat `createMastraCode` as a compatibility alias, not a new composition boundary.
 
+## Dependency and trust layers
+
+- Keep canonical role and model policy independent of MCode, Factory, GitHub, storage domains, API clients, credentials, project bindings, and scheduler state.
+- Let agent configuration receive request-scoped tool capabilities, never raw SDK clients, tokens, database handles, or control-plane commands.
+- Put host-neutral agent tool schemas and policy in `packages/agent-tools`; inject authenticated API ports from the consuming host or integration after project, session, repository, workspace, and approval checks succeed.
+- Never expose Factory scheduling, leases, status projection, or governed work-item commands as general agent tools. Project fields, issue bodies, webhook payloads, and API results are untrusted data, not authority.
+- Keep Factory composition in `packages/factory-integration`. It may consume a future `factory-github-projects` control-plane package; that package must not import agents, agent tools, sandboxes, MCode, or project mounting.
+- Keep exactly one GitHub integration responsible for credentials, installation state, token acquisition, signature verification, and webhook ingress. Downstream integrations may consume normalized, already-verified events only.
+- Applications import their host package facade only. Packages expose root exports only; do not add wildcard implementation subpaths.
+
 ## Configuration and secrets
 
 - Keep checked-in model configuration declarative and secret-free. Store environment-variable names such as `CLI_PROXY_API_KEY`, never resolved credential values.
@@ -61,6 +71,7 @@ applies_to: ["**/*"]
 - For configuration changes, also run `npm run secrets:check` when Infisical access is available; report an unavailable external credential gate rather than weakening it.
 - For fork changes, run the fork's nearest documented checks plus the toolkit consumer contract that exercises the changed surface.
 - Confirm `git diff --check` and inspect the final diff for credentials, generated state, copied prompts, and unrelated edits.
+- For MCode runtime changes, validate the real TUI through a PTY and a CUA/computer-use pass when available. For Factory UI/runtime changes, validate the real server with browser automation and an independent CUA pass. Treat an unavailable CUA or credential gate as blocked validation, never as a pass.
 
 ## Handoff
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,7 +15,7 @@ The repository initially had an instruction file without the matching narrative 
 
 ## Present
 
-The repository is an npm workspace with thin `mcode`, Studio, and Factory applications. Canonical roles, tools, model configuration, sandbox behavior, project mounting, Code adaptation, and Factory adaptation have explicit package owners. `mcode` mounts the published Mastra Code controller and TUI in-process, while `project-mounting-manager` hot-loads project specialists, workflows, and MCP as validated generations. Package-local checkpoint pairs record the purpose and rules of every ownership boundary. No upstream fork is currently required.
+The repository is an npm workspace with thin `mcode`, Studio, and Factory applications. Canonical roles, tools, model configuration, sandbox behavior, project mounting, Code adaptation, and Factory adaptation have explicit package owners. Factory consumes canonical agents directly rather than importing the MCode host. `mcode` mounts the published Mastra Code controller and TUI in-process, while `project-mounting-manager` hot-loads project specialists, workflows, and MCP as validated generations. Package-local checkpoint pairs record the purpose and rules of every ownership boundary. No upstream fork is currently required.
 
 Mastra Code itself is developed inside the upstream `mastra-ai/mastra` monorepo. The existing private `rlabs88/mastra-code` repository is a public-API wrapper around the published `mastracode` package, not a fork of the upstream source. This distinction shapes the target layout: wrappers belong with applications, while framework and TUI source deltas belong in one pinned Mastra monorepo fork.
 
@@ -26,5 +26,7 @@ The accepted [executive direction](docs/executive-direction.md) treats Mastra as
 The product monorepo continues toward one project runtime per checkout, then a single-project Factory deployment, and finally an isolated multi-project control plane. Mastra Code conventions remain authoritative for instructions, skills, hooks, commands, and plugins; the project mounting manager adds only the currently missing specialist, workflow, and transactional MCP generation contract. A typed, secret-free YAML model profile remains the input to every host adapter.
 
 Sandbox builds become a separate top-level boundary with reusable package layers and explicit ephemeral and persistent environment compositions. Persistent environments gain stronger operational controls and runtime secret delivery without turning images or repository configuration into credential stores.
+
+GitHub Projects V2 becomes an optional Factory control-plane integration only when issue #127 activates a real binding, lease, reconciliation, and scheduling lifecycle. It schedules governed Factory work but never owns agents, sessions, workspaces, sandboxes, GitHub credentials, or webhook verification. Agent-facing API capabilities remain request-scoped tools backed by injected ports; control-plane APIs do not become agent tools.
 
 Upstream source remains exceptional. One Mastra monorepo fork covers both framework and Mastra Code TUI changes. A separate desktop `mastra-code-ui` fork remains an option only if desktop interface work begins. Published packages and public extension APIs remain the ordinary integration path.

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@mastra/core": "1.57.0",
     "@rlabs/factory-integration": "*",
-    "@rlabs/mcode": "*",
     "@rlabs/runtime-config": "*",
     "@rlabs/sandbox": "*"
   }

--- a/apps/factory/src/index.ts
+++ b/apps/factory/src/index.ts
@@ -1,6 +1,6 @@
 import { Mastra } from "@mastra/core/mastra";
 import {
-  createFactoryMcodeRecipe,
+  createFactoryAgentBundle,
   createToolkitFactory,
   loadFactoryConfig,
 } from "@rlabs/factory-integration";
@@ -9,11 +9,11 @@ import { loadModelProfile, ProxyGateway, resolveRuntimeDefaultsV1 } from "@rlabs
 const profile = loadModelProfile();
 const runtimeDefaults = resolveRuntimeDefaultsV1(profile);
 export const config = loadFactoryConfig(process.env, process.cwd(), profile);
-const recipe = createFactoryMcodeRecipe({
+const agents = createFactoryAgentBundle({
   profile,
   browser: false,
 });
-export const factory = await createToolkitFactory(config, recipe, runtimeDefaults);
+export const factory = await createToolkitFactory(config, agents, runtimeDefaults);
 const prepared = await factory.prepare();
 export const mastra = new Mastra({
   ...prepared,
@@ -34,10 +34,29 @@ export const mastra = new Mastra({
 
 await factory.finalize();
 
-const stopFactory = () => {
-  void factory.shutdown().catch(error => {
+let shutdown: Promise<void> | undefined;
+export const stopFactory = async () => {
+  shutdown ??= (async () => {
+    const failures: unknown[] = [];
+    try {
+      await factory.shutdown();
+    } catch (error) {
+      failures.push(error);
+    }
+    try {
+      await mastra.shutdown();
+    } catch (error) {
+      failures.push(error);
+    }
+    if (failures.length > 0) throw new AggregateError(failures, "Factory shutdown failed");
+  })();
+  await shutdown;
+};
+const handleStopSignal = () => {
+  void stopFactory().catch(error => {
     console.error("Factory shutdown failed", error);
+    process.exitCode = 1;
   });
 };
-process.once("SIGINT", stopFactory);
-process.once("SIGTERM", stopFactory);
+process.once("SIGINT", handleStopSignal);
+process.once("SIGTERM", handleStopSignal);

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -1,8 +1,9 @@
 import { Mastra } from "@mastra/core/mastra";
 import { prepareMcodeRuntime } from "@rlabs/mcode";
 
-export const localProject = await prepareMcodeRuntime({ cwd: process.cwd() });
+export const localProject = await prepareMcodeRuntime({ cwd: process.cwd(), host: "studio" });
 export const agents = localProject.agents;
 export const mastra = new Mastra(localProject.mastraArgs);
 
-await localProject.finalize(mastra);
+export const runtime = await localProject.finalize(mastra);
+export const shutdown = () => runtime.close();

--- a/docs/host-validation.md
+++ b/docs/host-validation.md
@@ -1,0 +1,23 @@
+# Host validation
+
+Host-affecting changes require executable evidence from the real MCode, Studio, and Factory compositions. Unit tests remain necessary but do not prove that the TUI, browser UI, storage, background workers, and shutdown lifecycle compose correctly.
+
+## Preconditions
+
+Run typecheck, focused tests, and build first. Confirm `agent-browser` and its Chrome engine are installed, a CUA/computer-use capability is available, and Infisical access works without printing resolved values. Use temporary host-data directories rather than a developer's live databases. An unavailable CUA or credential gate is reported as blocked validation, not as a pass.
+
+## MCode
+
+Run `npm run code:infisical` in a private interactive tmux session. Wait up to 120 seconds for the TUI, capture the initial pane and a CUA screenshot, submit a deterministic request for `MCODE_E2E_OK`, and require the response within 180 seconds. Run one read-only `command_run` operation and verify its workspace is the isolated checkout. Exercise one rendered mode or agent switch, exit normally, require exit within 30 seconds, verify the MCode database, and confirm no owned child process remains. When CUA is unavailable, repeat with literal tmux keystrokes and record the CUA gate as blocked.
+
+## Factory
+
+Run `npm run dev:factory:infisical` as a named persistent tmux job and discover its URL from logs. Open the URL in a dedicated headed `agent-browser` session, capture an accessibility snapshot and screenshot, and verify there are no fatal page or console errors. Create or open an isolated Factory project/session, request `FACTORY_E2E_OK`, verify exactly one response and the expected project/repository binding, refresh to prove persistence, then repeat the critical path with visual CUA mouse/keyboard interaction. Send `SIGTERM`, require shutdown within 30 seconds, verify the port closes, and confirm no Factory worker remains.
+
+## Studio
+
+When MCode/Studio composition changes, run `npm run dev:infisical`, discover the URL, and use an isolated browser session to select a canonical agent, create a session, request `STUDIO_E2E_OK`, reload to prove Studio-specific persistence, and inspect console/network errors. Repeat the critical visual path with CUA when presentation changed, then verify graceful shutdown.
+
+## Evidence
+
+Store pane/server logs, accessibility snapshots, console and network reports, screenshots, exit codes, and storage-path listings in a temporary directory outside tracked source. Scrub credentials before handoff. A host passes only when it reaches ready state, completes the deterministic request in the authorized workspace, persists to the expected host store, shuts down within 30 seconds, and leaves no owned listener, worker, browser, or child process.

--- a/docs/mcode-factory-compatibility.md
+++ b/docs/mcode-factory-compatibility.md
@@ -1,78 +1,57 @@
-# MCode recipe and Factory compatibility
+# MCode and Factory compatibility
 
-`@rlabs/mcode` owns one versioned `McodeRecipeV1`. Both executable hosts construct that recipe once from the startup-resolved model profile and the sandbox-owned `command_run` tool. The recipe contains the canonical Cortex, Flux, and Zen agents, the six scope/build modes, the three native leaf subagents, the model settings input, and a deterministic secret-free capability descriptor.
-
-The capability descriptor is safe to persist or report. Runtime credentials, host settings, repository contents, controller state, and sandbox leases are deliberately absent. A changed descriptor digest is a CI/CD compatibility signal; it is not a runtime source scanner or a mutable registry.
+MCode and Factory are sibling hosts over the same canonical runtime. Neither host adapter imports the other.
 
 ```mermaid
 flowchart TB
-  Profile["runtime-config model profile<br/>environment-variable names only"]
-  Tool["sandbox command_run<br/>request workspace required"]
-  Recipe["@rlabs/mcode<br/>McodeRecipeV1"]
+  Config["runtime-config<br/>models, defaults, host paths"]
+  Tools["agent-tools<br/>host-neutral contracts"]
+  Roles["agents-roles<br/>Cortex / Flux / Zen"]
+  Sandbox["sandbox<br/>workspace-bound execution"]
+  MCode["mcode adapter"]
+  Factory["factory-integration"]
+  Projects["factory-github-projects<br/>future issue #127"]
 
-  Profile --> Recipe
-  Tool --> Recipe
-  Recipe --> Agents["Cortex / Flux / Zen"]
-  Recipe --> Modes["scope + build modes"]
-  Recipe --> Leaves["native leaf subagents"]
-  Recipe --> Descriptor["secret-free capability digest"]
-
-  subgraph Local["Local MCode process"]
-    Checkout["detected clone or Git worktree"]
-    LocalSandbox["Local sandbox bound to checkout root"]
-    LocalController["one AgentController"]
-    PMM["Project Mounting Manager generation"]
-    Checkout --> LocalSandbox
-    LocalSandbox --> LocalController
-    Checkout --> PMM
-    PMM --> LocalController
-  end
-
-  subgraph Factory["Factory control plane"]
-    FactoryController["one Factory-owned AgentController"]
-    Binding["project + user + session binding"]
-    Fleet["configured sandbox template / fleet"]
-    Clone["persisted clone workspace"]
-    Binding --> Fleet
-    Fleet --> Clone
-    Clone --> FactoryController
-  end
-
-  Recipe --> LocalController
-  Recipe -. "blocked: official construction seam" .-> FactoryController
-  Descriptor --> FactoryDiagnostics["Factory compatibility diagnostics"]
+  Config --> Roles
+  Tools --> Roles
+  Roles --> MCode
+  Roles --> Factory
+  Config --> MCode
+  Config --> Factory
+  Sandbox --> MCode
+  Sandbox --> Factory
+  Projects -. "optional control-plane input" .-> Factory
 ```
 
-The final `Recipe --> FactoryController` edge is a compatibility boundary today. Factory consumes the recipe for canonical delegated agents, provider settings, sandbox tools, and diagnostics, but installed and reviewed upstream `@mastra/factory` releases do not expose a supported input for modes or native subagents before constructing their controller. Diagnostics therefore report `controllerConstruction: unsupported-upstream`; the toolkit does not patch Factory, construct a second controller, or silently claim parity. Issue #125's local acceptance is the narrower, behaviorally verified delegates-plus-sandbox contract. Native Factory mode/subagent construction remains part of issue #119 until an official upstream release provides the seam.
+## Shared and host-owned surfaces
 
-## Execution and configuration boundaries
+| Surface | Canonical owner | MCode | Factory |
+| --- | --- | --- | --- |
+| Agent IDs, prompts, and factories | `agents-roles` | consumes | consumes through `createFactoryAgentBundle` |
+| Model profile and runtime defaults | `runtime-config` | resolves once at startup | resolves once at startup |
+| Executable `command_run` | `sandbox` | checkout-bound | session-workspace-bound |
+| Modes and native Code subagents | `mcode` | mounts | unsupported; not emulated |
+| Project specialists and workflows | `project-mounting-manager` | mounts validated generations | only explicit Factory workflow integration |
+| Authentication and persistence | host | local process | `factory-integration` |
 
-| Surface | Local MCode | Factory GitHub session |
-|---|---|---|
-| `command_run` | Resolves the checkout workspace and executes through its sandbox | Resolves the bound session workspace and executes through that sandbox |
-| Canonical agents | Recipe-owned | Recipe-owned delegated agents |
-| Scope/build modes and native leaf subagents | Mounted from the recipe | Declared by the recipe; controller mounting is blocked by upstream |
-| Repository skills | Checkout-scoped | Native upstream lookup is expected in the bound clone, but toolkit parity remains unverified |
-| Published workflows | Project Mounting Manager | `project_workflow` executes inside the bound clone sandbox |
-| Instructions, hooks, commands, plugins, MCP, specialists | Checkout-scoped through Code/Project Mounting Manager | Explicitly unsupported until request-aware sandbox adapters exist |
-| Credentials | Resolved by the local process at runtime | Owned by Factory or delivered task-scoped to the selected sandbox |
+`createFactoryAgentBundle` is deliberately branded. Factory cannot accept an arbitrary object shaped like a role bundle, and canonical role code cannot acquire Factory clients, storage handles, project schedulers, or credentials. Agent-facing API capabilities must be narrow Mastra tools backed by request-scoped ports injected by the host.
 
-`command_run` has no process-working-directory fallback. Its parser, scheduling, approval, trace, and output contracts remain in `@rlabs/agent-tools`; the executable Mastra tool is exported only by `@rlabs/sandbox`. Top-level agents, native leaf subagents, delegated/ADHD children, and Project Mounting Manager specialists receive that same tool contract. Delegated request contexts retain the bound workspace, so children cannot drift to the Factory source checkout.
+## Local data
 
-Factory adds a control-plane authorization gate around that contract. Direct `command_run` and Cortex/Flux/Zen delegation require Factory session coordinates, a native persisted Factory workspace ID, and a sandbox filesystem. The upstream local fallback workspace is rejected before its executor is called, including when repository execution is disabled.
+Default local state is segregated by host:
 
-Factory resolves `packages/runtime-config/config/models.yaml` once at startup and derives the immutable, secret-free `RuntimeDefaultsV1` projection from that profile. Factory configuration, Code SDK settings, persisted local Factory defaults, and the `ProxyGateway` consume their explicit projection directly; runtime defaults are not owned or transported by the MCode recipe. The recipe remains the composition boundary for canonical agents, modes, subagents, tools, and compatibility metadata. Factory registers the recipe's canonical agents on its single `Mastra` instance so their model references resolve through the same startup-loaded catalog as the native controller. The Factory host constructs the recipe with the session-authorized `command_run`, so direct agent APIs and delegate tools share the same fail-closed project binding. Delegate results retain completed child tool results for controller and UI evidence. Read-only `command_run` adapters execute through the bound clone without an additional approval; nested mutation and shell approvals remain suspended because the current upstream Factory controller does not surface a child agent's approval gate through an integration tool. Factory does not bypass that gate. Native nested-approval parity remains tracked with the upstream controller work in issue #119.
+- MCode: `~/.mastra-toolkit/mcode`
+- Studio: `~/.mastra-toolkit/studio`
+- Factory: `~/.mastra-toolkit/factory`
 
-`RuntimeDefaultsV1` maps `contextBudgetTokens` to the Code SDK and Factory observation threshold (120k in the bundled profile) and derives the reflection threshold from the remaining budget (60k). Local Factory storage fills missing threshold and observer/reflector fields while preserving explicit persisted selections. Factory diagnostics identify the runtime-config source, the persisted-settings precedence rule, the null-only fill policy, upstream's lack of an atomic threshold-fill contract, and issue #129's upstream-blocked display convergence separately from the MCode capability digest. This supported default-seeding boundary does not repair the upstream AgentController session/display reset; the toolkit does not mutate `createSession` or copy upstream lifecycle code to force display convergence.
+`MASTRA_APP_DATA_DIR` overrides the selected host directory. Startup performs a one-time migration of recognized legacy MCode or Factory database files and fails on conflicting source and destination data instead of silently overwriting either copy.
 
-The local Factory boot contract exercises the real LibSQL backend, while field-level partial-fill and repeated-startup behavior is tested through `prepareLocalA1Provider`'s `FactoryStorage` domain port. `createToolkitFactory` intentionally does not expose its storage handle, so a field-level readback from that same booted instance would require a new supported diagnostics or storage-query surface; tests do not reach into LibSQL tables or import private Factory domain implementations to manufacture that access.
+## GitHub Projects V2
 
-Standard Git clones and Git worktrees are both supported locally. The folder used for execution is the root detected from the CLI's starting directory. Factory clones or reattaches the repository under its persisted project/user/session workspace binding; it does not execute repository commands from the Factory application directory and does not assign one shared sandbox to a Factory process or agent runtime.
+Issue #127 belongs in a future `packages/factory-github-projects` control-plane package. That package may translate GitHub project items into bindings, leases, reconciliation events, and Factory scheduling requests. It must not import agents, agent tools, MCode, project mounting, or sandbox implementations, and it must not expose raw GitHub clients or credentials to agents. `factory-integration` remains the only consumer and composition boundary.
 
-Factory diagnostics classify only `published-workflows` as behaviorally verified. They report repository `skills` separately as `upstreamUnverified`. Local issue #125 acceptance requires the canonical delegate tools and sandbox execution to work in a persisted repository session; it does not reclassify native repository configuration surfaces that Factory does not yet expose.
+## Lifecycle and validation
 
-Ephemeral local Factory development uses Infisical for the proxy credential and the built-in local authentication path. WorkOS is intentionally optional there. The `persistent-operations` profile remains fail-closed on WorkOS, durable database and Redis state, Platform sandbox identity, production cookie policy, and HTTPS origins. Hosted authentication and native Factory mode parity therefore remain deployment work under issue #119 rather than hidden prerequisites for local operation.
+Both hosts own their process resources and await shutdown exactly once. Factory closes its Factory instance before the shared Mastra runtime; mounted MCode closes project resources, controller timers, PubSub, and Mastra before resetting provider state.
 
-## Release admission
-
-CI should build and validate the exact toolkit revision, record the MCode capability digest, and run the Factory consumer contracts. Prompt, mode, subagent, and safe-default changes do not require rebuilding the sandbox image. Changes to the sandbox filesystem, runtime layers, workflow runner, or toolchain require a new immutable image candidate and native runtime validation. No Mastra fork is permitted for this scope; Factory mode parity waits for a supported upstream release.
+Compatibility evidence consists of the root typecheck, tests, and build plus the host flows in [host validation](host-validation.md). Factory construction does not imply MCode mode parity, and no unsupported upstream surface is patched or copied.

--- a/docs/repository-manifest.md
+++ b/docs/repository-manifest.md
@@ -4,16 +4,16 @@ This manifest is the routing table for changes. A package owns a reusable contra
 
 | Boundary | Owns | Consumes | Extensions belong here when… |
 | --- | --- | --- | --- |
-| `packages/runtime-config` | model profile, aliases, environment resolution, proxy gateway | Mastra core, YAML, Zod | the change is host-neutral model or runtime configuration |
+| `packages/runtime-config` | model profile, aliases, environment resolution, host data paths, proxy gateway | Mastra core, YAML, Zod | the change is host-neutral model or runtime configuration |
 | `packages/agent-tools` | Command Run language/scheduling contracts, ADHD, visible browser policy, tool audit hooks | Mastra core and Stagehand | a capability contract is reusable independent of role and host |
 | `packages/agents-roles` | Cortex/Flux/Zen prompts, role metadata, agent factory | `agent-tools`, `runtime-config` | the canonical agent identity or policy changes |
 | `packages/sandbox` | sandbox schema/config, machine contract, Local/Docker/Platform adapters, executable `command_run` tool | Mastra sandbox providers and agent-tools command contracts | provider behavior or sandbox-contained execution changes |
 | `packages/project-mounting-manager` | specialist/workflow discovery, explicit publication, generations, watcher, transaction ports | Mastra core only | project resources must mount consistently across hosts |
 | `packages/mcode` | versioned recipe, Code modes/subagents/settings, controller mount, MCP and host adapters, session/TUI runtime | roles, config, sandbox, mounting manager, published Code APIs | RLabs extends Mastra Code without changing upstream source |
-| `packages/factory-integration` | Factory auth, storage, provider migration, recipe-based delegation, compatibility diagnostics, sandbox provisioning | MCode recipe, config, sandbox | behavior exists only because the host is Mastra Factory |
+| `packages/factory-integration` | Factory auth, storage, direct canonical-agent composition, compatibility diagnostics, sandbox provisioning, future control-plane composition | roles, config, sandbox | behavior exists only because the host is Mastra Factory |
 | `apps/mcode` | CLI process and exit lifecycle | `mcode` | command parsing or executable UX changes |
 | `apps/studio` | Studio/server composition | `mcode` prepared runtime | Studio transport or server lifecycle changes |
-| `apps/factory` | Factory composition root | `factory-integration`, `mcode`, config, sandbox | Factory process bootstrap changes |
+| `apps/factory` | Factory composition root and process lifecycle | `factory-integration` | Factory process bootstrap changes |
 | `deployment/mcode-sandbox` | ephemeral-development and persistent-operations image source, profile identity, runtime probes, native validation, rollback policy | immutable AES/OPS bases and canonical sandbox profiles | Factory workspace packaging or its deployment evidence changes |
 | `deployment/studio-server` | central Studio target intent | approved application artifacts | a concrete Studio server delivery is approved |
 
@@ -22,7 +22,9 @@ This manifest is the routing table for changes. A package owns a reusable contra
 - Applications may depend on packages; packages never depend on applications.
 - `agents-roles` may depend on `agent-tools` and `runtime-config`, but host adapters do not flow back into canonical roles.
 - `project-mounting-manager` stays independent of Code SDK, Factory, and TUI types; adapters implement its ports.
-- `mcode` must not import Factory. `factory-integration` may consume only the public MCode recipe, provider, and settings exports.
+- `mcode` and `factory-integration` are sibling host adapters. Neither imports the other; both consume canonical role, tool, runtime, and sandbox exports.
+- Canonical agents receive capabilities as narrow, request-scoped tool ports. They never import host clients, control-plane schedulers, storage implementations, or credentials.
+- A future `factory-github-projects` package may own GitHub Projects V2 bindings, leases, reconciliation, and scheduling. Only `factory-integration` may compose it; it must not import agents, agent tools, MCode, project mounting, or sandbox implementations.
 - Deployment targets consume built applications and packages; runtime source does not import deployment policy.
 - Issue #125 does not permit an upstream fork, dependency patch, or copied Factory controller implementation.
 

--- a/docs/workspace-architecture.md
+++ b/docs/workspace-architecture.md
@@ -19,7 +19,8 @@ mastra-toolkit/
 │   ├── sandbox/                  # Local/Docker/Platform machine contract
 │   ├── project-mounting-manager/ # hot-loaded project generations
 │   ├── mcode/                    # Code SDK/controller/TUI adapter
-│   └── factory-integration/      # Factory auth, storage, and integrations
+│   ├── factory-integration/      # Factory host and control-plane composition
+│   └── factory-github-projects/  # future, issue #127; not created yet
 ├── deployment/
 │   ├── mcode-sandbox/            # activated Factory runtime image source and probes
 │   └── studio-server/            # target intent; build assets not yet added
@@ -32,25 +33,25 @@ Every package has an `AGENTS.md`/`CONTEXT.md` checkpoint pair. Applications shar
 ## Canonical runtime projection
 
 ```text
-runtime-config ─┬──────────────┬───────────────────────┐
-               ▼              ▼                       ▼
-          agents-roles ◄── agent-tools             sandbox
-               │                                      │
-               ├─────────────┐                        │
-               ▼             ▼                        ▼
-             mcode   factory-integration ◄────────────┘
-               │             │
-               ▼             ▼
-     project-mounting-manager
+runtime-config ───────────┬──────────────┐
+                         ▼              ▼
+agent-tools ───────► agents-roles     sandbox
+                         │              │
+               ┌─────────┴───────┐      │
+               ▼                 ▼      ▼
+             mcode       factory-integration
+               │                 ▲
+               ▼                 │ optional, future
+project-mounting-manager  factory-github-projects
                │
-        ┌──────┴───────┐
-        ▼              ▼
-  apps/mcode      apps/studio       apps/factory
+        ┌──────┴───────┐          │
+        ▼              ▼           ▼
+  apps/mcode      apps/studio  apps/factory
 ```
 
 `agents-roles` is the one source of role IDs, prompt composition, model policy, and Mastra agent factories. Each role owns a folder containing `prompt.ts`, `role.ts`, and `index.ts`. `agent-tools` owns the host-neutral Command Run language/scheduling contracts and browser capabilities; `sandbox` owns the executable `command_run` tool because execution requires an active sandbox workspace. Hosts project these packages; they do not copy them.
 
-`runtime-config` owns the secret-free YAML catalog and resolves the credential named by `apiKeyEnv` at process start. `sandbox` owns the package-local runtime specification and the substitutable Local, Docker, and Platform machine adapters. No application-level aggregate configuration is canonical.
+`runtime-config` owns the secret-free YAML catalog, startup environment resolution, and host data paths. MCode, Studio, and Factory persist local state beneath `~/.mastra-toolkit/{mcode,studio,factory}` unless `MASTRA_APP_DATA_DIR` explicitly selects another host directory. `sandbox` owns the package-local runtime specification and the substitutable Local, Docker, and Platform machine adapters. No application-level aggregate configuration is canonical.
 
 ## Project mounting
 
@@ -71,7 +72,9 @@ The package is host-neutral. Model lookup, MCP lifecycle, current tool enumerati
 - `packages/mcode` is an RLabs extension built on published `@mastra/code-sdk` and `mastracode` APIs. Its versioned recipe is the single construction seam for canonical agents, modes, native leaf subagents, settings input, and a secret-free capability digest. It also owns provider adaptation, local project mounting, sessions, and reusable TUI construction.
 - `apps/mcode` owns only the executable process lifecycle. `npm run code` launches it; `npm run code:infisical` injects runtime secrets first.
 - `apps/studio` creates the same prepared local project runtime and exposes it through Mastra Studio. The agent, workflow, and mounting definitions are shared with MCode.
-- `packages/factory-integration` owns Factory authentication, persistence, recipe-based delegation integration, sandbox provisioning, compatibility diagnostics, and local provider migration. `apps/factory` is its composition root. The current upstream Factory package cannot mount the recipe's modes and native subagents; that unsupported surface is explicit and remains blocked until an official upstream construction API exists.
+- `packages/factory-integration` owns Factory authentication, persistence, direct construction of canonical agents, sandbox provisioning, compatibility diagnostics, and local provider migration. It does not import MCode. `apps/factory` is its thin composition root.
+- A future `packages/factory-github-projects` belongs between the GitHub Projects V2 API and `factory-integration`. It may own project-item bindings, leases, reconciliation, and scheduling, but never agent definitions, agent tools, sessions, sandboxes, project mounting, or credentials. Its creation is deferred until issue #127 needs executable code.
+- Agent-facing project or RLabs API access enters through narrow tool ports injected at host composition time. Raw SDK clients, tokens, webhook verification, persistence, and control-plane scheduling cannot cross into `agents-roles`.
 
 The local MCode path is serverless in the transport sense: the controller, workflows, specialists, and Mastra instance run in the CLI process and require no central HTTP server. Studio and Factory are server hosts of shared package contracts.
 
@@ -95,11 +98,14 @@ Fork checkouts are external trust boundaries and are not npm workspace members. 
 4. User-selected valid models and Code preferences are preserved; proxy keys are never persisted.
 5. Provider failure is explicit and cannot silently weaken sandbox or model policy.
 6. Applications remain thin and consume package public exports only.
+7. Host adapters are siblings: Factory does not consume MCode, and canonical packages do not depend on either host.
+8. Process shutdown awaits host resources and the shared Mastra runtime exactly once.
 
 ## Validation gates
 
 - Root: `npm run typecheck`, `npm test`, and `npm run build`.
 - Package: the owning package's `npm run check`.
-- MCode: local project boot, six modes, native subagent targets, project workflow tools, and TUI CVUA evidence when UI behavior changes.
-- Factory: auth, storage migration, delegation, sandbox, and external integration gates appropriate to the change.
+- MCode: local project boot, six modes, native subagent targets, project workflow tools, and PTY/CUA evidence when UI behavior changes.
+- Factory: auth, storage migration, delegation, sandbox, an `agent-browser` browser pass, and CUA evidence for visible workflows.
+- Studio: browser validation when the Studio host or shared mounted runtime changes.
 - Repository: `git diff --check`, checkpoint verification, secret scan, and generated-state inspection.

--- a/packages/agent-tools/AGENTS.md
+++ b/packages/agent-tools/AGENTS.md
@@ -19,6 +19,8 @@ applies_to: ["**/*"]
 - Keep this package independent from role definitions, Mastra Code SDK projections, and Factory adapters.
 - Keep Command Run parsing, scheduling, approval, traces, and output contracts host-neutral. Executable sandbox containment belongs to `packages/sandbox`.
 - Keep browser actions visible and preserve explicit approval for mutating navigation, tab, and page actions.
+- Keep API-interacting tools request-scoped and backed by narrow injected ports. Do not store credentials, bindings, leases, persistent workers, or external SDK clients here.
+- Require authorization, explicit approval for mutation, idempotency, auditability, and bounded output at external API boundaries. Do not add a generic arbitrary HTTP or API tool.
 
 ## Structure and extension
 
@@ -34,6 +36,7 @@ src/
 - Treat `command-run/` and the sandbox-owned executable tool as one behavioral contract; changes spanning parser, execution, containment, media, web, and audit surfaces must remain coherent across both packages.
 - Start a new role- and host-neutral tool as one module. Create a subdirectory only after it has multiple private responsibilities behind one narrow facade.
 - Existing helper exports are compatibility surfaces. New internals do not become public solely for testing; add or narrow exports only through an explicit compatibility migration.
+- `command_run` and `adhd_run` are retained compatibility capabilities. Do not add new consumers or expand their DSL/fan-out scope; future replacement uses native Mastra workflows, task state, subagents, and background tasks after parity is proven.
 
 ## Change boundaries
 

--- a/packages/agents-roles/AGENTS.md
+++ b/packages/agents-roles/AGENTS.md
@@ -19,6 +19,8 @@ applies_to: ["**/*"]
 - Keep Cortex, Flux, and Zen in separate `prompt.ts`, `role.ts`, and `index.ts` module folders.
 - Consume role-independent tools from `@rlabs/agent-tools` and model profiles from `@rlabs/runtime-config`.
 - Preserve public role IDs and the exact six-section prompt order.
+- Do not import Factory, MCode, GitHub, storage, scheduler, project-binding, credential, or API-client packages. Agent definitions may receive host-neutral tools, but never the clients or authority behind them.
+- Treat request workspace and tool availability as injected capability ceilings. Prompts and model-authored identifiers cannot select another project, repository, or API authority.
 
 ## Structure and extension
 

--- a/packages/factory-integration/AGENTS.md
+++ b/packages/factory-integration/AGENTS.md
@@ -17,9 +17,10 @@ applies_to: ["**/*"]
 ## Operating rules
 
 - Own Factory authentication, storage, integrations, provider migration, and sandbox composition here.
-- Consume canonical agents and Code construction metadata through the versioned public MCode recipe, and sandbox machines from `sandbox`.
+- Consume canonical agents directly from `agents-roles` and sandbox machines from `sandbox`. Do not import MCode settings, recipes, controller lifecycle, or project detection.
 - Report unsupported upstream controller or repository-configuration surfaces explicitly; do not patch Factory, construct a second controller, or read project settings from the Factory checkout.
 - Keep the executable Factory composition in `apps/factory` and deployment artifacts outside packages.
+- Remain the sole Factory composition owner and the sole adapter for GitHub credentials/webhook ownership. A Projects V2 control-plane extension receives verified events and governed command ports; it does not become an agent tool or a second GitHub integration owner.
 
 ## Structure and extension
 

--- a/packages/factory-integration/CONTEXT.md
+++ b/packages/factory-integration/CONTEXT.md
@@ -13,7 +13,7 @@ Factory construction, authentication, provider preparation, storage, canonical a
 
 ## Present
 
-This package adapts the versioned MCode recipe to Mastra Factory. It owns Factory-specific lifecycle and persistence while applications and deployment targets remain separate boundaries. The control plane can omit repository execution; enabled repository execution consumes the shared sandbox machine as a fleet template and persists project/user/session bindings. Ephemeral development and persistent operations are explicit, fail-closed runtime profiles. Until upstream Factory accepts controller-construction ingredients, diagnostics explicitly report canonical mode/native-subagent mounting as unsupported.
+This package projects canonical agents directly into Mastra Factory. It owns Factory-specific lifecycle, persistence, authorization, and integration composition while applications and deployment targets remain separate boundaries. The control plane can omit repository execution; enabled repository execution consumes the shared sandbox machine as a fleet template and persists project/user/session bindings. Ephemeral development and persistent operations are explicit, fail-closed runtime profiles. Until upstream Factory accepts controller-construction ingredients, diagnostics explicitly report canonical mode/native-subagent mounting as unsupported.
 
 ## Future
 

--- a/packages/factory-integration/package.json
+++ b/packages/factory-integration/package.json
@@ -14,7 +14,6 @@
     "@mastra/pg": "1.19.0",
     "@mastra/redis-streams": "0.3.0",
     "@rlabs/agents-roles": "*",
-    "@rlabs/mcode": "*",
     "@rlabs/project-mounting-manager": "*",
     "@rlabs/runtime-config": "*",
     "@rlabs/sandbox": "*",

--- a/packages/factory-integration/src/create.ts
+++ b/packages/factory-integration/src/create.ts
@@ -1,14 +1,9 @@
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
 import type { FactoryStorage } from "@mastra/core/storage";
 import { MastraFactory, type MastraArgs, type MastraFactoryConfig } from "@mastra/factory";
 import { GithubIntegration } from "@mastra/factory/integrations/github/integration";
 import { RedisStreamsPubSub } from "@mastra/redis-streams";
-import {
-  prepareCodeSdkSettings,
-  type A1ProviderOptions,
-} from "@rlabs/mcode";
-import type { RuntimeDefaultsV1 } from "@rlabs/runtime-config";
+import { prepareHostDataDirectory, type RuntimeDefaultsV1 } from "@rlabs/runtime-config";
 import {
   createSandboxMachine,
   type CloneableSandboxMachine,
@@ -18,11 +13,17 @@ import { createFactoryAuth } from "./auth.js";
 import type { FactoryConfig } from "./config.js";
 import { prepareLocalA1Provider } from "./local-provider.js";
 import { createFactoryStorage } from "./storage.js";
-import { ToolkitFactoryIntegration, type FactoryMcodeRecipe } from "./toolkit-integration.js";
+import { ToolkitFactoryIntegration, type FactoryAgentBundle } from "./toolkit-integration.js";
+
+interface A1ProviderOptions {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+  readonly models: readonly string[];
+}
 
 export async function createToolkitFactory(
   config: FactoryConfig,
-  recipe: FactoryMcodeRecipe,
+  bundle: FactoryAgentBundle,
   defaults: RuntimeDefaultsV1,
 ): Promise<MastraFactory> {
   const provider = {
@@ -30,10 +31,10 @@ export async function createToolkitFactory(
     models: defaults.gateway.models,
     ...(config.runtime.proxy.apiKey ? { apiKey: config.runtime.proxy.apiKey } : {}),
   } satisfies A1ProviderOptions;
-  const dataDirectory = await prepareCodeSdkSettings({ defaults });
-  const controlPlaneDirectory = join(dataDirectory, "factory-control-plane");
+  const hostData = await prepareHostDataDirectory("factory");
+  const controlPlaneDirectory = hostData.controlPlaneDirectory!;
   await mkdir(controlPlaneDirectory, { recursive: true, mode: 0o700 });
-  const { factoryStorage, vector } = createFactoryStorage(config.databaseUrl);
+  const { factoryStorage, vector } = createFactoryStorage(config.databaseUrl, hostData.databasePath);
   const github = config.github ? new GithubIntegration({
     appId: config.github.GITHUB_APP_ID,
     privateKey: config.github.GITHUB_APP_PRIVATE_KEY,
@@ -51,7 +52,7 @@ export async function createToolkitFactory(
     storage: factoryStorage,
     ...(vector ? { vector } : {}),
     ...(config.redisUrl ? { pubsub: new RedisStreamsPubSub({ url: config.redisUrl }) } : {}),
-    integrations: [new ToolkitFactoryIntegration(recipe, defaults), ...(github ? [github] : [])],
+    integrations: [new ToolkitFactoryIntegration(bundle, defaults), ...(github ? [github] : [])],
     ...(config.sandbox ? {
       sandbox: {
         machine: createFactorySandboxMachine(config),
@@ -68,7 +69,7 @@ export async function createToolkitFactory(
   return new ToolkitMastraFactory(
     factoryConfig,
     factoryStorage,
-    recipe.agents,
+    bundle.agents,
     config.workos ? undefined : { provider, defaults },
     controlPlaneDirectory,
     config.workos ? undefined : loopbackServerHost(config.server.publicUrl),
@@ -94,7 +95,7 @@ class ToolkitMastraFactory extends MastraFactory {
   constructor(
     config: MastraFactoryConfig,
     private readonly factoryStorage: FactoryStorage,
-    private readonly toolkitAgents: FactoryMcodeRecipe["agents"],
+    private readonly toolkitAgents: FactoryAgentBundle["agents"],
     private readonly localA1?: { provider: A1ProviderOptions; defaults: RuntimeDefaultsV1 },
     private readonly controlPlaneDirectory?: string,
     private readonly localServerHost?: string,

--- a/packages/factory-integration/src/local-provider.ts
+++ b/packages/factory-integration/src/local-provider.ts
@@ -1,11 +1,16 @@
 import type { FactoryStorage } from "@mastra/core/storage";
 import {
-  A1_CODE_PROVIDER_ID,
-  A1_CODE_PROVIDER_NAME,
-  getA1CodeModelId,
-  type A1ProviderOptions,
-} from "@rlabs/mcode";
-import type { RuntimeDefaultsV1 } from "@rlabs/runtime-config";
+  A1_PROXY_PROVIDER_ID,
+  A1_PROXY_PROVIDER_NAME,
+  getA1ProxyModelId,
+  type RuntimeDefaultsV1,
+} from "@rlabs/runtime-config";
+
+interface A1ProviderOptions {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+  readonly models: readonly string[];
+}
 
 const LOCAL_ORG_ID = "local-org";
 const LOCAL_USER_ID = "local-user";
@@ -76,8 +81,8 @@ async function seedProvider(storage: FactoryStorage, provider: A1ProviderOptions
     orgId: LOCAL_ORG_ID,
     userId: LOCAL_USER_ID,
     input: {
-      providerId: A1_CODE_PROVIDER_ID,
-      name: A1_CODE_PROVIDER_NAME,
+      providerId: A1_PROXY_PROVIDER_ID,
+      name: A1_PROXY_PROVIDER_NAME,
       url: provider.baseUrl,
       ...(provider.apiKey ? { apiKey: provider.apiKey } : {}),
       models: [...provider.models],
@@ -170,7 +175,7 @@ function normalizeMemorySettings(memory: ModelMemorySettings): ModelMemorySettin
 export function normalizeStoredModelId(modelId: string | null | undefined): string | undefined {
   if (!modelId) return undefined;
   if (/^(?:mastracode\/)?a1-proxy\/gpt-5\.6-luna$/.test(modelId) || modelId === "mastracode/gpt-5.6-luna") {
-    return getA1CodeModelId("code-workhorse-high");
+    return getA1ProxyModelId("code-workhorse-high");
   }
   if (modelId.startsWith("mastracode/a1-proxy/")) return modelId.slice("mastracode/".length);
   return modelId;

--- a/packages/factory-integration/src/storage.ts
+++ b/packages/factory-integration/src/storage.ts
@@ -1,10 +1,9 @@
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import { LibSQLFactoryStorage } from "@mastra/libsql";
 import { PgFactoryStorage, PgVector } from "@mastra/pg";
 
-export function createFactoryStorage(databaseUrl?: string) {
+export function createFactoryStorage(databaseUrl?: string, localDatabasePath?: string) {
   if (databaseUrl) {
     const factoryStorage = new PgFactoryStorage({
       id: "mastra-toolkit-storage",
@@ -16,9 +15,8 @@ export function createFactoryStorage(databaseUrl?: string) {
       vector: new PgVector({ id: "mastra-toolkit-vectors", connectionString: databaseUrl }),
     };
   }
-  const dataDirectory = process.env.MASTRA_APP_DATA_DIR
-    ?? join(homedir(), ".mastra-toolkit", "data");
-  const databasePath = join(dataDirectory, "factory.db");
+  if (!localDatabasePath) throw new Error("Local Factory storage requires a resolved database path");
+  const databasePath = localDatabasePath;
   mkdirSync(dirname(databasePath), { recursive: true });
   const factoryStorage = new LibSQLFactoryStorage({
     id: "mastra-toolkit-storage",

--- a/packages/factory-integration/src/toolkit-integration.ts
+++ b/packages/factory-integration/src/toolkit-integration.ts
@@ -5,15 +5,12 @@ import { createTool } from "@mastra/core/tools";
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from "@mastra/factory";
 import { getFactorySessionAddress } from "@mastra/factory/rules/binding-context";
 import {
+  createToolkitAgents,
   TOOLKIT_FACTORY_DELEGATION_CONTEXT_KEY,
   TOOLKIT_WORKSPACE_CONTEXT_KEY,
+  type ToolkitAgents,
+  type ToolkitAgentsOptions,
 } from "@rlabs/agents-roles";
-import {
-  createMcodeRecipe,
-  type McodeCapabilityDescriptorV1,
-  type McodeRecipeOptions,
-  type McodeRecipeV1,
-} from "@rlabs/mcode";
 import {
   createSandboxCommandRunTool,
   type SandboxCommandRunAuthorizationContext,
@@ -24,10 +21,11 @@ import { createFactoryProjectWorkflowTool } from "./project-workflow.js";
 
 const MAX_DELEGATED_TOOL_RESULTS = 24;
 const MAX_DELEGATED_TOOL_RESULT_CHARS = 4_000;
-const FACTORY_MCODE_RECIPE = Symbol("factory-mcode-recipe");
+const FACTORY_AGENT_BUNDLE = Symbol("factory-agent-bundle");
 
-export type FactoryMcodeRecipe = McodeRecipeV1 & {
-  readonly [FACTORY_MCODE_RECIPE]: true;
+export interface FactoryAgentBundle {
+  readonly agents: ToolkitAgents;
+  readonly [FACTORY_AGENT_BUNDLE]: true;
 };
 
 const delegationOutputSchema = z.object({
@@ -46,11 +44,11 @@ export class ToolkitFactoryIntegration implements FactoryIntegration {
   readonly id = "mastra-toolkit";
 
   constructor(
-    private readonly recipe: FactoryMcodeRecipe,
+    private readonly bundle: FactoryAgentBundle,
     private readonly runtimeDefaults: RuntimeDefaultsV1,
   ) {
-    if (recipe[FACTORY_MCODE_RECIPE] !== true) {
-      throw new Error("Factory MCode recipes must be created with createFactoryMcodeRecipe");
+    if (bundle[FACTORY_AGENT_BUNDLE] !== true) {
+      throw new Error("Factory agent bundles must be created with createFactoryAgentBundle");
     }
   }
 
@@ -60,16 +58,15 @@ export class ToolkitFactoryIntegration implements FactoryIntegration {
 
   async agentTools(): Promise<IntegrationTools> {
     return {
-      delegate_cortex: delegationTool("delegate_cortex", this.recipe.agents.cortex),
-      delegate_flux: delegationTool("delegate_flux", this.recipe.agents.flux),
-      delegate_zen: delegationTool("delegate_zen", this.recipe.agents.zen),
+      delegate_cortex: delegationTool("delegate_cortex", this.bundle.agents.cortex),
+      delegate_flux: delegationTool("delegate_flux", this.bundle.agents.flux),
+      delegate_zen: delegationTool("delegate_zen", this.bundle.agents.zen),
       command_run: createFactoryCommandRunTool(),
       project_workflow: createFactoryProjectWorkflowTool(),
     } as IntegrationTools;
   }
 
   diagnostics(): Record<string, unknown> {
-    const capability = this.recipe.capability;
     return {
       configured: true,
       agents: ["cortex", "flux", "zen"],
@@ -86,7 +83,15 @@ export class ToolkitFactoryIntegration implements FactoryIntegration {
           issue: "#129",
         },
       },
-      mcode: factoryMcodeDiagnostics(capability),
+      agentBoundary: {
+        source: "@rlabs/agents-roles",
+        controllerConstruction: "unsupported-upstream",
+        repositoryConfiguration: {
+          verified: ["published-workflows"],
+          upstreamUnverified: ["skills"],
+          unsupported: ["instructions", "hooks", "commands", "plugins", "mcp", "specialists"],
+        },
+      },
     };
   }
 }
@@ -95,29 +100,12 @@ export function createFactoryCommandRunTool() {
   return createSandboxCommandRunTool({ authorize: requireFactoryProjectSession });
 }
 
-export function createFactoryMcodeRecipe(
-  options: Omit<McodeRecipeOptions, "commandRun">,
-): FactoryMcodeRecipe {
-  return Object.assign(createMcodeRecipe({
-    ...options,
-    commandRun: createFactoryCommandRunTool(),
-  }), {
-    [FACTORY_MCODE_RECIPE]: true as const,
-  });
-}
-
-function factoryMcodeDiagnostics(capability: McodeCapabilityDescriptorV1): Record<string, unknown> {
+export function createFactoryAgentBundle(
+  options: Omit<ToolkitAgentsOptions, "commandRun">,
+): FactoryAgentBundle {
   return {
-    schemaVersion: capability.schemaVersion,
-    digest: capability.digest,
-    controllerConstruction: "unsupported-upstream",
-    repositoryConfiguration: {
-      verified: ["published-workflows"],
-      upstreamUnverified: ["skills"],
-      unsupported: ["instructions", "hooks", "commands", "plugins", "mcp", "specialists"],
-    },
-    controlPlaneProjectConfig: "isolated-empty-directory",
-    globalExecutableConfig: "unsupported-upstream",
+    agents: createToolkitAgents({ ...options, commandRun: createFactoryCommandRunTool() }),
+    [FACTORY_AGENT_BUNDLE]: true,
   };
 }
 

--- a/packages/factory-integration/test/factory.test.ts
+++ b/packages/factory-integration/test/factory.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { ApiRoute } from "@mastra/core/server";
 import { RequestContext } from "@mastra/core/request-context";
 import { Mastra } from "@mastra/core/mastra";
-import { createMcodeRecipe } from "@rlabs/mcode/recipe";
+import { createToolkitAgents } from "@rlabs/agents-roles";
 import { loadModelProfile, resolveRuntimeDefaultsV1 } from "@rlabs/runtime-config";
 import { createSandboxCommandRunTool } from "@rlabs/sandbox";
 import { Hono } from "hono";
@@ -12,7 +12,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { loadFactoryConfig } from "../src/config.js";
 import { createToolkitFactory } from "../src/create.js";
 import {
-  createFactoryMcodeRecipe,
+  createFactoryAgentBundle,
   ToolkitFactoryIntegration,
 } from "../src/toolkit-integration.js";
 
@@ -26,14 +26,16 @@ afterEach(async () => {
 });
 
 describe("single-project Factory composition", () => {
-  test("rejects an MCode recipe without the Factory session authorization boundary", () => {
+  test("rejects an unbranded agent bundle without the Factory session authorization boundary", () => {
     const profile = loadModelProfile();
-    const recipe = createMcodeRecipe({ profile, commandRun: createSandboxCommandRunTool(), browser: false });
+    const bundle = {
+      agents: createToolkitAgents({ profile, commandRun: createSandboxCommandRunTool(), browser: false }),
+    };
 
     expect(() => new ToolkitFactoryIntegration(
-      recipe as never,
+      bundle as never,
       resolveRuntimeDefaultsV1(profile),
-    )).toThrow(/createFactoryMcodeRecipe/);
+    )).toThrow(/createFactoryAgentBundle/);
   });
 
   test("boots without a sandbox and fails GitHub project preparation closed", async () => {
@@ -52,13 +54,13 @@ describe("single-project Factory composition", () => {
       FACTORY_PUBLIC_URL: "http://127.0.0.1:4111",
       FACTORY_ALLOWED_ORIGINS: "http://127.0.0.1:4111",
     }, process.cwd(), profile);
-    const recipe = createFactoryMcodeRecipe({
+    const bundle = createFactoryAgentBundle({
       profile,
       browser: false,
     });
     const defaults = resolveRuntimeDefaultsV1(profile);
-    expect(recipe).not.toHaveProperty("settings");
-    const diagnostics = new ToolkitFactoryIntegration(recipe, defaults).diagnostics();
+    expect(bundle).not.toHaveProperty("settings");
+    const diagnostics = new ToolkitFactoryIntegration(bundle, defaults).diagnostics();
     expect(diagnostics).toMatchObject({
       runtimeDefaults: {
         source: "@rlabs/runtime-config/models.yaml",
@@ -75,8 +77,8 @@ describe("single-project Factory composition", () => {
           issue: "#129",
         },
       },
-      mcode: {
-        digest: recipe.capability.digest,
+      agentBoundary: {
+        source: "@rlabs/agents-roles",
         controllerConstruction: "unsupported-upstream",
         repositoryConfiguration: {
           verified: ["published-workflows"],
@@ -85,8 +87,8 @@ describe("single-project Factory composition", () => {
         },
       },
     });
-    await expect(new ToolkitFactoryIntegration(recipe, defaults).agentTools()).resolves.toHaveProperty("command_run");
-    const tools = await new ToolkitFactoryIntegration(recipe, defaults).agentTools();
+    await expect(new ToolkitFactoryIntegration(bundle, defaults).agentTools()).resolves.toHaveProperty("command_run");
+    const tools = await new ToolkitFactoryIntegration(bundle, defaults).agentTools();
     const commandRun = tools.command_run as {
       execute?: (input: unknown, context: unknown) => Promise<unknown>;
     };
@@ -113,7 +115,7 @@ describe("single-project Factory composition", () => {
     }, unboundContext)).rejects.toThrow(/persisted Factory project session/i);
     await expect(delegateCortex.execute?.({ task: "must not delegate on the Factory host", maxSteps: 1 }, unboundContext))
       .rejects.toThrow(/persisted Factory project session/i);
-    for (const agent of Object.values(recipe.agents)) {
+    for (const agent of Object.values(bundle.agents)) {
       const directCommandRun = (await agent.listTools()).command_run as {
         execute?: (input: unknown, context: unknown) => Promise<unknown>;
       };
@@ -123,14 +125,14 @@ describe("single-project Factory composition", () => {
       }, unboundContext)).rejects.toThrow(/persisted Factory project session/i);
     }
     expect(sandboxInvoked).toBe(false);
-    const factory = await createToolkitFactory(config, recipe, defaults);
+    const factory = await createToolkitFactory(config, bundle, defaults);
 
     try {
       const prepared = await factory.prepare();
       expect(prepared.agents).toMatchObject({
-        cortex: recipe.agents.cortex,
-        flux: recipe.agents.flux,
-        zen: recipe.agents.zen,
+        cortex: bundle.agents.cortex,
+        flux: bundle.agents.flux,
+        zen: bundle.agents.zen,
       });
       const composed = new Mastra(prepared);
       for (const id of ["cortex", "flux", "zen"] as const) {
@@ -182,8 +184,8 @@ describe("single-project Factory composition", () => {
         FACTORY_REPOSITORY_EXECUTION: "disabled",
         CLI_PROXY_API_KEY: "test-only-key",
       }, hostTrapDirectory, profile);
-      const recipe = createFactoryMcodeRecipe({ profile, browser: false });
-      factory = await createToolkitFactory(config, recipe, resolveRuntimeDefaultsV1(profile));
+      const bundle = createFactoryAgentBundle({ profile, browser: false });
+      factory = await createToolkitFactory(config, bundle, resolveRuntimeDefaultsV1(profile));
       await factory.prepare();
       expect(process.env.FACTORY_HOST_TRAP).toBeUndefined();
       expect(process.cwd()).toBe(canonicalHostTrapDirectory);
@@ -196,7 +198,7 @@ describe("single-project Factory composition", () => {
 
   test("returns delegated command results when a canonical agent ends on a tool step", async () => {
     const profile = loadModelProfile();
-    const recipe = createFactoryMcodeRecipe({ profile, browser: false });
+    const bundle = createFactoryAgentBundle({ profile, browser: false });
     const commandResult = {
       version: 1,
       description: "show the bound checkout",
@@ -204,7 +206,7 @@ describe("single-project Factory composition", () => {
       attachments: [],
     };
     const oversizedResult = { output: "x".repeat(5_000) };
-    const generate = vi.spyOn(recipe.agents.cortex, "generate").mockResolvedValue({
+    const generate = vi.spyOn(bundle.agents.cortex, "generate").mockResolvedValue({
       text: "",
       runId: "delegated-run-1",
       steps: [{
@@ -226,7 +228,7 @@ describe("single-project Factory composition", () => {
       }],
     } as never);
     const delegate = (await new ToolkitFactoryIntegration(
-      recipe,
+      bundle,
       resolveRuntimeDefaultsV1(profile),
     ).agentTools()).delegate_cortex as {
       execute?: (input: unknown, context: unknown) => Promise<unknown>;

--- a/packages/factory-integration/test/project-workflow.test.ts
+++ b/packages/factory-integration/test/project-workflow.test.ts
@@ -7,7 +7,7 @@ import { SandboxFilesystem } from "@mastra/code-sdk/agents/sandbox-filesystem";
 import { loadModelProfile, resolveRuntimeDefaultsV1 } from "@rlabs/runtime-config";
 import { createSandboxMachine, loadSandboxConfig } from "@rlabs/sandbox";
 import { afterEach, describe, expect, test } from "vitest";
-import { createFactoryMcodeRecipe, ToolkitFactoryIntegration } from "../src/toolkit-integration.js";
+import { createFactoryAgentBundle, ToolkitFactoryIntegration } from "../src/toolkit-integration.js";
 
 let projectRoot: string | undefined;
 
@@ -307,7 +307,7 @@ describe("Factory project workflows", () => {
 
 function factoryIntegration(): ToolkitFactoryIntegration {
   const profile = loadModelProfile();
-  return new ToolkitFactoryIntegration(createFactoryMcodeRecipe({
+  return new ToolkitFactoryIntegration(createFactoryAgentBundle({
     profile,
     browser: false,
   }), resolveRuntimeDefaultsV1(profile));

--- a/packages/mcode/CONTEXT.md
+++ b/packages/mcode/CONTEXT.md
@@ -13,7 +13,7 @@ The RLabs Mastra Code wrapper lived across `src/code`, agent mode files, Factory
 
 ## Present
 
-This package is the reusable adapter for RLabs' extended Mastra Code runtime. Its versioned recipe is the one construction seam for canonical agents, modes, native subagents, tools, and the secret-free capability descriptor consumed by local MCode and Factory. Runtime defaults remain a separate `@rlabs/runtime-config` projection consumed directly by each host. MCode projects those canonical packages into published Code SDK and TUI APIs without owning the executable process or forking upstream source.
+This package is the reusable adapter for RLabs' extended Mastra Code runtime. Its versioned recipe is the MCode construction seam for canonical agents, modes, native subagents, tools, and its secret-free capability descriptor. Factory is a sibling adapter and consumes canonical agents directly. Runtime defaults remain a separate `@rlabs/runtime-config` projection consumed directly by each host. MCode projects those canonical packages into published Code SDK and TUI APIs without owning the executable process or forking upstream source.
 
 ## Future
 

--- a/packages/mcode/src/mount.ts
+++ b/packages/mcode/src/mount.ts
@@ -37,6 +37,7 @@ export interface McodeRuntimeOptions {
   readonly config?: McodeConfig;
   readonly profile?: ModelProfile;
   readonly dataDirectory?: string;
+  readonly host?: "mcode" | "studio";
   readonly browser?: boolean;
   readonly watch?: boolean;
   readonly mcp?: McpLifecyclePort;
@@ -96,6 +97,8 @@ export async function prepareMcodeRuntime(
   const agents = recipe.agents;
   const dataDirectory = await prepareCodeSdkSettings({
     ...(options.dataDirectory ? { dataDirectory: options.dataDirectory } : {}),
+    host: options.host ?? "mcode",
+    environment,
     defaults: runtimeDefaults,
     provider: { baseUrl: config.runtime.proxy.baseUrl, models: runtimeDefaults.gateway.models },
   });
@@ -166,12 +169,21 @@ export async function prepareMcodeRuntime(
         await controllerMount.finalize();
         if (options.watch ?? true) resources.startWatching();
       } catch (error) {
-        await resources?.close().catch(() => undefined);
-        if (!resources) await mcp.close().catch(() => undefined);
+        let cleanupError: unknown;
+        try {
+          if (resources) await resources.close();
+          else await mcp.close();
+        } catch (caught) {
+          cleanupError = caught;
+        }
         setCustomProvidersSource(undefined);
+        if (cleanupError !== undefined) {
+          throw new AggregateError([error, cleanupError], "MCode runtime initialization and cleanup failed");
+        }
         throw error;
       }
 
+      let closePromise: Promise<void> | undefined;
       return {
         project,
         config,
@@ -181,12 +193,12 @@ export async function prepareMcodeRuntime(
         code: controllerMount.base,
         resources,
         async close(): Promise<void> {
-          await resources!.close();
-          await controllerMount.base.controller.getMastra()?.stopWorkers();
-          await controllerMount.base.controller.stopIntervals();
-          await closePubSub(controllerMount.base.signalsPubSub);
-          await controllerMount.base.storageMaintenance.closeStorage?.();
-          setCustomProvidersSource(undefined);
+          closePromise ??= closeMountedRuntime(
+            mastra,
+            resources!,
+            controllerMount.base,
+          );
+          await closePromise;
         },
       };
     },
@@ -209,4 +221,27 @@ class EmptyMcpLifecycle implements McpLifecyclePort {
 async function closePubSub(pubsub: MastraCodeAgentController["signalsPubSub"]): Promise<void> {
   const close = (pubsub as { close?: () => void | Promise<void> } | undefined)?.close;
   await close?.call(pubsub);
+}
+
+async function closeMountedRuntime(
+  mastra: Mastra,
+  resources: ProjectMountingManager,
+  code: MastraCodeAgentController,
+): Promise<void> {
+  const failures: unknown[] = [];
+  try {
+    await resources.close();
+  } catch (error) {
+    failures.push(error);
+  }
+  const results = await Promise.allSettled([
+    code.controller.stopIntervals(),
+    closePubSub(code.signalsPubSub),
+    mastra.shutdown(),
+  ]);
+  setCustomProvidersSource(undefined);
+  for (const result of results) {
+    if (result.status === "rejected") failures.push(result.reason);
+  }
+  if (failures.length > 0) throw new AggregateError(failures, "MCode runtime shutdown failed");
 }

--- a/packages/mcode/src/settings.ts
+++ b/packages/mcode/src/settings.ts
@@ -1,13 +1,19 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { createMastraCodeGateway, type MastraCodeCustomProvider } from "@mastra/code-sdk/agents/model";
 import { ONBOARDING_VERSION } from "@mastra/code-sdk/onboarding/index";
-import type { RuntimeDefaultsV1 } from "@rlabs/runtime-config";
+import {
+  A1_PROXY_PROVIDER_ID,
+  A1_PROXY_PROVIDER_NAME,
+  getA1ProxyModelId,
+  prepareHostDataDirectory,
+  type RuntimeDefaultsV1,
+  type ToolkitHostId,
+} from "@rlabs/runtime-config";
 import { CANONICAL_AGENT_IDS, CODE_MODE_IDS } from "./modes/index.js";
 
-export const A1_CODE_PROVIDER_ID = "a1-proxy";
-export const A1_CODE_PROVIDER_NAME = "A1 Proxy";
+export const A1_CODE_PROVIDER_ID = A1_PROXY_PROVIDER_ID;
+export const A1_CODE_PROVIDER_NAME = A1_PROXY_PROVIDER_NAME;
 
 interface SettingsDocument {
   onboarding?: Record<string, unknown>;
@@ -31,17 +37,19 @@ export interface A1ProviderOptions {
 }
 
 export function getA1CodeModelId(model: string): string {
-  return `${A1_CODE_PROVIDER_ID}/${model.replace(/^a1-proxy\//, "")}`;
+  return getA1ProxyModelId(model);
 }
 
 export async function prepareCodeSdkSettings(options: {
   readonly dataDirectory?: string;
+  readonly host?: Extract<ToolkitHostId, "mcode" | "studio">;
+  readonly environment?: NodeJS.ProcessEnv;
   readonly defaults: RuntimeDefaultsV1;
   readonly provider?: Omit<A1ProviderOptions, "apiKey">;
 }): Promise<string> {
+  const environment = options.environment ?? process.env;
   const directory = options.dataDirectory
-    ?? process.env.MASTRA_APP_DATA_DIR
-    ?? join(homedir(), ".mastra-toolkit", "code-sdk");
+    ?? (await prepareHostDataDirectory(options.host ?? "mcode", environment)).directory;
   process.env.MASTRA_APP_DATA_DIR = directory;
   await mkdir(directory, { recursive: true });
   const settingsPath = join(directory, "settings.json");

--- a/packages/project-mounting-manager/AGENTS.md
+++ b/packages/project-mounting-manager/AGENTS.md
@@ -20,6 +20,7 @@ applies_to: ["**/*"]
 - Model host and MCP changes as prepared transactions with explicit commit and rollback.
 - Publish workflows as agent tools only when their module exports valid `agentTool` metadata.
 - Preserve the last-known-good generation whenever discovery, validation, preparation, or commit fails.
+- Keep GitHub Project planning, work selection, execution leases, Factory transitions, and status projection outside this package. Project resources cannot change Factory bindings or control-plane policy.
 
 ## Structure and extension
 

--- a/packages/runtime-config/src/environment.ts
+++ b/packages/runtime-config/src/environment.ts
@@ -1,3 +1,6 @@
+import { mkdir, readdir, rename } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 import { z } from "zod";
 import { DEFAULT_ACTIVE_ALIAS, loadModelProfile, resolveAliasModelId, type ModelProfile } from "./profile.js";
 
@@ -22,6 +25,18 @@ export interface RuntimeConfig {
   readonly proxy: ModelHostConfig;
 }
 
+export type ToolkitHostId = "mcode" | "studio" | "factory";
+
+export interface HostDataPaths {
+  readonly rootDirectory: string;
+  readonly directory: string;
+  readonly databasePath: string;
+  readonly settingsPath?: string;
+  readonly vectorDatabasePath?: string;
+  readonly observabilityDatabasePath?: string;
+  readonly controlPlaneDirectory?: string;
+}
+
 export function loadRuntimeConfig(
   environment: NodeJS.ProcessEnv = process.env,
   profile: ModelProfile = loadModelProfile(),
@@ -39,6 +54,86 @@ export function loadRuntimeConfig(
     mode: parsed.MASTRA_TOOLKIT_MODE,
     proxy: apiKey ? { ...modelHost, apiKey } : modelHost,
   };
+}
+
+export function resolveHostDataPaths(
+  host: ToolkitHostId,
+  environment: NodeJS.ProcessEnv = process.env,
+  userHome: string = homedir(),
+): HostDataPaths {
+  const rootDirectory = resolve(userHome, ".mastra-toolkit");
+  const directory = resolve(environment.MASTRA_APP_DATA_DIR ?? join(rootDirectory, host));
+  if (host === "factory") {
+    return {
+      rootDirectory,
+      directory,
+      databasePath: join(directory, "factory.db"),
+      controlPlaneDirectory: join(directory, "control-plane"),
+    };
+  }
+  return {
+    rootDirectory,
+    directory,
+    databasePath: join(directory, "mastra.db"),
+    settingsPath: join(directory, "settings.json"),
+    vectorDatabasePath: join(directory, "mastra-vectors.db"),
+    observabilityDatabasePath: join(directory, "observability.duckdb"),
+  };
+}
+
+export async function prepareHostDataDirectory(
+  host: ToolkitHostId,
+  environment: NodeJS.ProcessEnv = process.env,
+  userHome: string = homedir(),
+): Promise<HostDataPaths> {
+  const paths = resolveHostDataPaths(host, environment, userHome);
+  if (!environment.MASTRA_APP_DATA_DIR) await migrateLegacyHostData(host, paths);
+  await mkdir(paths.directory, { recursive: true, mode: 0o700 });
+  return paths;
+}
+
+async function migrateLegacyHostData(host: ToolkitHostId, paths: HostDataPaths): Promise<void> {
+  const legacyDirectory = host === "mcode"
+    ? join(paths.rootDirectory, "code-sdk")
+    : host === "factory"
+      ? join(paths.rootDirectory, "data")
+      : undefined;
+  if (!legacyDirectory) return;
+
+  const names = host === "factory"
+    ? ["factory.db", "factory.db-wal", "factory.db-shm"]
+    : [
+        "settings.json",
+        "mastra.db",
+        "mastra.db-wal",
+        "mastra.db-shm",
+        "mastra-vectors.db",
+        "mastra-vectors.db-wal",
+        "mastra-vectors.db-shm",
+        "observability.duckdb",
+      ];
+  const legacyEntries = await directoryEntries(legacyDirectory);
+  const destinationEntries = await directoryEntries(paths.directory);
+  const legacyData = names.filter(name => legacyEntries.has(name));
+  const destinationData = names.filter(name => destinationEntries.has(name));
+  if (legacyData.length === 0) return;
+  if (destinationData.length > 0) {
+    throw new Error(`Legacy and destination directories both contain local data for ${host}`);
+  }
+
+  await mkdir(paths.directory, { recursive: true, mode: 0o700 });
+  for (const name of legacyData) {
+    await rename(join(legacyDirectory, name), join(paths.directory, name));
+  }
+}
+
+async function directoryEntries(directory: string): Promise<Set<string>> {
+  try {
+    return new Set(await readdir(directory));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return new Set();
+    throw error;
+  }
 }
 
 function parseProfileApiKey(value: string | undefined): string | undefined {

--- a/packages/runtime-config/src/index.ts
+++ b/packages/runtime-config/src/index.ts
@@ -1,9 +1,12 @@
 export {
+  A1_PROXY_PROVIDER_ID,
+  A1_PROXY_PROVIDER_NAME,
   DEFAULT_ACTIVE_ALIAS,
   DEFAULT_MODEL_PROFILE_PATH,
   DEFAULT_OBSERVER_ALIAS,
   RUNTIME_DEFAULTS_VERSION,
   loadModelProfile,
+  getA1ProxyModelId,
   resolveAliasModelId,
   resolveObservationalMemoryThresholds,
   resolveProxyGatewayModelId,
@@ -14,8 +17,12 @@ export {
 } from "./profile.js";
 export {
   loadRuntimeConfig,
+  prepareHostDataDirectory,
+  resolveHostDataPaths,
+  type HostDataPaths,
   type ModelHostConfig,
   type RuntimeConfig,
   type RuntimeMode,
+  type ToolkitHostId,
 } from "./environment.js";
 export { ProxyGateway, type ProxyGatewayConfig } from "./proxy-gateway.js";

--- a/packages/runtime-config/src/profile.ts
+++ b/packages/runtime-config/src/profile.ts
@@ -4,6 +4,8 @@ import { parse } from "yaml";
 import { z } from "zod";
 
 export const DEFAULT_ACTIVE_ALIAS = "code-frontier-high";
+export const A1_PROXY_PROVIDER_ID = "a1-proxy";
+export const A1_PROXY_PROVIDER_NAME = "A1 Proxy";
 export const DEFAULT_OBSERVER_ALIAS = "code-workhorse-high";
 export const DEFAULT_MODEL_PROFILE_PATH = createRequire(import.meta.url).resolve("@rlabs/runtime-config/models.yaml");
 
@@ -105,6 +107,10 @@ export function resolveAliasModelId(profile: ModelProfile, alias: string): strin
 
 export function resolveProxyGatewayModelId(profile: ModelProfile, alias: string): string {
   return `proxy/${resolveAliasModelId(profile, alias)}`;
+}
+
+export function getA1ProxyModelId(model: string): string {
+  return `${A1_PROXY_PROVIDER_ID}/${model.replace(/^a1-proxy\//, "")}`;
 }
 
 export function resolveRuntimeDefaultsV1(profile: ModelProfile): RuntimeDefaultsV1 {

--- a/packages/runtime-config/test/environment.test.ts
+++ b/packages/runtime-config/test/environment.test.ts
@@ -1,5 +1,12 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
-import { loadRuntimeConfig } from "../src/index.js";
+import {
+  loadRuntimeConfig,
+  prepareHostDataDirectory,
+  resolveHostDataPaths,
+} from "../src/index.js";
 
 describe("loadRuntimeConfig", () => {
   test("uses standalone A1 proxy defaults without resolving a secret", () => {
@@ -35,5 +42,44 @@ describe("loadRuntimeConfig", () => {
 
   test("rejects a model outside the package catalog", () => {
     expect(() => loadRuntimeConfig({ PROXY_MODEL: "gpt-5.6-sol" })).toThrow(/unknown model alias/i);
+  });
+});
+
+describe("host data", () => {
+  test("isolates MCode, Studio, and Factory below one toolkit root", () => {
+    const home = "/users/example";
+
+    expect(resolveHostDataPaths("mcode", {}, home)).toMatchObject({
+      directory: "/users/example/.mastra-toolkit/mcode",
+      databasePath: "/users/example/.mastra-toolkit/mcode/mastra.db",
+    });
+    expect(resolveHostDataPaths("studio", {}, home)).toMatchObject({
+      directory: "/users/example/.mastra-toolkit/studio",
+      databasePath: "/users/example/.mastra-toolkit/studio/mastra.db",
+    });
+    expect(resolveHostDataPaths("factory", {}, home)).toMatchObject({
+      directory: "/users/example/.mastra-toolkit/factory",
+      databasePath: "/users/example/.mastra-toolkit/factory/factory.db",
+    });
+  });
+
+  test("treats MASTRA_APP_DATA_DIR as an exact host directory override", () => {
+    expect(resolveHostDataPaths("factory", { MASTRA_APP_DATA_DIR: "/runtime/factory" }, "/ignored"))
+      .toMatchObject({ directory: "/runtime/factory", databasePath: "/runtime/factory/factory.db" });
+  });
+
+  test("moves a legacy database family once and rejects an ambiguous destination", async () => {
+    const home = await mkdtemp(join(tmpdir(), "mastra-toolkit-data-"));
+    const legacy = join(home, ".mastra-toolkit", "data");
+    await mkdir(legacy, { recursive: true });
+    await writeFile(join(legacy, "factory.db"), "database");
+    await writeFile(join(legacy, "factory.db-wal"), "wal");
+
+    const prepared = await prepareHostDataDirectory("factory", {}, home);
+    await expect(readFile(prepared.databasePath, "utf8")).resolves.toBe("database");
+    await expect(readFile(`${prepared.databasePath}-wal`, "utf8")).resolves.toBe("wal");
+
+    await writeFile(join(legacy, "factory.db"), "conflict");
+    await expect(prepareHostDataDirectory("factory", {}, home)).rejects.toThrow(/both contain local data/i);
   });
 });

--- a/test/workspace-structure.test.ts
+++ b/test/workspace-structure.test.ts
@@ -122,8 +122,8 @@ describe("workspace ownership", () => {
   test("keeps canonical Factory agents behind the sandbox-bound integration", async () => {
     const source = await readFile(join(root, "apps/factory/src/index.ts"), "utf8");
 
-    expect(source).toContain("createFactoryMcodeRecipe");
-    expect(source).toContain("createToolkitFactory(config, recipe, runtimeDefaults)");
+    expect(source).toContain("createFactoryAgentBundle");
+    expect(source).toContain("createToolkitFactory(config, agents, runtimeDefaults)");
     expect(source).toContain("models: runtimeDefaults.gateway.models");
     expect(source).toContain('process.once("SIGINT"');
     expect(source).toContain('process.once("SIGTERM"');
@@ -197,7 +197,7 @@ describe("workspace ownership", () => {
       await readTypeScriptTree(join(root, "packages/sandbox/src")),
     ].join("\n");
 
-    expect(factorySources).toContain('from "@rlabs/mcode"');
+    expect(factorySources).not.toContain('from "@rlabs/mcode"');
     expect(factorySources).not.toMatch(/from "@rlabs\/[^"/]+\//);
   });
 


### PR DESCRIPTION
## Summary

- move MCode, Studio, and Factory local state into isolated `~/.mastra-toolkit/<host>` directories with guarded legacy migration
- remove Factory→MCode coupling and compose branded canonical agent bundles directly
- make host shutdown explicit and failure-preserving
- declare the future GitHub Projects V2 control-plane boundary and executable browser/CUA validation gates

Refs rlabs88/agentics-mono#146
Wayfinder: rlabs88/agentics-mono#145

## Validation

- `npm run check`
- `npm run secrets:check`
- `npm run secrets:check:factory`
- `git diff --check`
- credential-pattern scan

Interactive browser/CUA flows are documented release gates and were not executed in this noninteractive implementation run.