### PR TITLE
Tolerate unavailable optional MCP servers during MCode startup

### DIFF
--- a/packages/mcode/src/project.ts
+++ b/packages/mcode/src/project.ts
@@ -18,11 +18,7 @@ export class CodeMcpAdapter implements McpLifecyclePort {
 
   async prepare(): Promise<PreparedMcpGeneration> {
     const candidate = this.#createCandidate();
-    const result = await candidate.initInBackground();
-    if (result.failed.length > 0) {
-      await candidate.disconnect();
-      throw new Error(`MCP candidate failed to connect: ${result.failed.map(server => server.name).join(", ")}`);
-    }
+    await candidate.initInBackground();
     const previous = this.#current;
     let committed = false;
     let rolledBack = false;

--- a/packages/mcode/test/mcp-adapter.test.ts
+++ b/packages/mcode/test/mcp-adapter.test.ts
@@ -31,16 +31,33 @@ describe("CodeMcpAdapter", () => {
     await adapter.close();
     expect(third.disconnects()).toBe(1);
   });
+
+  test("keeps connected MCP tools when an optional server fails", async () => {
+    const candidate = fakeManager({ surviving_tool: {} }, [{ name: "browseros" }]);
+    const adapter = new CodeMcpAdapter(() => candidate.manager);
+
+    const generation = await adapter.prepare();
+    await generation.commit();
+
+    expect(adapter.getTools()).toEqual({ surviving_tool: {} });
+    expect(candidate.disconnects()).toBe(0);
+
+    await adapter.close();
+    expect(candidate.disconnects()).toBe(1);
+  });
 });
 
-function fakeManager(tools: Record<string, unknown>): {
+function fakeManager(
+  tools: Record<string, unknown>,
+  failed: readonly { name: string }[] = [],
+): {
   manager: McpManager;
   disconnects(): number;
 } {
   let disconnectCount = 0;
   return {
     manager: {
-      initInBackground: async () => ({ connected: [], failed: [] }),
+      initInBackground: async () => ({ connected: [], failed, skipped: [], totalTools: Object.keys(tools).length }),
       getTools: () => tools,
       disconnect: async () => { disconnectCount += 1; },
     } as unknown as McpManager,


### PR DESCRIPTION
## Summary

- keep MCode startup alive when an optional MCP server fails to connect
- preserve tools from MCP servers that connected successfully
- add regression coverage for mixed connected/failed initialization

Closes #166

## Validation

- `npm test -- --run packages/mcode/test/mcp-adapter.test.ts`
- `npm run typecheck --workspace @rlabs/mcode`
- real `ax mcode` boot reached and remained in the Mastra Code TUI for the 20-second validation window
- `git diff --check`
