### PR TITLE
feat(agent-tools): durable dynamic_workflow orchestration tool

### DIFF
--- a/docs/repository-manifest.md
+++ b/docs/repository-manifest.md
@@ -5,7 +5,7 @@ This manifest is the routing table for changes. A package owns a reusable contra
 | Boundary | Owns | Consumes | Extensions belong here when… |
 | --- | --- | --- | --- |
 | `packages/runtime-config` | model profile, aliases, environment resolution, host data paths, proxy gateway | Mastra core, YAML, Zod | the change is host-neutral model or runtime configuration |
-| `packages/agent-tools` | Command Run language/scheduling contracts, ADHD, visible browser policy, tool audit hooks | Mastra core and Stagehand | a capability contract is reusable independent of role and host |
+| `packages/agent-tools` | Command Run language/scheduling contracts, ADHD, visible browser policy, tool audit hooks, the `dynamic_workflow` authoring contract | Mastra core and Stagehand | a capability contract is reusable independent of role and host |
 | `packages/agents-roles` | Cortex/Flux/Zen prompts, role metadata, agent factory | `agent-tools`, `runtime-config` | the canonical agent identity or policy changes |
 | `packages/sandbox` | sandbox schema/config, machine contract, Local/Docker/Platform adapters, executable `command_run` tool | Mastra sandbox providers and agent-tools command contracts | provider behavior or sandbox-contained execution changes |
 | `packages/project-mounting-manager` | specialist/workflow discovery, explicit publication, generations, watcher, transaction ports | Mastra core only | project resources must mount consistently across hosts |

--- a/docs/workspace-architecture.md
+++ b/docs/workspace-architecture.md
@@ -38,7 +38,7 @@ The eight package boundaries remain distinct, but their implementation is intent
 ```text
 packages/
 ├── runtime-config/src/{index,profile,environment,gateway}.ts
-├── agent-tools/src/{index,capabilities,command-run-contract,command-run}.ts
+├── agent-tools/src/{index,capabilities,command-run-contract,command-run,dynamic-workflow}.ts
 ├── agents-roles/src/{index,roles,prompts,agents}.ts
 ├── sandbox/src/{index,contract,machine,providers,command-run}.ts
 ├── project-mounting-manager/src/{index,contract,discovery,manager}.ts
@@ -71,7 +71,7 @@ project-mounting-manager  factory-github-projects
     apps/mcode      apps/studio  apps/factory
 ```
 
-`agents-roles` is the one source of role IDs, prompt composition, model policy, and Mastra agent factories. Its four deep modules group role policy, prompt policy, agent construction, and the public facade; Cortex, Flux, and Zen do not require one-file directories or public implementation subpaths. `agent-tools` owns the host-neutral Command Run language/scheduling contracts and browser capabilities; `sandbox` owns the executable `command_run` tool because execution requires an active sandbox workspace. Hosts project these packages; they do not copy them.
+`agents-roles` is the one source of role IDs, prompt composition, model policy, and Mastra agent factories. Its four deep modules group role policy, prompt policy, agent construction, and the public facade; Cortex, Flux, and Zen do not require one-file directories or public implementation subpaths. `agent-tools` owns the host-neutral Command Run language/scheduling contracts, browser capabilities, and the `dynamic_workflow` authoring contract; `sandbox` owns the executable `command_run` tool because execution requires an active sandbox workspace. `dynamic_workflow` stays in `agent-tools` because it crosses no containment boundary: it issues no command and touches no filesystem, and its agent and nested-workflow allowlists are injected by the host. Hosts project these packages; they do not copy them.
 
 `runtime-config` owns the secret-free YAML catalog, startup environment resolution, and host data paths. MCode, Studio, and Factory persist local state beneath `~/.mastra-toolkit/{mcode,studio,factory}` unless `MASTRA_APP_DATA_DIR` explicitly selects another host directory. `sandbox` owns the package-local runtime specification and the substitutable Local, Docker, and Platform machine adapters. No application-level aggregate configuration is canonical.
 

--- a/packages/agent-tools/AGENTS.md
+++ b/packages/agent-tools/AGENTS.md
@@ -29,6 +29,7 @@ src/
 ├── capabilities.ts        # ADHD, audit, and visible-browser policy
 ├── command-run-contract.ts # schemas, parsing, paths, and trace contract
 ├── command-run.ts          # scheduling and execution adapters
+├── dynamic-workflow.ts     # declarative graph authoring, ceilings, and durable run lifecycle
 └── index.ts                # sole TypeScript package facade
 ```
 
@@ -36,6 +37,8 @@ src/
 - Keep all supported TypeScript consumers on the package root. Do not restore implementation subpath exports.
 - Start a new role- and host-neutral capability inside `capabilities.ts` until it proves a deeper independent contract.
 - `command_run` and `adhd_run` are retained compatibility capabilities. Do not add new consumers or expand their DSL/fan-out scope; future replacement uses native Mastra workflows, task state, subagents, and background tasks after parity is proven.
+- `dynamic_workflow` accepts declarative graph data only. Do not add a source, script, expression, `eval`, or closure-carrying field, and do not admit `step` or unrestricted `tool` graph entries. Keep agent and nested-workflow allowlists injected by the host so this package owns no role or workflow identity.
+- Keep every dynamic-workflow ceiling enforced by rewriting the authored graph rather than trusting it, and keep authored definitions archived so discovery never grants execution authority.
 
 ## Change boundaries
 

--- a/packages/agent-tools/CONTEXT.md
+++ b/packages/agent-tools/CONTEXT.md
@@ -13,8 +13,12 @@ Command Run, ADHD exploration, browser policy, and tool audit behavior began und
 
 ## Present
 
-This private package exposes one root facade over three deep modules: host-neutral capabilities, the Command Run contract, and Command Run execution. It owns parsing, scheduling, approval, trace, and result behavior plus ADHD, visible-browser, and audit policies. The executable Command Run tool belongs to `packages/sandbox`, where execution requires a sandbox workspace. Role packages consume the root facade; Mastra Code and Factory behavior remain outside this boundary.
+This private package exposes one root facade over four deep modules: host-neutral capabilities, the Command Run contract, Command Run execution, and dynamic workflow authoring. It owns parsing, scheduling, approval, trace, and result behavior plus ADHD, visible-browser, and audit policies. The executable Command Run tool belongs to `packages/sandbox`, where execution requires a sandbox workspace. Role packages consume the root facade; Mastra Code and Factory behavior remain outside this boundary.
+
+`dynamic_workflow` earns its own module because it carries a versioned authoring schema, a retention policy over persisted definitions, an action-dependent approval predicate, and a content-addressed audit identity — four lifecycles that change independently of the capabilities module. It accepts a declarative graph rather than source, so nothing it admits is executable in its own right; the host injects which agents and nested workflows a graph may reference. Authored definitions are archived immediately because only active definitions load at `startWorkers()`, and discovery must never grant execution authority.
 
 ## Future
 
 Hosts may add tools through their own adapters, while the guarded execution and approval semantics here remain stable. New capability families should join this package only when they are role-independent and have package-local containment and failure contracts.
+
+`dynamic_workflow` is the sanctioned replacement path for `adhd_run` fan-out. Retirement waits until a parity contract test covers bounded concurrency, index-stable ordering, retained-output limits, and the depth guard, and until the approval and read-only differences between the two are deliberately resolved rather than dropped.

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -1,0 +1,737 @@
+import { RequestContext } from "@mastra/core/request-context";
+import { createTool } from "@mastra/core/tools";
+import type { Workspace } from "@mastra/core/workspace";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * Marks a dispatched run so a delegated agent cannot author another graph.
+ * Mirrors `adhdDepth`: the check lives inside `execute`, which is the only
+ * layer that also covers native subagent leaves and project specialists —
+ * both are freshly constructed agents with neither tool hooks nor a dynamic
+ * tool resolver.
+ */
+export const DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY = "dynamicWorkflowDepth";
+
+/** Stamped on every definition this tool persists so boot reconciliation can find them. */
+export const DYNAMIC_WORKFLOW_ORIGIN = "dynamic_workflow";
+
+const DYNAMIC_WORKFLOW_ID_PATTERN = /^dyn_[0-9a-f]{16}$/;
+
+const MAX_GRAPH_ENTRIES = 16;
+const MAX_FAN_OUT = 8;
+const MAX_CONCURRENCY = 3;
+const MAX_NESTING_DEPTH = 2;
+const MAX_SLEEP_MS = 60_000;
+const MAX_ROW_CHARS = 2_000;
+const MAX_RETAINED_CHARS = 24_000;
+
+const identifier = z.string().min(1).max(64).regex(/^[A-Za-z0-9_-]+$/);
+const jsonSchemaObject = z.record(z.string(), z.unknown());
+
+const stepOptionsSchema = z.object({
+  retries: z.number().int().min(0).max(3).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+const agentEntrySchema = z.object({
+  type: z.literal("agent"),
+  id: identifier,
+  agentId: z.string().min(1).max(64),
+  description: z.string().max(400).optional(),
+  outputSchema: jsonSchemaObject.optional(),
+  options: stepOptionsSchema.optional(),
+}).strict();
+
+const mappingEntrySchema = z.object({
+  type: z.literal("mapping"),
+  id: identifier,
+  mapConfig: z.string().min(1).max(8_000),
+}).strict();
+
+const workflowEntrySchema = z.object({
+  type: z.literal("workflow"),
+  id: identifier,
+  workflowId: z.string().min(1).max(128),
+  description: z.string().max(400).optional(),
+}).strict();
+
+const sleepEntrySchema = z.object({
+  type: z.literal("sleep"),
+  id: identifier,
+  duration: z.number().int().min(1).max(MAX_SLEEP_MS),
+}).strict();
+
+/** Suspension inside `foreach` wedges on the second resume, so fan-out bodies are agents only. */
+const foreachEntrySchema = z.object({
+  type: z.literal("foreach"),
+  step: agentEntrySchema,
+  opts: z.object({ concurrency: z.number().int().min(1) }).strict().optional(),
+}).strict();
+
+/** `.parallel` is an unbounded `Promise.all`, so width is the only available cap. */
+const parallelEntrySchema = z.object({
+  type: z.literal("parallel"),
+  steps: z.array(agentEntrySchema).min(1).max(MAX_CONCURRENCY),
+}).strict();
+
+const suspendableInnerSchema = z.discriminatedUnion("type", [agentEntrySchema, workflowEntrySchema]);
+
+const conditionalEntrySchema = z.object({
+  type: z.literal("conditional"),
+  steps: z.array(suspendableInnerSchema).min(1).max(MAX_CONCURRENCY),
+  // Predicates are upstream's declarative language; `assertValidStoredWorkflow` is their authority.
+  predicates: z.array(z.unknown()).min(1),
+}).strict();
+
+const loopEntrySchema = z.object({
+  type: z.literal("loop"),
+  step: suspendableInnerSchema,
+  loopType: z.enum(["dowhile", "dountil"]),
+  predicate: z.unknown(),
+}).strict();
+
+const graphEntrySchema = z.discriminatedUnion("type", [
+  agentEntrySchema,
+  mappingEntrySchema,
+  workflowEntrySchema,
+  sleepEntrySchema,
+  foreachEntrySchema,
+  parallelEntrySchema,
+  conditionalEntrySchema,
+  loopEntrySchema,
+]);
+
+export type DynamicWorkflowGraphEntry = z.infer<typeof graphEntrySchema>;
+
+const definitionSchema = z.object({
+  description: z.string().min(1).max(2_000).optional(),
+  inputSchema: jsonSchemaObject,
+  outputSchema: jsonSchemaObject,
+  stateSchema: jsonSchemaObject.optional(),
+  graph: z.array(graphEntrySchema).min(1).max(MAX_GRAPH_ENTRIES),
+}).strict();
+
+export type DynamicWorkflowDefinition = z.infer<typeof definitionSchema>;
+
+const singleLine = z.string().min(1).max(400).regex(/^[^\r\n]+$/);
+
+const inputSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("run"),
+    description: singleLine.describe("Single-line label shown in the approval prompt and the audit trace."),
+    definition: definitionSchema.describe(
+      "A Mastra workflow graph as data. Agents and nested workflows are referenced by id and resolved against this runtime.",
+    ),
+    input: z.unknown().default({}).describe("Validated at run time against the definition's own inputSchema."),
+    timeoutMs: z.number().int().min(1_000).max(600_000).default(300_000),
+    dryRun: z.boolean().default(false).describe("Validate and content-address only. No approval, no execution, no persistence."),
+  }).strict(),
+  z.object({
+    action: z.literal("resume"),
+    description: singleLine,
+    workflowId: z.string().regex(DYNAMIC_WORKFLOW_ID_PATTERN),
+    runId: z.string().min(1).max(200),
+    step: z.array(z.string().min(1)).min(1).max(8).optional(),
+    resumeData: z.unknown().default({}),
+    timeoutMs: z.number().int().min(1_000).max(600_000).default(300_000),
+  }).strict(),
+  z.object({
+    action: z.literal("inspect"),
+    workflowId: z.string().regex(DYNAMIC_WORKFLOW_ID_PATTERN).optional(),
+    runId: z.string().min(1).max(200).optional(),
+  }).strict(),
+]);
+
+const outputSchema = z.object({
+  version: z.literal(1),
+  action: z.enum(["run", "resume", "inspect"]),
+  workflowId: z.string().optional(),
+  graphDigest: z.string().optional(),
+  runId: z.string().optional(),
+  status: z.enum([
+    "validated", "pending", "running", "success", "failed",
+    "suspended", "waiting", "canceled", "invalid",
+  ]).optional(),
+  output: z.unknown().optional(),
+  error: z.string().max(2_000).optional(),
+  issues: z.array(z.string().max(600)).max(24).optional(),
+  suspended: z.array(z.object({ path: z.array(z.string()) }).passthrough()).max(8).optional(),
+  steps: z.array(z.object({ id: z.string(), status: z.string() }).passthrough()).max(32).optional(),
+  runs: z.array(z.object({
+    workflowId: z.string(),
+    runId: z.string(),
+    status: z.string(),
+  }).passthrough()).max(20).optional(),
+  resumable: z.boolean(),
+  truncated: z.boolean(),
+}).strict();
+
+export interface DynamicWorkflowAuthorizationContext {
+  readonly requestContext: RequestContext;
+  readonly workspace?: Workspace;
+}
+
+export interface DynamicWorkflowToolOptions {
+  /** Agent ids a graph may dispatch. Injected so this package stays role-neutral. */
+  readonly agents: readonly string[];
+  /** Registered workflow ids a graph may nest. Nested workflows are the only route to a human gate. */
+  readonly nestedWorkflows?: readonly string[];
+  readonly authorize?: (context: DynamicWorkflowAuthorizationContext) => Promise<void> | void;
+  /** Factory has no stable workspace across a resume, so it opts out. */
+  readonly resumable?: boolean;
+}
+
+/** Structural view of the host runtime, so this package depends on no host type. */
+interface DynamicWorkflowHost {
+  addStoredWorkflow(definition: unknown): Promise<void>;
+  getWorkflow(id: string): unknown;
+  removeWorkflow?(id: string): boolean;
+  getStorage?(): unknown;
+}
+
+interface WorkflowDefinitionRow {
+  readonly id: string;
+  readonly metadata?: Record<string, unknown>;
+  readonly inputSchema: unknown;
+  readonly outputSchema: unknown;
+  readonly stateSchema?: unknown;
+  readonly graph: unknown;
+  readonly description?: string;
+}
+
+interface WorkflowDefinitionsStore {
+  upsert(input: Record<string, unknown>): Promise<unknown>;
+  get(id: string): Promise<WorkflowDefinitionRow | null>;
+  list(args?: { status?: "active" | "archived" }): Promise<{ definitions: WorkflowDefinitionRow[] }>;
+}
+
+/**
+ * Registration is refcounted because the id is content-addressed: two turns
+ * submitting the same graph share one id, so unregistering in a `finally`
+ * would tear down a registration another in-flight run still depends on.
+ */
+const registrations = new WeakMap<object, Map<string, number>>();
+
+export function createDynamicWorkflowTool(options: DynamicWorkflowToolOptions) {
+  const allowedAgents = new Set(options.agents);
+  const allowedWorkflows = new Set(options.nestedWorkflows ?? []);
+  const resumable = options.resumable ?? true;
+
+  return createTool({
+    id: "dynamic_workflow",
+    description:
+      "Author a Mastra workflow as a declarative graph and run it durably to orchestrate other agents. "
+      + "Agents and nested workflows are referenced by id. Use dryRun to validate a graph for free before "
+      + "spending an approval; validation issues come back precise enough to repair. Runs are durable: keep "
+      + "workflowId and runId to resume a suspended run.",
+    inputSchema,
+    outputSchema,
+    requireApproval: input =>
+      input.action === "run" ? !input.dryRun : input.action === "resume",
+    background: { enabled: true, timeoutMs: 600_000 },
+    mcp: {
+      annotations: {
+        title: "Dynamic Workflow",
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+    },
+    execute: async (input, context) => {
+      if (context.requestContext.get(DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY) === 1) {
+        throw new Error("Nested dynamic_workflow calls are not allowed");
+      }
+      await options.authorize?.({
+        requestContext: context.requestContext,
+        ...(context.workspace ? { workspace: context.workspace } : {}),
+      });
+      const host = context.mastra as unknown as DynamicWorkflowHost | undefined;
+      if (!host?.addStoredWorkflow) throw new Error("dynamic_workflow requires an active Mastra runtime");
+
+      if (input.action === "inspect") return inspect(host, input);
+      if (input.action === "resume") {
+        if (!resumable) {
+          return fail("resume", "This host does not support resuming a dynamic workflow run");
+        }
+        return resume(host, input, context);
+      }
+
+      const prepared = prepare(input.definition, allowedAgents, allowedWorkflows);
+      if (!prepared.ok) {
+        return {
+          version: 1 as const,
+          action: "run" as const,
+          status: "invalid" as const,
+          issues: prepared.issues.slice(0, 24),
+          resumable: false,
+          truncated: false,
+        };
+      }
+      if (input.dryRun) {
+        return {
+          version: 1 as const,
+          action: "run" as const,
+          workflowId: prepared.workflowId,
+          graphDigest: prepared.digest,
+          status: "validated" as const,
+          resumable: false,
+          truncated: false,
+        };
+      }
+      return run(host, prepared, input, context);
+    },
+  });
+}
+
+/**
+ * Archives every definition this tool left active, so a crash between the
+ * create and archive writes cannot leave a model-authored graph auto-mounting
+ * at `startWorkers()`. Idempotent; a no-op on the happy path.
+ */
+export async function reconcileDynamicWorkflowDefinitions(mastra: unknown): Promise<number> {
+  const store = await definitionsStore(mastra as DynamicWorkflowHost);
+  if (!store) return 0;
+  const { definitions } = await store.list({ status: "active" });
+  let archived = 0;
+  for (const definition of definitions) {
+    if (definition.metadata?.origin !== DYNAMIC_WORKFLOW_ORIGIN) continue;
+    await store.upsert({ id: definition.id, status: "archived" });
+    (mastra as DynamicWorkflowHost).removeWorkflow?.(definition.id);
+    archived += 1;
+  }
+  return archived;
+}
+
+interface PreparedDefinition {
+  readonly ok: true;
+  readonly workflowId: string;
+  readonly digest: string;
+  readonly stored: Record<string, unknown>;
+}
+
+type PrepareResult = PreparedDefinition | { readonly ok: false; readonly issues: string[] };
+
+function prepare(
+  definition: DynamicWorkflowDefinition,
+  allowedAgents: ReadonlySet<string>,
+  allowedWorkflows: ReadonlySet<string>,
+): PrepareResult {
+  const issues: string[] = [];
+  const ids = new Set<string>();
+  definition.graph.forEach((entry, index) => {
+    checkEntry(entry, `graph.${index}`, 0, { allowedAgents, allowedWorkflows, ids, issues, topLevel: true });
+  });
+  if (issues.length > 0) return { ok: false, issues };
+
+  const graph = definition.graph.map(clampEntry);
+  const inputSchema = boundArraySchema(definition.inputSchema);
+  const outputSchema = boundArraySchema(definition.outputSchema);
+  const digest = createHash("sha256")
+    .update(canonicalJson({ inputSchema, outputSchema, stateSchema: definition.stateSchema, graph }))
+    .digest("hex");
+  const workflowId = `dyn_${digest.slice(0, 16)}`;
+  return {
+    ok: true,
+    workflowId,
+    digest: `sha256:${digest}`,
+    stored: {
+      id: workflowId,
+      inputSchema,
+      outputSchema,
+      ...(definition.stateSchema ? { stateSchema: definition.stateSchema } : {}),
+      graph,
+      ...(definition.description ? { description: definition.description } : {}),
+      metadata: { origin: DYNAMIC_WORKFLOW_ORIGIN, graphDigest: `sha256:${digest}` },
+    },
+  };
+}
+
+interface CheckContext {
+  readonly allowedAgents: ReadonlySet<string>;
+  readonly allowedWorkflows: ReadonlySet<string>;
+  readonly ids: Set<string>;
+  readonly issues: string[];
+  readonly topLevel: boolean;
+}
+
+function checkEntry(entry: DynamicWorkflowGraphEntry, path: string, depth: number, check: CheckContext): void {
+  if (depth > MAX_NESTING_DEPTH) {
+    check.issues.push(`${path}: container nesting exceeds depth ${MAX_NESTING_DEPTH}`);
+    return;
+  }
+  switch (entry.type) {
+    case "agent":
+      claimId(entry.id, path, check);
+      if (!check.allowedAgents.has(entry.agentId)) {
+        check.issues.push(
+          `${path}.agentId: unknown agent "${entry.agentId}". Allowed: ${[...check.allowedAgents].join(", ")}`,
+        );
+      }
+      return;
+    case "mapping":
+    case "sleep":
+      claimId(entry.id, path, check);
+      return;
+    case "workflow":
+      claimId(entry.id, path, check);
+      if (!check.allowedWorkflows.has(entry.workflowId)) {
+        check.issues.push(
+          `${path}.workflowId: nested workflow "${entry.workflowId}" is not allowlisted for dynamic use`,
+        );
+      }
+      if (!check.topLevel && depth > 0) {
+        check.issues.push(`${path}: a nested workflow may only appear at the top level or as a loop body`);
+      }
+      return;
+    case "foreach":
+      checkEntry(entry.step, `${path}.step`, depth + 1, { ...check, topLevel: false });
+      return;
+    case "parallel":
+      entry.steps.forEach((step, index) =>
+        checkEntry(step, `${path}.steps.${index}`, depth + 1, { ...check, topLevel: false }));
+      return;
+    case "conditional":
+      if (entry.predicates.length !== entry.steps.length) {
+        check.issues.push(`${path}: predicates must align one-to-one with steps`);
+      }
+      entry.steps.forEach((step, index) =>
+        checkEntry(step, `${path}.steps.${index}`, depth + 1, { ...check, topLevel: false }));
+      return;
+    case "loop":
+      checkEntry(entry.step, `${path}.step`, depth + 1, { ...check, topLevel: true });
+      return;
+  }
+}
+
+function claimId(id: string, path: string, check: CheckContext): void {
+  if (check.ids.has(id)) check.issues.push(`${path}.id: duplicate step id "${id}"`);
+  check.ids.add(id);
+}
+
+/** Concurrency is rewritten rather than rejected: the ceiling is ours, never the author's. */
+function clampEntry(entry: DynamicWorkflowGraphEntry): DynamicWorkflowGraphEntry {
+  if (entry.type === "foreach") {
+    const concurrency = Math.min(entry.opts?.concurrency ?? 1, MAX_CONCURRENCY);
+    return { ...entry, step: clampAgent(entry.step), opts: { concurrency } };
+  }
+  if (entry.type === "parallel") return { ...entry, steps: entry.steps.map(clampAgent) };
+  if (entry.type === "conditional") {
+    return { ...entry, steps: entry.steps.map(step => step.type === "agent" ? clampAgent(step) : step) };
+  }
+  if (entry.type === "loop" && entry.step.type === "agent") {
+    return { ...entry, step: clampAgent(entry.step) };
+  }
+  if (entry.type === "agent") return clampAgent(entry);
+  return entry;
+}
+
+function clampAgent(entry: z.infer<typeof agentEntrySchema>): z.infer<typeof agentEntrySchema> {
+  if (!entry.outputSchema) return entry;
+  return { ...entry, outputSchema: boundArraySchema(entry.outputSchema) as Record<string, unknown> };
+}
+
+/**
+ * A `maxItems` ceiling on every array schema is the only static bound on
+ * fan-out width, and `jsonSchemaToZod` enforces it at run time.
+ */
+function boundArraySchema(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) return schema.map(boundArraySchema);
+  const record = schema as Record<string, unknown>;
+  const mapped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) mapped[key] = boundArraySchema(value);
+  if (record.type !== "array") return mapped;
+  const declared = typeof record.maxItems === "number" ? record.maxItems : MAX_FAN_OUT;
+  return { ...mapped, maxItems: Math.min(declared, MAX_FAN_OUT) };
+}
+
+async function run(
+  host: DynamicWorkflowHost,
+  prepared: PreparedDefinition,
+  input: { description: string; input: unknown; timeoutMs: number },
+  context: ToolContext,
+): Promise<Output> {
+  try {
+    await register(host, prepared.workflowId, prepared.stored);
+  } catch (error) {
+    return {
+      version: 1 as const,
+      action: "run" as const,
+      workflowId: prepared.workflowId,
+      graphDigest: prepared.digest,
+      status: "invalid" as const,
+      issues: validationIssues(error),
+      resumable: false,
+      truncated: false,
+    };
+  }
+  try {
+    const workflow = host.getWorkflow(prepared.workflowId) as WorkflowHandle;
+    const workflowRun = await workflow.createRun();
+    return await execute(
+      () => workflowRun.start({
+        inputData: input.input,
+        requestContext: dispatchContext(context.requestContext),
+        ...writerBridge(context),
+      }),
+      workflowRun,
+      { action: "run", workflowId: prepared.workflowId, digest: prepared.digest, timeoutMs: input.timeoutMs },
+      context,
+    );
+  } finally {
+    await unregister(host, prepared.workflowId);
+  }
+}
+
+async function resume(
+  host: DynamicWorkflowHost,
+  input: {
+    workflowId: string;
+    runId: string;
+    step?: string[] | undefined;
+    resumeData: unknown;
+    timeoutMs: number;
+  },
+  context: ToolContext,
+): Promise<Output> {
+  const store = await definitionsStore(host);
+  if (!store) return fail("resume", "This runtime has no workflow definition storage");
+  const definition = await store.get(input.workflowId);
+  if (!definition) return fail("resume", `No stored definition for ${input.workflowId}`);
+  await register(host, input.workflowId, toStoredInput(definition));
+  try {
+    const workflow = host.getWorkflow(input.workflowId) as WorkflowHandle;
+    const workflowRun = await workflow.createRun({ runId: input.runId });
+    return await execute(
+      () => workflowRun.resume({
+        ...(input.step ? { step: input.step } : {}),
+        resumeData: input.resumeData,
+        requestContext: dispatchContext(context.requestContext),
+        ...writerBridge(context),
+      }),
+      workflowRun,
+      { action: "resume", workflowId: input.workflowId, timeoutMs: input.timeoutMs },
+      context,
+    );
+  } finally {
+    await unregister(host, input.workflowId);
+  }
+}
+
+async function inspect(
+  host: DynamicWorkflowHost,
+  input: { workflowId?: string | undefined; runId?: string | undefined },
+): Promise<Output> {
+  const store = await definitionsStore(host);
+  if (!store) return { version: 1 as const, action: "inspect" as const, runs: [], resumable: false, truncated: false };
+  const { definitions } = await store.list({ status: "archived" });
+  const runs = definitions
+    .filter(definition => definition.metadata?.origin === DYNAMIC_WORKFLOW_ORIGIN)
+    .filter(definition => !input.workflowId || definition.id === input.workflowId)
+    .slice(0, 20)
+    .map(definition => ({ workflowId: definition.id, runId: "", status: "stored" }));
+  return { version: 1 as const, action: "inspect" as const, runs, resumable: false, truncated: false };
+}
+
+interface RunMeta {
+  readonly action: "run" | "resume";
+  readonly workflowId: string;
+  readonly digest?: string;
+  readonly timeoutMs: number;
+}
+
+async function execute(
+  start: () => Promise<WorkflowResultLike>,
+  workflowRun: RunHandle,
+  meta: RunMeta,
+  context: ToolContext,
+): Promise<Output> {
+  const timeout = AbortSignal.timeout(meta.timeoutMs);
+  const signal = context.abortSignal ? AbortSignal.any([context.abortSignal, timeout]) : timeout;
+  const cancel = () => { void workflowRun.cancel().catch(() => undefined); };
+  signal.addEventListener("abort", cancel, { once: true });
+  try {
+    const result = await start();
+    const bounded = boundSteps(result.steps);
+    return {
+      version: 1 as const,
+      action: meta.action,
+      workflowId: meta.workflowId,
+      ...(meta.digest ? { graphDigest: meta.digest } : {}),
+      runId: workflowRun.runId,
+      status: result.status as Output["status"],
+      ...(result.result === undefined ? {} : { output: result.result }),
+      ...(result.error ? { error: String(result.error.message ?? result.error).slice(0, 2_000) } : {}),
+      ...(result.suspended ? { suspended: result.suspended.map(path => ({ path })).slice(0, 8) } : {}),
+      steps: bounded.steps,
+      resumable: result.status === "suspended",
+      truncated: bounded.truncated,
+    };
+  } catch (error) {
+    return {
+      version: 1 as const,
+      action: meta.action,
+      workflowId: meta.workflowId,
+      runId: workflowRun.runId,
+      status: "failed" as const,
+      error: message(error).slice(0, 2_000),
+      resumable: false,
+      truncated: false,
+    };
+  } finally {
+    signal.removeEventListener("abort", cancel);
+  }
+}
+
+/**
+ * A narrowed, JSON-safe context. The workspace and run-budget keys are
+ * deliberately withheld: `RequestContext.toJSON()` persists a live Workspace
+ * as a method-less husk that then wins over the real workspace on resume.
+ * Dispatched agents fall through to the runtime's own workspace instead.
+ */
+function dispatchContext(parent: RequestContext): RequestContext {
+  const dispatch = new RequestContext();
+  dispatch.set(DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY, 1);
+  const workspaceRoot = parent.get("workspaceRoot");
+  if (typeof workspaceRoot === "string") dispatch.set("workspaceRoot", workspaceRoot);
+  return dispatch;
+}
+
+function writerBridge(context: ToolContext): { outputWriter?: (chunk: unknown) => Promise<void> } {
+  if (!context.writer) return {};
+  const writer = context.writer;
+  return { outputWriter: async chunk => { await writer.write(chunk); } };
+}
+
+async function register(host: DynamicWorkflowHost, id: string, stored: Record<string, unknown>): Promise<void> {
+  const counts = registrations.get(host) ?? new Map<string, number>();
+  registrations.set(host, counts);
+  const current = counts.get(id) ?? 0;
+  if (current === 0) {
+    await host.addStoredWorkflow(stored);
+    // `addStoredWorkflow` persists as active, and only active rows load at
+    // startWorkers(). Archive immediately so discovery never grants authority.
+    const store = await definitionsStore(host);
+    await store?.upsert({ id, status: "archived" });
+  }
+  counts.set(id, current + 1);
+}
+
+async function unregister(host: DynamicWorkflowHost, id: string): Promise<void> {
+  const counts = registrations.get(host);
+  if (!counts) return;
+  const next = (counts.get(id) ?? 1) - 1;
+  if (next > 0) {
+    counts.set(id, next);
+    return;
+  }
+  counts.delete(id);
+  host.removeWorkflow?.(id);
+}
+
+async function definitionsStore(host: DynamicWorkflowHost): Promise<WorkflowDefinitionsStore | undefined> {
+  const storage = host.getStorage?.() as { getStore?: (name: string) => unknown } | undefined;
+  if (!storage?.getStore) return undefined;
+  const store = await storage.getStore("workflowDefinitions") as WorkflowDefinitionsStore | undefined;
+  return store?.upsert ? store : undefined;
+}
+
+function toStoredInput(definition: WorkflowDefinitionRow): Record<string, unknown> {
+  return {
+    id: definition.id,
+    inputSchema: definition.inputSchema,
+    outputSchema: definition.outputSchema,
+    ...(definition.stateSchema ? { stateSchema: definition.stateSchema } : {}),
+    graph: definition.graph,
+    ...(definition.description ? { description: definition.description } : {}),
+    metadata: definition.metadata ?? { origin: DYNAMIC_WORKFLOW_ORIGIN },
+  };
+}
+
+/** Upstream reports every graph problem at once; that list is the repair loop. */
+function validationIssues(error: unknown): string[] {
+  return message(error)
+    .split("\n")
+    .map(line => line.replace(/^-\s*/, "").trim())
+    .filter(line => line.length > 0 && !line.startsWith("Stored workflow"))
+    .slice(0, 24)
+    .map(line => line.slice(0, 600));
+}
+
+function boundSteps(steps: unknown): { steps: Array<{ id: string; status: string }>; truncated: boolean } {
+  if (!steps || typeof steps !== "object") return { steps: [], truncated: false };
+  let remaining = MAX_RETAINED_CHARS;
+  let truncated = false;
+  const bounded: Array<{ id: string; status: string }> = [];
+  for (const [id, value] of Object.entries(steps as Record<string, unknown>).slice(0, 32)) {
+    const record = (value ?? {}) as { status?: unknown; output?: unknown };
+    const serialized = record.output === undefined ? "" : safeJson(record.output);
+    const budget = Math.min(MAX_ROW_CHARS, Math.max(0, remaining));
+    const output = serialized.length > budget ? `${serialized.slice(0, Math.max(0, budget - 1))}…` : serialized;
+    if (output.length < serialized.length) truncated = true;
+    remaining -= output.length;
+    bounded.push({
+      id,
+      status: typeof record.status === "string" ? record.status : "unknown",
+      ...(output ? { output } : {}),
+    });
+  }
+  return { steps: bounded, truncated };
+}
+
+function fail(action: "run" | "resume", error: string): Output {
+  return { version: 1 as const, action, status: "failed" as const, error, resumable: false, truncated: false };
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}
+
+/** Key-sorted so an identical graph always yields an identical digest. */
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+type Output = z.infer<typeof outputSchema>;
+
+interface ToolContext {
+  readonly requestContext: RequestContext;
+  readonly abortSignal?: AbortSignal;
+  readonly writer?: { write(chunk: unknown): Promise<void> };
+}
+
+interface WorkflowHandle {
+  createRun(options?: { runId?: string }): Promise<RunHandle>;
+}
+
+interface RunHandle {
+  readonly runId: string;
+  start(options: Record<string, unknown>): Promise<WorkflowResultLike>;
+  resume(options: Record<string, unknown>): Promise<WorkflowResultLike>;
+  cancel(): Promise<void>;
+}
+
+interface WorkflowResultLike {
+  readonly status: string;
+  readonly result?: unknown;
+  readonly error?: { message?: string };
+  readonly suspended?: string[][];
+  readonly steps?: unknown;
+}

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./capabilities.js";
 export * from "./command-run-contract.js";
 export * from "./command-run.js";
+export * from "./dynamic-workflow.js";

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -1,0 +1,263 @@
+import { Agent } from "@mastra/core/agent";
+import { Mastra } from "@mastra/core/mastra";
+import { RequestContext } from "@mastra/core/request-context";
+import { InMemoryStore } from "@mastra/core/storage";
+import { createStep, createWorkflow } from "@mastra/core/workflows";
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import {
+  createDynamicWorkflowTool,
+  DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY,
+  DYNAMIC_WORKFLOW_ORIGIN,
+  reconcileDynamicWorkflowDefinitions,
+} from "../src/index.js";
+
+const helper = createWorkflow({
+  id: "helper",
+  inputSchema: z.object({ task: z.string() }),
+  outputSchema: z.object({ done: z.string() }),
+}).then(createStep({
+  id: "run-helper",
+  inputSchema: z.object({ task: z.string() }),
+  outputSchema: z.object({ done: z.string() }),
+  execute: async ({ inputData }) => ({ done: `handled:${inputData.task}` }),
+})).commit();
+
+function harness() {
+  const mastra = new Mastra({
+    agents: {
+      flux: new Agent({ id: "flux", name: "flux", instructions: "test", model: "openai/gpt-4o-mini" }),
+    },
+    workflows: { helper },
+    storage: new InMemoryStore(),
+    logger: false as never,
+  });
+  const tool = createDynamicWorkflowTool({ agents: ["flux"], nestedWorkflows: ["helper"] });
+  const invoke = (input: unknown, requestContext = new RequestContext()) =>
+    (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute(input, { mastra, requestContext });
+  return { mastra, tool, invoke };
+}
+
+const objectSchema = { type: "object", properties: { task: { type: "string" } }, required: ["task"] };
+const doneSchema = { type: "object", properties: { done: { type: "string" } }, required: ["done"] };
+
+const nestedGraph = {
+  inputSchema: objectSchema,
+  outputSchema: doneSchema,
+  graph: [{ type: "workflow", id: "h", workflowId: "helper" }],
+};
+
+describe("dynamic_workflow", () => {
+  test("requires approval to run or resume but not to validate or inspect", () => {
+    const { tool } = harness();
+    const requireApproval = (tool as unknown as {
+      requireApproval: (input: unknown) => boolean;
+    }).requireApproval;
+
+    expect(requireApproval({ action: "run", dryRun: false })).toBe(true);
+    expect(requireApproval({ action: "run", dryRun: true })).toBe(false);
+    expect(requireApproval({ action: "resume" })).toBe(true);
+    expect(requireApproval({ action: "inspect" })).toBe(false);
+  });
+
+  test("derives a content-addressed id so an identical graph is idempotent", async () => {
+    const { invoke } = harness();
+
+    const first = await invoke({ action: "run", description: "d", definition: nestedGraph, input: {}, dryRun: true, timeoutMs: 1_000 });
+    const again = await invoke({ action: "run", description: "d", definition: nestedGraph, input: {}, dryRun: true, timeoutMs: 1_000 });
+    const other = await invoke({
+      action: "run",
+      description: "d",
+      dryRun: true,
+      timeoutMs: 1_000,
+      input: {},
+      definition: { ...nestedGraph, graph: [{ type: "workflow", id: "different", workflowId: "helper" }] },
+    });
+
+    expect(first.status).toBe("validated");
+    expect(first.workflowId).toMatch(/^dyn_[0-9a-f]{16}$/);
+    expect(again.workflowId).toBe(first.workflowId);
+    expect(other.workflowId).not.toBe(first.workflowId);
+  });
+
+  test("rejects an agent outside the injected allowlist", async () => {
+    const { invoke } = harness();
+
+    const result = await invoke({
+      action: "run",
+      description: "d",
+      dryRun: true,
+      timeoutMs: 1_000,
+      input: {},
+      definition: { ...nestedGraph, graph: [{ type: "agent", id: "a", agentId: "cortex" }] },
+    });
+
+    expect(result.status).toBe("invalid");
+    expect((result.issues as string[]).join(" ")).toContain('unknown agent "cortex"');
+  });
+
+  test("rejects a nested workflow outside the injected allowlist", async () => {
+    const { invoke } = harness();
+
+    const result = await invoke({
+      action: "run",
+      description: "d",
+      dryRun: true,
+      timeoutMs: 1_000,
+      input: {},
+      definition: { ...nestedGraph, graph: [{ type: "workflow", id: "x", workflowId: "helper-2" }] },
+    });
+
+    expect(result.status).toBe("invalid");
+    expect((result.issues as string[]).join(" ")).toContain("not allowlisted");
+  });
+
+  test("rejects duplicate step ids", async () => {
+    const { invoke } = harness();
+
+    const result = await invoke({
+      action: "run",
+      description: "d",
+      dryRun: true,
+      timeoutMs: 1_000,
+      input: {},
+      definition: {
+        ...nestedGraph,
+        graph: [
+          { type: "agent", id: "same", agentId: "flux" },
+          { type: "agent", id: "same", agentId: "flux" },
+        ],
+      },
+    });
+
+    expect(result.status).toBe("invalid");
+    expect((result.issues as string[]).join(" ")).toContain('duplicate step id "same"');
+  });
+
+  test("admits no code-carrying or unbounded step type", () => {
+    const { tool } = harness();
+    const schema = (tool as unknown as {
+      inputSchema: { safeParse(value: unknown): { success: boolean } };
+    }).inputSchema;
+    const withGraph = (entry: unknown) => schema.safeParse({
+      action: "run",
+      description: "d",
+      definition: { ...nestedGraph, graph: [entry] },
+    }).success;
+
+    // `step` carries a live Step object and is not reference-checked upstream.
+    expect(withGraph({ type: "step", step: { id: "x" } })).toBe(false);
+    // `tool` executes outside the agent tool-call loop, so command_run's own
+    // approval predicate would never fire.
+    expect(withGraph({ type: "tool", id: "t", toolId: "command_run" })).toBe(false);
+    // `sleepUntil` could park a durable run for hours inside one approval.
+    expect(withGraph({ type: "sleepUntil", id: "s", date: "2030-01-01T00:00:00Z" })).toBe(false);
+    expect(withGraph({ type: "sleep", id: "s", duration: 600_000 })).toBe(false);
+    // A suspendable body inside foreach wedges on the second resume.
+    expect(withGraph({ type: "foreach", step: { type: "workflow", id: "w", workflowId: "helper" } })).toBe(false);
+    expect(withGraph({ type: "agent", id: "a", agentId: "flux" })).toBe(true);
+  });
+
+  test("refuses to run when a delegated agent authored the call", async () => {
+    const { invoke } = harness();
+    const delegated = new RequestContext();
+    delegated.set(DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY, 1);
+
+    await expect(invoke(
+      { action: "run", description: "d", definition: nestedGraph, input: {}, dryRun: true, timeoutMs: 1_000 },
+      delegated,
+    )).rejects.toThrow("Nested dynamic_workflow calls are not allowed");
+  });
+
+  test("runs an authored graph and leaves its definition archived, not auto-mounting", async () => {
+    const { mastra, invoke } = harness();
+
+    const result = await invoke({
+      action: "run",
+      description: "run the helper",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.output).toEqual({ done: "handled:ship" });
+    expect(result.runId).toBeTruthy();
+
+    const store = await (mastra.getStorage() as unknown as {
+      getStore(name: string): Promise<{
+        list(args?: { status?: string }): Promise<{ definitions: Array<{ id: string; metadata?: Record<string, unknown> }> }>;
+      }>;
+    }).getStore("workflowDefinitions");
+    const active = await store.list({ status: "active" });
+    const archived = await store.list({ status: "archived" });
+
+    expect(active.definitions).toHaveLength(0);
+    expect(archived.definitions.map(definition => definition.id)).toEqual([result.workflowId]);
+    expect(archived.definitions[0]?.metadata?.origin).toBe(DYNAMIC_WORKFLOW_ORIGIN);
+    // Registration is released once no run holds it, so Studio's HTTP surface
+    // never carries a model-authored graph beyond its in-flight runs.
+    const lookup = mastra as unknown as { getWorkflow(id: string): unknown };
+    expect(() => lookup.getWorkflow(result.workflowId as string)).toThrow();
+  });
+
+  test("clamps author-supplied fan-out concurrency to the host ceiling", async () => {
+    const { mastra, invoke } = harness();
+    // `createStep(agent)` pins the step input to `{ prompt }` and its default
+    // output to `{ text }`, so a fan-out array must carry that element shape.
+    const promptSchema = { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] };
+    const textSchema = { type: "object", properties: { text: { type: "string" } }, required: ["text"] };
+
+    const result = await invoke({
+      action: "run",
+      description: "fan out",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: [],
+      definition: {
+        inputSchema: { type: "array", items: promptSchema },
+        outputSchema: { type: "array", items: textSchema },
+        graph: [{
+          type: "foreach",
+          step: { type: "agent", id: "fan", agentId: "flux" },
+          opts: { concurrency: 9 },
+        }],
+      },
+    });
+
+    expect(result.status).toBe("success");
+
+    const store = await (mastra.getStorage() as unknown as {
+      getStore(name: string): Promise<{ get(id: string): Promise<{ graph: Array<Record<string, unknown>>; inputSchema: Record<string, unknown> } | null> }>;
+    }).getStore("workflowDefinitions");
+    const stored = await store.get(result.workflowId as string);
+
+    expect((stored?.graph[0] as { opts?: { concurrency?: number } })?.opts?.concurrency).toBe(3);
+    // A maxItems ceiling is the only static bound on fan-out width.
+    expect(stored?.inputSchema.maxItems).toBe(8);
+  });
+
+  test("archives a stray active definition at boot", async () => {
+    const { mastra } = harness();
+    const store = await (mastra.getStorage() as unknown as {
+      getStore(name: string): Promise<{
+        upsert(input: Record<string, unknown>): Promise<unknown>;
+        list(args?: { status?: string }): Promise<{ definitions: Array<{ id: string }> }>;
+      }>;
+    }).getStore("workflowDefinitions");
+    await store.upsert({
+      id: "dyn_0000000000000000",
+      inputSchema: objectSchema,
+      outputSchema: doneSchema,
+      graph: [],
+      metadata: { origin: DYNAMIC_WORKFLOW_ORIGIN },
+    });
+
+    expect((await store.list({ status: "active" })).definitions).toHaveLength(1);
+    await expect(reconcileDynamicWorkflowDefinitions(mastra)).resolves.toBe(1);
+    expect((await store.list({ status: "active" })).definitions).toHaveLength(0);
+  });
+});

--- a/packages/agents-roles/src/agents.ts
+++ b/packages/agents-roles/src/agents.ts
@@ -26,6 +26,13 @@ export const TOOLKIT_DELEGATED_RUN_CONTEXT_KEY = "mastraToolkitDelegatedRun";
 export interface ToolkitAgentsOptions {
   readonly browser: boolean;
   readonly commandRun: NonNullable<ToolsInput[string]>;
+  /**
+   * Durable multi-agent orchestration. Injected by the host, like `commandRun`,
+   * so this package keeps owning role policy rather than tool construction.
+   * Attached to Cortex and Zen only: Flux is the exploration role and keeps
+   * `adhd_run`, which needs no approval.
+   */
+  readonly dynamicWorkflow?: NonNullable<ToolsInput[string]>;
   readonly browserExecutablePath?: string;
   readonly browserUserDataDir?: string;
   readonly additionalTools?: ToolkitAdditionalTools;
@@ -49,10 +56,13 @@ export function createToolkitAgents(options: ToolkitAgentsOptions): ToolkitAgent
   const commandRun = options.commandRun;
   let flux!: Agent<"flux">;
   const adhdRun = createAdhdTool(() => flux);
+  const orchestration = options.dynamicWorkflow
+    ? { dynamic_workflow: options.dynamicWorkflow }
+    : {};
   const cortex = createAgent(
     CORTEX_ROLE,
     profile,
-    { command_run: commandRun },
+    { command_run: commandRun, ...orchestration },
     options.additionalTools,
     browser(options),
     options.hooks,
@@ -68,7 +78,7 @@ export function createToolkitAgents(options: ToolkitAgentsOptions): ToolkitAgent
   const zen = createAgent(
     ZEN_ROLE,
     profile,
-    { command_run: commandRun },
+    { command_run: commandRun, ...orchestration },
     options.additionalTools,
     browser(options),
     options.hooks,

--- a/packages/factory-integration/src/integration.ts
+++ b/packages/factory-integration/src/integration.ts
@@ -176,6 +176,7 @@ export interface FactoryControllerProjection {
   readonly binding: ToolkitRuntimeBinding;
   readonly tools: {
     readonly command_run: ReturnType<typeof createSandboxCommandRunTool>;
+    readonly dynamic_workflow: NonNullable<ToolkitAgentsOptions["dynamicWorkflow"]>;
   };
   readonly runtime: {
     readonly defaults: RuntimeDefaultsV1;
@@ -231,6 +232,7 @@ export class ToolkitFactoryIntegration implements FactoryIntegration {
       delegate_flux: delegationTool("delegate_flux", this.bundle.agents.flux),
       delegate_zen: delegationTool("delegate_zen", this.bundle.agents.zen),
       command_run: this.bundle.tools.command_run,
+      dynamic_workflow: this.bundle.tools.dynamic_workflow,
       project_workflow: createFactoryProjectWorkflowTool(),
     } as IntegrationTools;
   }
@@ -290,14 +292,23 @@ export function createFactoryControllerProjection(
       ...(context.workspace ? { workspace: context.workspace } : {}),
     }),
   });
+  // Factory sessions rebind their workspace and rotate task-scoped tokens, so a
+  // resumed run can face a different checkout than its earlier steps ran
+  // against. Fail closed until session re-materialization is a proven slice.
+  const dynamicWorkflow = contract.tools.createDynamicWorkflow({
+    agents: contract.roles.ids,
+    authorize: requireFactoryProjectSession,
+    resumable: false,
+  });
   return {
     binding,
     agents: contract.roles.createAgents({
       ...options,
       commandRun,
+      dynamicWorkflow,
       profile: contract.runtime.profile,
     }),
-    tools: { command_run: commandRun },
+    tools: { command_run: commandRun, dynamic_workflow: dynamicWorkflow },
     runtime: { defaults: contract.runtime.defaults },
     capability: {
       projection: "factory",

--- a/packages/mastra-primitives-export/src/primitives.ts
+++ b/packages/mastra-primitives-export/src/primitives.ts
@@ -1,8 +1,10 @@
 import {
   browserActionRequiresApproval,
+  createDynamicWorkflowTool,
   createRunBudgetHooks,
   createToolAuditHooks,
   createVisibleBrowser,
+  reconcileDynamicWorkflowDefinitions,
   RUN_CONTAINMENT_POLICY,
 } from "@rlabs/agent-tools";
 import {
@@ -110,7 +112,10 @@ export interface ToolkitRuntimeContract {
   };
   readonly tools: {
     readonly commandRun: "command-run/v1";
+    readonly dynamicWorkflow: "dynamic-workflow/v1";
     readonly createCommandRun: typeof createSandboxCommandRunTool;
+    readonly createDynamicWorkflow: typeof createDynamicWorkflowTool;
+    readonly reconcileDynamicWorkflowDefinitions: typeof reconcileDynamicWorkflowDefinitions;
     readonly createRunBudgetHooks: typeof createRunBudgetHooks;
     readonly createToolAuditHooks: typeof createToolAuditHooks;
     readonly createVisibleBrowser: typeof createVisibleBrowser;
@@ -200,7 +205,10 @@ export function createToolkitRuntimeContract(
     },
     tools: {
       commandRun: "command-run/v1",
+      dynamicWorkflow: "dynamic-workflow/v1",
       createCommandRun: createSandboxCommandRunTool,
+      createDynamicWorkflow: createDynamicWorkflowTool,
+      reconcileDynamicWorkflowDefinitions,
       createRunBudgetHooks,
       createToolAuditHooks,
       createVisibleBrowser,

--- a/packages/mcode/src/recipe.ts
+++ b/packages/mcode/src/recipe.ts
@@ -134,7 +134,7 @@ interface McodeRecipeCompatibilityOptions extends Omit<ToolkitAgentsOptions, "pr
 export type McodeRecipeOptions = McodeRecipeCompatibilityOptions;
 
 export interface McodeControllerProjectionOptions
-  extends Omit<ToolkitAgentsOptions, "profile" | "commandRun"> {}
+  extends Omit<ToolkitAgentsOptions, "profile" | "commandRun" | "dynamicWorkflow"> {}
 
 export interface McodeControllerIngredientsV1 {
   readonly modes: AgentControllerMode[];
@@ -188,6 +188,7 @@ export interface McodeControllerProjection {
   readonly agents: ToolkitAgents;
   readonly tools: {
     readonly command_run: McodeRecipeOptions["commandRun"];
+    readonly dynamic_workflow: NonNullable<ToolkitAgentsOptions["dynamicWorkflow"]>;
   };
   readonly controller: McodeControllerIngredientsV1;
   readonly capability: McodeCapabilityDescriptorV1;
@@ -228,18 +229,23 @@ function createControllerProjection(
       });
     },
   });
+  // Agents are the only allowlisted dispatch targets, so an authored graph can
+  // never reach a role this projection did not construct.
+  const dynamicWorkflow = contract.tools.createDynamicWorkflow({ agents: contract.roles.ids });
   const agents = contract.roles.createAgents({
     ...options,
     commandRun,
+    dynamicWorkflow,
     profile: contract.runtime.profile,
   });
   const modes = createCodeModes(agents, contract.runtime.profile);
+  // Leaves receive command_run only, so a delegated agent cannot author a graph.
   const subagents = createCodeSubagents(contract.runtime.profile, { command_run: commandRun });
   return {
     version: MCODE_CONTROLLER_PROJECTION_VERSION,
     binding,
     agents,
-    tools: { command_run: commandRun },
+    tools: { command_run: commandRun, dynamic_workflow: dynamicWorkflow },
     controller: { modes, subagents },
     capability: createMcodeCapabilityDescriptor(
       contract.runtime.profile,

--- a/packages/mcode/src/runtime.ts
+++ b/packages/mcode/src/runtime.ts
@@ -296,6 +296,7 @@ export async function prepareMcodeRuntime(
     ...(config.browser.userDataDir ? { browserUserDataDir: config.browser.userDataDir } : {}),
   });
   const commandRun = projection.tools.command_run;
+  const dynamicWorkflow = projection.tools.dynamic_workflow;
   const agents = projection.agents;
   const dataDirectory = await prepareCodeSdkSettings({
     ...(options.dataDirectory ? { dataDirectory: options.dataDirectory } : {}),
@@ -363,11 +364,20 @@ export async function prepareMcodeRuntime(
       const mcp = options.mcp
         ?? (options.disableMcp ? new EmptyMcpLifecycle() : createCodeMcpAdapter(project.rootPath));
       try {
+        // A crash between the create and archive writes can leave a
+        // model-authored definition active, and only active rows load at
+        // startWorkers(). Archive them before anything can mount them.
+        await contract.tools.reconcileDynamicWorkflowDefinitions(mastra);
         resources = await ProjectMountingManager.create({
           projectRoot: project.rootPath,
           modelAliases: new ProfileModelAliasResolver(contractProfile),
           mcp,
-          currentTools: new StaticToolSnapshot({ command_run: commandRun }),
+          // Reported, not published: the mounting manager rejects a project
+          // workflow that would shadow a reserved host tool id.
+          currentTools: new StaticToolSnapshot({
+            command_run: commandRun,
+            dynamic_workflow: dynamicWorkflow,
+          }),
           requiredSpecialistTools: ["command_run"],
           host: new MastraProjectHostRegistry(mastra),
           workspace,

--- a/test/workspace-structure.test.ts
+++ b/test/workspace-structure.test.ts
@@ -97,7 +97,7 @@ describe("workspace ownership", () => {
   test("uses the approved deep-module source layout", async () => {
     const expectedSources: Record<(typeof packageNames)[number], readonly string[]> = {
       "runtime-config": ["environment.ts", "gateway.ts", "index.ts", "profile.ts"],
-      "agent-tools": ["capabilities.ts", "command-run-contract.ts", "command-run.ts", "index.ts"],
+      "agent-tools": ["capabilities.ts", "command-run-contract.ts", "command-run.ts", "dynamic-workflow.ts", "index.ts"],
       "agents-roles": ["agents.ts", "index.ts", "prompts.ts", "roles.ts"],
       "sandbox": ["command-run.ts", "contract.ts", "index.ts", "machine.ts", "providers.ts"],
       "project-mounting-manager": ["contract.ts", "discovery.ts", "index.ts", "manager.ts"],


### PR DESCRIPTION
## What

Adds `dynamic_workflow` — a tool an agent calls to **author a Mastra workflow as a declarative graph and run it durably** to orchestrate other agents.

This is the replacement path [`packages/agent-tools/AGENTS.md`](https://github.com/rlabs88/mastra-toolkit/blob/main/packages/agent-tools/AGENTS.md) already reserves:

> `command_run` and `adhd_run` are retained compatibility capabilities … future replacement uses native Mastra workflows, task state, subagents, and background tasks after parity is proven.

`adhd_run` and `command_run` are **untouched** here.

## The authored artifact is data, not code

Mastra 1.57 ships `@mastra/core/workflows/builder` (`WorkflowBuilderDefinition`) and `Mastra.addStoredWorkflow`, so the graph is validated, rehydrated, and registered by upstream. There is no source string, no `esbuild`, no `import()`, no sandbox escape hatch — nothing the tool admits is executable in its own right.

Upstream's validator returns repair-grade diagnostics, which is the iteration loop. Verified against this repo's pinned core:

```
- [incompatible-schema] graph.1: Foreach input must be a raw array. A mapping step cannot
  produce one — mappings always build an object — so the preceding step (or the workflow
  inputSchema itself) must already be an array of the child input.
- [invalid-map-config] graph.2.mapConfig.total: Mapping descriptor must define exactly one source.
- [missing-step-id] graph.0.step.id: Step id is required.
```

`dryRun` validates and content-addresses for free — no approval, no execution, no persistence — so a bad graph never burns an approval.

## Durability is Mastra's own

A run gets a snapshot and a `runId`, and the definition is persisted, so a process that never saw the authoring call can reconstruct the graph and resume. Verified end to end:

```
PROCESS 1  authored JSON → addStoredWorkflow → validated → persisted → RUN: success
PROCESS 2  fresh process, no authoring → startWorkers() → definition rehydrated from storage
           getWorkflow -> committed: true → REHYDRATED RUN: success
```

Identity is content-addressed (`dyn_<sha256-16>` over the canonical definition), so registration is idempotent and a changed graph mints a new id rather than invalidating in-flight snapshots.

## Containment

A graph commands host-side agent dispatch, so every ceiling is enforced by rewriting the graph rather than trusting it:

| Guard | Why |
|---|---|
| agent / nested-workflow allowlists injected by the host | keeps `agent-tools` role-neutral; a graph cannot reach a role the projection did not construct |
| `step`, `tool`, `sleepUntil` refused | `step` is not reference-checked upstream; `tool` executes outside the agent tool-call loop so `command_run`'s approval predicate would never fire |
| `foreach` body must be an agent | suspension inside `foreach` advances on the first resume then wedges on the second in 1.57, corrupting the snapshot to `failed` |
| concurrency clamped, `maxItems` injected | `.foreach` is the only concurrency primitive; `.parallel` is an unbounded `Promise.all`, so width is capped too |
| definitions archived immediately + boot reconciliation | only `active` rows load at `startWorkers()`; leaving them active would auto-mount every model-authored graph at every boot — an Invariant 2 violation |
| refcounted registration | a shared content-addressed id must not be torn down by a concurrent run |
| narrowed, JSON-safe request context | `RequestContext.toJSON()` persists a live `Workspace` as a method-less husk that would win over the real one on resume |
| depth guard inside `execute` | the only layer that also covers subagent leaves and project specialists, which have neither hooks nor a dynamic tool resolver |

Approval: `run` and `resume` are gated; `dryRun` and `inspect` are free. `resume` is gated **on purpose** — the human gate exists for a human, but the model is the caller, so an approval-free resume would let it self-approve its own gate.

## Wiring

The shared runtime contract exposes the factory, so mcode and Factory both consume it **without Factory depending on mcode** (invariant 7).

- **mcode** — published via `StaticToolSnapshot` (reported, so a project workflow cannot shadow the reserved id); boot reconciliation in `finalize`
- **Studio** — inherits it for free from the prepared runtime
- **Factory** — `authorize: requireFactoryProjectSession`, and `resumable: false` because its workspace rebinds and its task tokens rotate across a resume
- **Roles** — attached to Cortex and Zen; Flux keeps `adhd_run`, which needs no approval

## Validation

`npm run typecheck` ✅ · `npm test` ✅ **248 passed (39 files)** · `npm run build` ✅

10 new package-local tests cover approval policy, content addressing, the allowlists, duplicate ids, the refused step types, the depth guard, an end-to-end run leaving the definition archived and unregistered, concurrency clamping, and boot reconciliation.

## Deliberately not in this PR

- **`adhd_run` retirement** — needs a parity contract test first. Two clauses do not reproduce (shared abort-signal *identity* across children; distinct-perspective semantics), and `adhd_run` is free/read-only while this is approval-gated. That is a product call, not an implementation detail.
- **Nested TUI rendering** — v1 streams into the ordinary tool box; the nested subagent box needs a mastracode plugin render config that does not reach canonical agents today.
- **Factory resume** — fail-closed until session re-materialization is its own slice.

## Note, unrelated to this change

`.npmrc` sets `cache=${HOME}/.npm-cache-user-codex`, and npm does not expand `${HOME}` when `mastra build` packs workspace dependencies — so a literal `${HOME}/` directory is created inside each package. It is untracked and ungitignored on `main` too. Not touched here; worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)