### PR TITLE
Contain multi-file dynamic workflows and reserved host tools

### DIFF
--- a/packages/factory-integration/test/project-workflow.test.ts
+++ b/packages/factory-integration/test/project-workflow.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readFile, readdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RequestContext } from "@mastra/core/request-context";
@@ -10,11 +10,14 @@ import { afterEach, describe, expect, test } from "vitest";
 import { createFactoryAgentBundle, ToolkitFactoryIntegration } from "../src/index.js";
 
 let projectRoot: string | undefined;
+let scratchRoot: string | undefined;
 
 afterEach(async () => {
   delete process.env.FACTORY_PRIVILEGED_SENTINEL;
   if (projectRoot) await rm(projectRoot, { recursive: true, force: true });
+  if (scratchRoot) await rm(scratchRoot, { recursive: true, force: true });
   projectRoot = undefined;
+  scratchRoot = undefined;
 });
 
 describe("Factory project workflows", () => {
@@ -302,7 +305,146 @@ describe("Factory project workflows", () => {
       await workspace.destroy();
     }
   }, 30_000);
+
+  test("publishes a workflow whose steps live in a helper subdirectory", async () => {
+    const workflowDirectory = await containmentFixture("multi-file");
+    await mkdir(join(workflowDirectory, "steps"), { recursive: true });
+    await writeFile(join(workflowDirectory, "flow.ts"), multiFileWorkflowFixture("flow", "./steps/one.js"));
+    await writeFile(join(workflowDirectory, "steps", "one.ts"), helperModule("first"));
+
+    await expect(listProjectWorkflows()).resolves.toEqual({
+      workflows: [{ id: "flow", description: "Run flow" }],
+    });
+  }, 30_000);
+
+  test("rejects a relative helper import that escapes the project root", async () => {
+    const workflowDirectory = await containmentFixture("relative-escape");
+    await mkdir(join(scratchRoot!, "outside"), { recursive: true });
+    await writeFile(join(scratchRoot!, "outside", "evil.ts"), helperModule("evil"));
+    await writeFile(
+      join(workflowDirectory, "flow.ts"),
+      multiFileWorkflowFixture("flow", "../../../outside/evil.js"),
+    );
+
+    await expect(listProjectWorkflows()).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("rejects an absolute helper import outside the project root", async () => {
+    const workflowDirectory = await containmentFixture("absolute-escape");
+    await writeFile(join(workflowDirectory, "flow.ts"), multiFileWorkflowFixture("flow", "/etc/anything.js"));
+
+    await expect(listProjectWorkflows()).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("rejects a helper subdirectory entry symlinked outside the project root", async () => {
+    const workflowDirectory = await containmentFixture("symlink-escape");
+    await mkdir(join(scratchRoot!, "outside"), { recursive: true });
+    await mkdir(join(workflowDirectory, "steps"), { recursive: true });
+    await writeFile(join(scratchRoot!, "outside", "evil.ts"), helperModule("evil"));
+    await symlink(join(scratchRoot!, "outside", "evil.ts"), join(workflowDirectory, "steps", "link.ts"));
+    await writeFile(join(workflowDirectory, "flow.ts"), multiFileWorkflowFixture("flow", "./steps/link.js"));
+
+    await expect(listProjectWorkflows()).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("names the helper-subdirectory layout when a flat sibling is not a workflow", async () => {
+    const workflowDirectory = await containmentFixture("flat-helper");
+    await writeFile(join(workflowDirectory, "flow.ts"), multiFileWorkflowFixture("flow", "./steps.js"));
+    await writeFile(join(workflowDirectory, "steps.ts"), helperModule("flat"));
+
+    const failure = await listProjectWorkflows().catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toMatch(/must default-export a committed Mastra Workflow/);
+    expect((failure as Error).message).toMatch(/subdirectory/i);
+  }, 30_000);
+
+  test("ignores declaration files in every module extension", async () => {
+    const workflowDirectory = await containmentFixture("declarations");
+    await mkdir(join(workflowDirectory, "steps"), { recursive: true });
+    await writeFile(join(workflowDirectory, "flow.ts"), multiFileWorkflowFixture("flow", "./steps/one.js"));
+    await writeFile(join(workflowDirectory, "steps", "one.ts"), helperModule("first"));
+    await writeFile(join(workflowDirectory, "types.d.ts"), "export type Unused = string;\n");
+    await writeFile(join(workflowDirectory, "types.d.mts"), "export type Unused = string;\n");
+    await writeFile(join(workflowDirectory, "types.d.cts"), "export type Unused = string;\n");
+
+    await expect(listProjectWorkflows()).resolves.toEqual({
+      workflows: [{ id: "flow", description: "Run flow" }],
+    });
+  }, 30_000);
 });
+
+async function containmentFixture(label: string): Promise<string> {
+  scratchRoot = await mkdtemp(join(tmpdir(), `rlabs-factory-workflow-${label}-`));
+  projectRoot = join(scratchRoot, "project");
+  const workflowDirectory = join(projectRoot, ".mastracode", "workflow");
+  await mkdir(workflowDirectory, { recursive: true });
+  return workflowDirectory;
+}
+
+async function listProjectWorkflows(): Promise<unknown> {
+  const root = projectRoot;
+  if (!root) throw new Error("containmentFixture must run before listProjectWorkflows");
+  const sandbox = localSandboxMachine(root);
+  if (!sandbox.executeCommand) throw new Error("LocalSandbox command execution is unavailable");
+  const workspace = new Workspace({
+    id: "factory-project-workflow-containment-test",
+    filesystem: new SandboxFilesystem({
+      sandbox: {
+        id: sandbox.id,
+        executeCommand: (command, args, options) => sandbox.executeCommand!(command, args, options),
+      },
+      workdir: root,
+    }),
+    sandbox,
+  });
+  await workspace.init();
+  const tools = await factoryIntegration().agentTools();
+  const projectWorkflow = tools.project_workflow as {
+    execute?: (input: unknown, context: unknown) => Promise<unknown>;
+  };
+  try {
+    return await projectWorkflow.execute?.({ action: "list" }, {
+      requestContext: new RequestContext(),
+      workspace,
+    });
+  } finally {
+    await workspace.destroy();
+  }
+}
+
+function multiFileWorkflowFixture(id: string, helperSpecifier: string): string {
+  return `import { helperValue } from ${JSON.stringify(helperSpecifier)};
+
+const schema = {
+  "~standard": {
+    version: 1,
+    vendor: "fixture",
+    validate: (value: unknown) => ({ value }),
+  },
+};
+
+export const agentTool = { description: "Run ${id}" };
+
+export default {
+  component: "WORKFLOW",
+  committed: true,
+  id: ${JSON.stringify(id)},
+  helperValue,
+  inputSchema: schema,
+  outputSchema: schema,
+  createRun: async () => ({
+    runId: ${JSON.stringify(`${id}-run`)},
+    cancel: async () => undefined,
+    start: async () => ({ status: "success", result: { helperValue } }),
+  }),
+};
+`;
+}
+
+function helperModule(value: string): string {
+  return `export const helperValue = ${JSON.stringify(value)};\n`;
+}
 
 function factoryIntegration(): ToolkitFactoryIntegration {
   const profile = loadModelProfile();

--- a/packages/project-mounting-manager/CONTEXT.md
+++ b/packages/project-mounting-manager/CONTEXT.md
@@ -31,6 +31,12 @@ Every file directly in `.mastracode/workflow` is an entrypoint and must default-
 
 Containment covers every bundled file, not only the entrypoint. Relative and absolute specifiers are checked against the project root before esbuild reads them, and every bundled input is realpath-checked after the build, so a helper that is a symlink out of the project is rejected too. Bare specifiers are externalized and resolved from the importing file's own directory first, then the entrypoint's, then this package's; TypeScript `paths` aliases are not resolved, because an alias like `@steps/foo` is indistinguishable from a package name at this layer.
 
+### Reserved host tools
+
+`publishedTools` is the single merge point that feeds both project specialists and the host bridge, and the two are siblings rather than parent and child: specialists are built from `publishedTools` directly, while `getTools()` returns `{ ...publishedTools, project_specialist }`. A host-side filter over the bridge therefore cannot restrict what specialists can call, and an unrestricted specialist — one whose frontmatter has no `tools:` key — receives every published tool.
+
+A host tool ID that a project must not shadow *and* must not call is declared through `reservedToolIds`, not `currentTools`. Reserved IDs are claimed before any snapshot is merged, so a project workflow whose tool ID collides is still rejected, while the tool itself never becomes publishable. Everything passed through `currentTools` is published to unrestricted specialists; that port is for tools the project is genuinely allowed to use. A specialist that names a reserved ID fails the generation as reserved rather than as an unknown tool.
+
 ### Recorded asymmetries
 
 Loading a project workflow executes the entrypoint's top-level module code in the MCode host process at discovery time, with no approval prompt and no sandbox. Only the subsequent *run* is gated by tool approval. Factory takes the opposite position: its sandbox runner requires approval before even listing workflows, precisely because listing loads project code. Multi-file authoring widens the amount of code an entrypoint can pull in without a reviewer seeing it in one file. Containment now bounds *where* that code may come from, but not *whether* it runs. Closing the asymmetry means either sandboxing host-side discovery or gating it behind approval, and remains open.

--- a/packages/project-mounting-manager/CONTEXT.md
+++ b/packages/project-mounting-manager/CONTEXT.md
@@ -15,6 +15,28 @@ Project specialist, workflow, MCP, and watcher behavior first lived inside the r
 
 This package owns project specialist and workflow discovery, explicit workflow-tool publication, generation state, diagnostics, resource watching, and the transactional mounting facade. Its root Interface exposes deep contract, discovery, and manager Modules. Host-specific model lookup, MCP connections, current tool enumeration, and registry mutation enter through ports defined by the contract Module.
 
+### Workflow layout
+
+A dynamic workflow may span several TypeScript files. The sanctioned layout is a flat entrypoint plus a helper subdirectory:
+
+```text
+.mastracode/workflow/
+├── flow.ts        # entrypoint: default-exports a committed Workflow, optionally exports agentTool
+└── steps/         # helpers, bundled into the entrypoint
+    ├── one.ts
+    └── two.ts
+```
+
+Every file directly in `.mastracode/workflow` is an entrypoint and must default-export a committed Mastra Workflow; a flat helper beside the entrypoint fails that check and takes down the whole generation, including specialists and MCP, so the failure now names this layout. Subdirectories are never entrypoints. Relative imports are bundled into the entrypoint rather than externalized, so editing a helper changes the entrypoint's generation hash and the workflow reloads. Declaration files (`.d.ts`, `.d.mts`, `.d.cts`) are skipped. This layout is a convention enforced by the loader, not a manifest; do not add a second project manifest to describe it.
+
+Containment covers every bundled file, not only the entrypoint. Relative and absolute specifiers are checked against the project root before esbuild reads them, and every bundled input is realpath-checked after the build, so a helper that is a symlink out of the project is rejected too. Bare specifiers are externalized and resolved from the importing file's own directory first, then the entrypoint's, then this package's; TypeScript `paths` aliases are not resolved, because an alias like `@steps/foo` is indistinguishable from a package name at this layer.
+
+### Recorded asymmetries
+
+Loading a project workflow executes the entrypoint's top-level module code in the MCode host process at discovery time, with no approval prompt and no sandbox. Only the subsequent *run* is gated by tool approval. Factory takes the opposite position: its sandbox runner requires approval before even listing workflows, precisely because listing loads project code. Multi-file authoring widens the amount of code an entrypoint can pull in without a reviewer seeing it in one file. Containment now bounds *where* that code may come from, but not *whether* it runs. Closing the asymmetry means either sandboxing host-side discovery or gating it behind approval, and remains open.
+
+Compiled bundles are written to one unversioned shared temp directory (`<tmpdir>/rlabs-project-workflows`) under a name derived from the entrypoint basename and a content hash. Two projects with a same-named workflow of identical content therefore share one compiled file, and stale bundles are never cleaned up. Neither is exploited by current behavior, since the hash covers the bundle bytes, but both are unowned.
+
 ## Future
 
-Studio, local Code, and Factory adapters can share this mounting contract while retaining their own lifecycle and policy. Cross-project scheduling and a new project manifest remain outside this boundary.
+Studio, local Code, and Factory adapters can share this mounting contract while retaining their own lifecycle and policy. Cross-project scheduling and a new project manifest remain outside this boundary. Host-side discovery approval or sandboxing, and a per-project versioned compilation cache with eviction, are the two known open items above.

--- a/packages/project-mounting-manager/src/contract.ts
+++ b/packages/project-mounting-manager/src/contract.ts
@@ -116,11 +116,14 @@ import { createHash } from "node:crypto";
 import { access, mkdir, readdir, realpath, unlink, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { basename, delimiter, dirname, extname, join, resolve, sep } from "node:path";
+import { basename, delimiter, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const RESULT_PREFIX = "__RLABS_PROJECT_WORKFLOW_RESULT__";
 const STREAM_PREFIX = "__RLABS_PROJECT_WORKFLOW_STREAM__";
+const WORKFLOW_LAYOUT_HINT = "Every file directly in .mastracode/workflow is loaded as a workflow entrypoint;"
+  + " keep shared helpers in a subdirectory such as .mastracode/workflow/steps/ and import them"
+  + " from the entrypoint with a relative specifier.";
 
 async function validate(schema, value, label) {
   const standard = assertStandardSchema(schema, label);
@@ -154,9 +157,44 @@ function publishedAgentTool(value) {
 function committedWorkflow(value, source) {
   if (!value || typeof value !== "object" || value.component !== "WORKFLOW" || value.committed !== true
     || typeof value.id !== "string" || typeof value.createRun !== "function") {
-    throw new Error("Project workflow must default-export a committed Mastra Workflow: " + source);
+    throw new Error("Project workflow must default-export a committed Mastra Workflow: " + source + ". " + WORKFLOW_LAYOUT_HINT);
   }
   return value;
+}
+
+function isUnderRoot(roots, target) {
+  return roots.some(root => target === root || target.startsWith(root + sep));
+}
+
+async function isContainedPath(roots, target) {
+  if (isUnderRoot(roots, target)) return true;
+  try {
+    return isUnderRoot(roots, await realpath(target));
+  } catch {
+    return false;
+  }
+}
+
+async function assertBundleContained(roots, metafile, sourcePath) {
+  for (const input of Object.keys(metafile.inputs)) {
+    const absolute = resolve(process.cwd(), input);
+    let real;
+    try {
+      real = await realpath(absolute);
+    } catch {
+      throw new Error("Project workflow escapes the project root: " + absolute + " bundled into " + sourcePath);
+    }
+    if (isUnderRoot(roots, real)) continue;
+    throw new Error("Project workflow escapes the project root: " + real + " bundled into " + sourcePath);
+  }
+}
+
+function requireForDirectory(directory, cache) {
+  const existing = cache.get(directory);
+  if (existing) return existing;
+  const created = createRequire(join(directory, "package.json"));
+  cache.set(directory, created);
+  return created;
 }
 
 function runtimePackageRequires() {
@@ -168,8 +206,8 @@ function runtimePackageRequires() {
   return { projectRequire, runtimeRequires };
 }
 
-function resolvePackage(packageName, projectRequire, runtimeRequires) {
-  for (const candidate of [projectRequire, ...runtimeRequires]) {
+function resolvePackage(packageName, requires) {
+  for (const candidate of requires) {
     try {
       return candidate.resolve(packageName);
     } catch {}
@@ -177,10 +215,15 @@ function resolvePackage(packageName, projectRequire, runtimeRequires) {
   throw new Error("Project workflow dependency is unavailable in the project or mcode-runtime layer: " + packageName);
 }
 
-async function compileWorkflow(sourcePath) {
+// Mirrors the host loader: bundled files stay inside the project, and each file resolves bare
+// specifiers from its own directory first so a workflow may span a helper subdirectory.
+async function compileWorkflow(sourcePath, roots) {
   const { projectRequire, runtimeRequires } = runtimePackageRequires();
-  const esbuildPath = resolvePackage("esbuild", projectRequire, runtimeRequires);
+  const esbuildPath = resolvePackage("esbuild", [projectRequire, ...runtimeRequires]);
   const { build } = await import(pathToFileURL(esbuildPath).href);
+  const entryDirectory = dirname(sourcePath);
+  const scopedRequires = new Map();
+  const containment = {};
   const result = await build({
     entryPoints: [sourcePath],
     bundle: true,
@@ -189,17 +232,30 @@ async function compileWorkflow(sourcePath) {
     target: "node22",
     write: false,
     sourcemap: "inline",
+    metafile: true,
     plugins: [{
-      name: "factory-runtime-package-imports",
+      name: "factory-project-workflow-imports",
       setup(builder) {
-        builder.onResolve({ filter: /^[^./]|^@/ }, args => {
+        builder.onResolve({ filter: /.*/ }, async args => {
           if (args.path.startsWith("node:")) return { path: args.path, external: true };
-          const resolved = resolvePackage(args.path, projectRequire, runtimeRequires);
+          if (isAbsolute(args.path) || args.path.startsWith(".")) {
+            const target = isAbsolute(args.path)
+              ? resolve(args.path)
+              : resolve(args.resolveDir || entryDirectory, args.path);
+            if (await isContainedPath(roots, target)) return undefined;
+            containment.violation = containment.violation
+              ?? new Error("Project workflow escapes the project root: " + target
+                + (args.importer ? " imported by " + args.importer : ""));
+            return { errors: [{ text: containment.violation.message }] };
+          }
+          const scope = requireForDirectory(args.resolveDir || entryDirectory, scopedRequires);
+          const resolved = resolvePackage(args.path, [scope, projectRequire, ...runtimeRequires]);
           return { path: pathToFileURL(resolved).href, external: true };
         });
       },
     }],
-  });
+  }).catch(error => { throw containment.violation ?? error; });
+  await assertBundleContained(roots, result.metafile, sourcePath);
   const output = result.outputFiles?.[0];
   if (!output) throw new Error("Project workflow compiler produced no output: " + sourcePath);
   const generation = createHash("sha256").update(output.contents).digest("hex").slice(0, 16);
@@ -212,6 +268,8 @@ async function compileWorkflow(sourcePath) {
 
 async function loadWorkflows() {
   const projectRoot = await realpath(process.cwd());
+  const declaredRoot = resolve(process.cwd());
+  const roots = declaredRoot === projectRoot ? [projectRoot] : [declaredRoot, projectRoot];
   const directory = resolve(projectRoot, ".mastracode", "workflow");
   let entries;
   try {
@@ -224,10 +282,10 @@ async function loadWorkflows() {
   const workflowIds = new Set();
   for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
     if (entry.isSymbolicLink()) throw new Error("Project workflow cannot be a symbolic link: " + entry.name);
-    if (!entry.isFile() || !/\.(?:[cm]?[jt]s)$/.test(entry.name) || entry.name.endsWith(".d.ts")) continue;
+    if (!entry.isFile() || !/\.(?:[cm]?[jt]s)$/.test(entry.name) || /\.d\.[cm]?ts$/.test(entry.name)) continue;
     const sourcePath = await realpath(resolve(directory, entry.name));
     if (!sourcePath.startsWith(projectRoot + sep)) throw new Error("Project workflow escapes the project root: " + entry.name);
-    const compiledPath = await compileWorkflow(sourcePath);
+    const compiledPath = await compileWorkflow(sourcePath, roots);
     const loaded = await import(pathToFileURL(compiledPath).href + "?factory=" + Date.now());
     const workflow = committedWorkflow(loaded.default, entry.name);
     assertStandardSchema(workflow.inputSchema, workflow.id + " input");

--- a/packages/project-mounting-manager/src/discovery.ts
+++ b/packages/project-mounting-manager/src/discovery.ts
@@ -1,13 +1,13 @@
 import type { ModelAliasResolverPort } from "./contract.js";
 import { createTool } from "@mastra/core/tools";
 import type { AnyWorkflow } from "@mastra/core/workflows";
-import { build, type Plugin } from "esbuild";
+import { build, type Metafile, type Plugin } from "esbuild";
 import { createHash } from "node:crypto";
 import { type FSWatcher, watch } from "node:fs";
 import { access, lstat, mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { homedir, tmpdir } from "node:os";
-import { basename, extname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parse } from "yaml";
 import { z } from "zod";
@@ -256,6 +256,16 @@ const workflowResultSchema = z.object({
 
 const packageRequire = createRequire(import.meta.url);
 
+/**
+ * The sanctioned multi-file layout: every file directly in `.mastracode/workflow` is a workflow
+ * entrypoint, and everything a workflow shares lives one level down. `SANDBOX_PROJECT_WORKFLOW_RUNNER`
+ * repeats this text so the host and Factory describe the same layout.
+ */
+export const WORKFLOW_LAYOUT_HINT =
+  "Every file directly in .mastracode/workflow is loaded as a workflow entrypoint;"
+  + " keep shared helpers in a subdirectory such as .mastracode/workflow/steps/ and import them"
+  + " from the entrypoint with a relative specifier.";
+
 export interface ProjectWorkflowAgentTool {
   readonly description: string;
   readonly metadata?: Readonly<Record<string, unknown>>;
@@ -282,10 +292,12 @@ export async function discoverProjectWorkflows(
     if (entry.isSymbolicLink()) throw new Error(`Project workflow cannot be a symbolic link: ${source}`);
     if (!entry.isFile() || !isWorkflowEntry(entry.name)) continue;
     await assertWorkflowContained(projectRoot, sourcePath);
-    const compiled = await compileWorkflow(sourcePath);
+    const compiled = await compileWorkflow(projectRoot, sourcePath);
     const loaded = await import(pathToFileURL(compiled.outputPath).href);
     if (!isCommittedWorkflow(loaded.default)) {
-      throw new Error(`Project workflow must default-export a committed Mastra Workflow: ${source}`);
+      throw new Error(
+        `Project workflow must default-export a committed Mastra Workflow: ${source}. ${WORKFLOW_LAYOUT_HINT}`,
+      );
     }
     const workflow = loaded.default;
     const schemas = workflowSchemas(workflow);
@@ -349,7 +361,12 @@ function createWorkflowTool(workflow: AnyWorkflow, description: string): ReturnT
   });
 }
 
-async function compileWorkflow(sourcePath: string): Promise<{ generation: string; outputPath: string }> {
+async function compileWorkflow(
+  projectRoot: string,
+  sourcePath: string,
+): Promise<{ generation: string; outputPath: string }> {
+  const roots = await containmentRoots(projectRoot);
+  const containment: { violation?: Error } = {};
   const result = await build({
     entryPoints: [sourcePath],
     bundle: true,
@@ -358,8 +375,12 @@ async function compileWorkflow(sourcePath: string): Promise<{ generation: string
     target: "node22",
     write: false,
     sourcemap: "inline",
-    plugins: [absolutePackageImports(sourcePath)],
+    metafile: true,
+    plugins: [projectWorkflowImports(sourcePath, roots, containment)],
+  }).catch((error: unknown) => {
+    throw containment.violation ?? error;
   });
+  await assertBundleContained(roots, result.metafile, sourcePath);
   const output = result.outputFiles?.[0];
   if (!output) throw new Error(`Workflow compiler produced no output: ${sourcePath}`);
   const generation = createHash("sha256").update(output.contents).digest("hex").slice(0, 16);
@@ -370,24 +391,112 @@ async function compileWorkflow(sourcePath: string): Promise<{ generation: string
   return { generation, outputPath };
 }
 
-function absolutePackageImports(sourcePath: string): Plugin {
-  const projectRequire = createRequire(sourcePath);
+/**
+ * Bundled workflow files must stay inside the project, not just the entrypoint. Relative and
+ * absolute specifiers are checked here before esbuild reads them; symlinked files that only
+ * escape once resolved are caught afterwards by `assertBundleContained`.
+ */
+function projectWorkflowImports(
+  sourcePath: string,
+  roots: readonly string[],
+  containment: { violation?: Error },
+): Plugin {
+  const entryDirectory = dirname(sourcePath);
+  const scopedRequires = new Map<string, NodeJS.Require>();
   return {
-    name: "absolute-package-imports",
+    name: "project-workflow-imports",
     setup(builder) {
-      builder.onResolve({ filter: /^[^./]|^@/ }, args => {
+      builder.onResolve({ filter: /.*/ }, async args => {
         if (args.path.startsWith("node:")) return { path: args.path, external: true };
-        return { path: resolvePackage(args.path, projectRequire), external: true };
+        if (isProjectFileSpecifier(args.path)) {
+          const target = isAbsolute(args.path)
+            ? resolve(args.path)
+            : resolve(args.resolveDir || entryDirectory, args.path);
+          if (await isContainedPath(roots, target)) return undefined;
+          containment.violation ??= new Error(
+            `Project workflow escapes the project root: ${target}`
+              + `${args.importer ? ` imported by ${args.importer}` : ""}`,
+          );
+          return { errors: [{ text: containment.violation.message }] };
+        }
+        const scope = requireForDirectory(args.resolveDir || entryDirectory, scopedRequires);
+        const entry = requireForDirectory(entryDirectory, scopedRequires);
+        return { path: resolvePackage(args.path, args.importer, scope, entry), external: true };
       });
     },
   };
 }
 
-function resolvePackage(packageName: string, projectRequire: NodeJS.Require): string {
+function isProjectFileSpecifier(specifier: string): boolean {
+  return isAbsolute(specifier) || specifier.startsWith(".");
+}
+
+function requireForDirectory(directory: string, cache: Map<string, NodeJS.Require>): NodeJS.Require {
+  const existing = cache.get(directory);
+  if (existing) return existing;
+  const created = createRequire(join(directory, "package.json"));
+  cache.set(directory, created);
+  return created;
+}
+
+/**
+ * A bundled helper resolves bare specifiers from its own directory first, so a workflow split
+ * across directories keeps each file's own resolution scope.
+ */
+function resolvePackage(
+  packageName: string,
+  importer: string,
+  ...requires: readonly NodeJS.Require[]
+): string {
+  for (const candidate of [...requires, packageRequire]) {
+    try {
+      return pathToFileURL(candidate.resolve(packageName)).href;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(
+    `Project workflow dependency is unavailable: ${packageName}`
+      + `${importer ? ` imported by ${importer}` : ""}.`
+      + ` Install it in the project, or import project files with a relative specifier;`
+      + ` TypeScript "paths" aliases are not resolved by the workflow compiler.`,
+  );
+}
+
+async function containmentRoots(projectRoot: string): Promise<readonly string[]> {
+  const declared = resolve(projectRoot);
+  const real = await realpath(declared);
+  return declared === real ? [declared] : [declared, real];
+}
+
+async function isContainedPath(roots: readonly string[], target: string): Promise<boolean> {
+  if (isUnderRoot(roots, target)) return true;
   try {
-    return pathToFileURL(projectRequire.resolve(packageName)).href;
+    return isUnderRoot(roots, await realpath(target));
   } catch {
-    return pathToFileURL(packageRequire.resolve(packageName)).href;
+    return false;
+  }
+}
+
+function isUnderRoot(roots: readonly string[], target: string): boolean {
+  return roots.some(root => target === root || target.startsWith(`${root}${sep}`));
+}
+
+async function assertBundleContained(
+  roots: readonly string[],
+  metafile: Metafile,
+  sourcePath: string,
+): Promise<void> {
+  for (const input of Object.keys(metafile.inputs)) {
+    const absolute = resolve(process.cwd(), input);
+    let real: string;
+    try {
+      real = await realpath(absolute);
+    } catch {
+      throw new Error(`Project workflow escapes the project root: ${absolute} bundled into ${sourcePath}`);
+    }
+    if (isUnderRoot(roots, real)) continue;
+    throw new Error(`Project workflow escapes the project root: ${real} bundled into ${sourcePath}`);
   }
 }
 
@@ -429,7 +538,7 @@ function sanitizeId(value: string): string {
 }
 
 function isWorkflowEntry(filename: string): boolean {
-  return /\.(?:[cm]?[jt]s)$/.test(filename) && !filename.endsWith(".d.ts");
+  return /\.(?:[cm]?[jt]s)$/.test(filename) && !/\.d\.[cm]?ts$/.test(filename);
 }
 
 async function readWorkflowDirectory(path: string) {

--- a/packages/project-mounting-manager/src/manager.ts
+++ b/packages/project-mounting-manager/src/manager.ts
@@ -14,6 +14,13 @@ export interface ProjectMountingManagerOptions {
   readonly workspace?: Workspace;
   readonly specialistMaxSteps?: number;
   readonly requiredSpecialistTools?: readonly string[];
+  /**
+   * Host tool IDs that a project may not shadow but may not call either. Reserved IDs take part in
+   * collision detection without entering the published tool map, so they reach neither project
+   * specialists nor `getTools()`. Pass a reserved ID here rather than through `currentTools`:
+   * everything in `currentTools` is published to unrestricted specialists.
+   */
+  readonly reservedToolIds?: readonly string[];
   readonly onDiagnostic?: ProjectMountingDiagnosticListener;
 }
 
@@ -104,6 +111,7 @@ export class ProjectMountingManager {
 
       phase = "prepare";
       const publishedTools = mergeToolSnapshots(
+        this.#options.reservedToolIds ?? [],
         await this.#options.currentTools.snapshot(),
         await mcpStage.snapshot(),
         workflowTools(workflows),
@@ -141,6 +149,7 @@ export class ProjectMountingManager {
       generationId: id,
       specialists,
       tools: publishedTools,
+      reservedToolIds: this.#options.reservedToolIds ?? [],
       requiredTools: this.#options.requiredSpecialistTools ?? [],
       ...(this.#options.workspace ? { workspace: this.#options.workspace } : {}),
       maxSteps: this.#options.specialistMaxSteps ?? 48,
@@ -172,6 +181,7 @@ interface CreateSpecialistAgentsOptions {
   readonly generationId: number;
   readonly specialists: ReadonlyMap<string, ProjectSpecialist>;
   readonly tools: ToolsInput;
+  readonly reservedToolIds: readonly string[];
   readonly requiredTools: readonly string[];
   readonly workspace?: Workspace;
   readonly maxSteps: number;
@@ -179,8 +189,9 @@ interface CreateSpecialistAgentsOptions {
 
 function createSpecialistAgents(options: CreateSpecialistAgentsOptions): ReadonlyMap<string, Agent> {
   const agents = new Map<string, Agent>();
+  const reserved = new Set(options.reservedToolIds);
   for (const specialist of options.specialists.values()) {
-    const tools = selectSpecialistTools(specialist, options.tools, options.requiredTools);
+    const tools = selectSpecialistTools(specialist, options.tools, options.requiredTools, reserved);
     agents.set(specialist.id, new Agent({
       id: `project-specialist-${specialist.id}-${options.generationId}`,
       name: specialist.name,
@@ -199,10 +210,16 @@ function selectSpecialistTools(
   specialist: ProjectSpecialist,
   available: ToolsInput,
   required: readonly string[],
+  reserved: ReadonlySet<string>,
 ): ToolsInput {
+  // An unrestricted specialist receives every published tool, so reserved IDs are kept out of
+  // `available` upstream rather than filtered here.
   if (!specialist.tools) return { ...available };
   const selected: ToolsInput = {};
   for (const toolName of new Set([...specialist.tools, ...required])) {
+    if (reserved.has(toolName)) {
+      throw new Error(`Reserved host tool cannot be granted to specialist ${specialist.id}: ${toolName}`);
+    }
     if (!Object.hasOwn(available, toolName)) {
       throw new Error(`Unknown tool for specialist ${specialist.id}: ${toolName}`);
     }
@@ -219,10 +236,21 @@ function workflowTools(workflows: ReadonlyMap<string, ProjectWorkflow>): ToolsIn
   return tools;
 }
 
-function mergeToolSnapshots(...snapshots: readonly Readonly<ToolsInput>[]): ToolsInput {
+/**
+ * Reserved IDs are claimed before any snapshot is merged, so a project workflow still cannot shadow
+ * a host tool ID, but the reserved tool itself never becomes publishable.
+ */
+function mergeToolSnapshots(
+  reservedToolIds: readonly string[],
+  ...snapshots: readonly Readonly<ToolsInput>[]
+): ToolsInput {
   const merged: ToolsInput = {};
+  const reserved = new Set(reservedToolIds);
   for (const snapshot of snapshots) {
     for (const [id, tool] of Object.entries(snapshot)) {
+      if (reserved.has(id)) {
+        throw new Error(`Duplicate published tool ID: ${id} (reserved by the host)`);
+      }
       if (Object.hasOwn(merged, id)) throw new Error(`Duplicate published tool ID: ${id}`);
       merged[id] = tool;
     }

--- a/packages/project-mounting-manager/test/discovery-and-watcher.test.ts
+++ b/packages/project-mounting-manager/test/discovery-and-watcher.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
   discoverProjectSpecialists,
+  discoverProjectWorkflows,
   isProjectResourcePath,
 } from "../src/index.js";
 
@@ -44,6 +45,157 @@ describe("project watcher scope", () => {
     expect(isProjectResourcePath("/workspace/project", "../other/.mastracode/workflow/demo.ts")).toBe(false);
   });
 });
+
+describe("project workflow layout", () => {
+  test("bundles a helper subdirectory into the entrypoint and repropagates helper edits", async () => {
+    const { root, workflowDirectory } = await projectFixture("multi-file");
+    await mkdir(join(workflowDirectory, "steps"), { recursive: true });
+    await writeFile(join(workflowDirectory, "flow.ts"), workflowEntrypoint("flow", "./steps/one.js"));
+    await writeFile(join(workflowDirectory, "steps", "one.ts"), helperModule("first"));
+
+    const first = await discoverProjectWorkflows(root);
+    expect([...first.keys()]).toEqual(["flow"]);
+    expect(first.get("flow")?.source).toBe(".mastracode/workflow/flow.ts");
+
+    await writeFile(join(workflowDirectory, "steps", "one.ts"), helperModule("second"));
+    const second = await discoverProjectWorkflows(root);
+
+    expect([...second.keys()]).toEqual(["flow"]);
+    expect(second.get("flow")?.generation).not.toBe(first.get("flow")?.generation);
+  }, 30_000);
+
+  test("rejects a relative helper import that escapes the project root", async () => {
+    const { base, root, workflowDirectory } = await projectFixture("relative-escape");
+    await mkdir(join(base, "outside"), { recursive: true });
+    await writeFile(join(base, "outside", "evil.ts"), helperModule("evil"));
+    await writeFile(
+      join(workflowDirectory, "flow.ts"),
+      workflowEntrypoint("flow", "../../../outside/evil.js"),
+    );
+
+    await expect(discoverProjectWorkflows(root)).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("rejects an absolute helper import outside the project root", async () => {
+    const { base, root, workflowDirectory } = await projectFixture("absolute-escape");
+    await mkdir(join(base, "outside"), { recursive: true });
+    await writeFile(join(base, "outside", "evil.ts"), helperModule("evil"));
+    await writeFile(
+      join(workflowDirectory, "flow.ts"),
+      workflowEntrypoint("flow", join(base, "outside", "evil.js")),
+    );
+
+    await expect(discoverProjectWorkflows(root)).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("rejects an absolute helper import that does not exist on disk", async () => {
+    const { root, workflowDirectory } = await projectFixture("absolute-missing");
+    await writeFile(join(workflowDirectory, "flow.ts"), workflowEntrypoint("flow", "/etc/anything.js"));
+
+    await expect(discoverProjectWorkflows(root)).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("rejects a helper subdirectory entry symlinked outside the project root", async () => {
+    const { base, root, workflowDirectory } = await projectFixture("symlink-escape");
+    await mkdir(join(base, "outside"), { recursive: true });
+    await mkdir(join(workflowDirectory, "steps"), { recursive: true });
+    await writeFile(join(base, "outside", "evil.ts"), helperModule("evil"));
+    await symlink(join(base, "outside", "evil.ts"), join(workflowDirectory, "steps", "link.ts"));
+    await writeFile(join(workflowDirectory, "flow.ts"), workflowEntrypoint("flow", "./steps/link.js"));
+
+    await expect(discoverProjectWorkflows(root)).rejects.toThrow(/escapes the project root/);
+  }, 30_000);
+
+  test("names the helper-subdirectory layout when a flat sibling is not a workflow", async () => {
+    const { root, workflowDirectory } = await projectFixture("flat-helper");
+    await writeFile(join(workflowDirectory, "flow.ts"), workflowEntrypoint("flow", "./steps.js"));
+    await writeFile(join(workflowDirectory, "steps.ts"), helperModule("flat"));
+
+    const failure = await discoverProjectWorkflows(root).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toMatch(/must default-export a committed Mastra Workflow/);
+    expect((failure as Error).message).toMatch(/\.mastracode\/workflow\/steps\.ts/);
+    expect((failure as Error).message).toMatch(/subdirectory/i);
+  }, 30_000);
+
+  test("ignores declaration files in every module extension", async () => {
+    const { root, workflowDirectory } = await projectFixture("declarations");
+    await mkdir(join(workflowDirectory, "steps"), { recursive: true });
+    await writeFile(join(workflowDirectory, "flow.ts"), workflowEntrypoint("flow", "./steps/one.js"));
+    await writeFile(join(workflowDirectory, "steps", "one.ts"), helperModule("first"));
+    await writeFile(join(workflowDirectory, "types.d.ts"), "export type Unused = string;\n");
+    await writeFile(join(workflowDirectory, "types.d.mts"), "export type Unused = string;\n");
+    await writeFile(join(workflowDirectory, "types.d.cts"), "export type Unused = string;\n");
+
+    const workflows = await discoverProjectWorkflows(root);
+
+    expect([...workflows.keys()]).toEqual(["flow"]);
+  }, 30_000);
+
+  test("resolves a bare import from the importing helper's own resolution scope", async () => {
+    const { root, workflowDirectory } = await projectFixture("helper-scope");
+    const scopedPackage = join(workflowDirectory, "steps", "node_modules", "scoped-helper");
+    await mkdir(scopedPackage, { recursive: true });
+    await writeFile(
+      join(scopedPackage, "package.json"),
+      JSON.stringify({ name: "scoped-helper", version: "1.0.0", type: "module", exports: "./index.mjs" }),
+    );
+    await writeFile(join(scopedPackage, "index.mjs"), 'export const scopedValue = "scoped";\n');
+    await writeFile(join(workflowDirectory, "flow.ts"), workflowEntrypoint("flow", "./steps/one.js"));
+    await writeFile(
+      join(workflowDirectory, "steps", "one.ts"),
+      'import { scopedValue } from "scoped-helper";\n\nexport const helperValue = scopedValue;\n',
+    );
+
+    const workflows = await discoverProjectWorkflows(root);
+
+    expect([...workflows.keys()]).toEqual(["flow"]);
+  }, 30_000);
+});
+
+async function projectFixture(label: string): Promise<{
+  base: string;
+  root: string;
+  workflowDirectory: string;
+}> {
+  const base = await mkdtemp(join(tmpdir(), `project-workflow-${label}-`));
+  const root = join(base, "project");
+  const workflowDirectory = join(root, ".mastracode", "workflow");
+  await mkdir(workflowDirectory, { recursive: true });
+  return { base, root, workflowDirectory };
+}
+
+function workflowEntrypoint(id: string, helperSpecifier: string): string {
+  return `import { helperValue } from ${JSON.stringify(helperSpecifier)};
+
+const schema = {
+  "~standard": {
+    version: 1,
+    vendor: "fixture",
+    validate: (value: unknown) => ({ value }),
+  },
+};
+
+export default {
+  component: "WORKFLOW",
+  committed: true,
+  id: ${JSON.stringify(id)},
+  helperValue,
+  inputSchema: schema,
+  outputSchema: schema,
+  createRun: async () => ({
+    runId: ${JSON.stringify(`${id}-run`)},
+    cancel: async () => undefined,
+    start: async () => ({ status: "success", result: { helperValue } }),
+  }),
+};
+`;
+}
+
+function helperModule(value: string): string {
+  return `export const helperValue = ${JSON.stringify(value)};\n`;
+}
 
 function specialist(description: string): string {
   return `---\ndescription: ${description}\n---\n\nReview the project.`;

--- a/packages/project-mounting-manager/test/manager.test.ts
+++ b/packages/project-mounting-manager/test/manager.test.ts
@@ -117,6 +117,104 @@ describe("ProjectMountingManager", () => {
     expect(manager.diagnostics().at(-1)?.phase).toBe("prepare");
   });
 
+  test("keeps a reserved host tool ID out of an unrestricted project specialist", async () => {
+    const projectRoot = await projectFixture();
+    const manager = await ProjectMountingManager.create({
+      projectRoot,
+      modelAliases: { resolveSpecialistModel: alias => `openai/${alias ?? "specialist-default"}` },
+      mcp: new RecordingMcp(),
+      currentTools: { snapshot: () => ({ host_read: tool("host_read") }) },
+      reservedToolIds: ["dynamic_workflow"],
+      host: new RecordingHost(),
+    });
+
+    const specialistTools = await manager.snapshot().specialistAgents.get("review")!.listTools();
+
+    expect(Object.keys(specialistTools).sort()).toEqual(["host_read", "mcp_lookup", "workflow_demo"]);
+    expect(specialistTools).not.toHaveProperty("dynamic_workflow");
+  });
+
+  test("does not surface a reserved host tool ID through the host bridge", async () => {
+    const projectRoot = await projectFixture();
+    const manager = await ProjectMountingManager.create({
+      projectRoot,
+      modelAliases: { resolveSpecialistModel: alias => `openai/${alias ?? "specialist-default"}` },
+      mcp: new RecordingMcp(),
+      currentTools: { snapshot: () => ({ host_read: tool("host_read") }) },
+      reservedToolIds: ["dynamic_workflow"],
+      host: new RecordingHost(),
+    });
+
+    expect(Object.keys(manager.getTools()).sort()).toEqual([
+      "host_read",
+      "mcp_lookup",
+      "project_specialist",
+      "workflow_demo",
+    ]);
+    expect(manager.getTools()).not.toHaveProperty("dynamic_workflow");
+  });
+
+  test("still rejects a project workflow whose tool ID shadows a reserved host tool ID", async () => {
+    const projectRoot = await projectFixture();
+    await writeFile(join(projectRoot, ".mastracode", "workflow", "shadow.ts"), workflow("shadow", true));
+    const host = new RecordingHost();
+    const mcp = new RecordingMcp();
+
+    await expect(ProjectMountingManager.create({
+      projectRoot,
+      modelAliases: { resolveSpecialistModel: alias => `openai/${alias ?? "specialist-default"}` },
+      mcp,
+      currentTools: { snapshot: () => ({ host_read: tool("host_read") }) },
+      reservedToolIds: ["workflow_shadow"],
+      host,
+    })).rejects.toThrow("Duplicate published tool ID: workflow_shadow");
+
+    expect(host.current).toBeUndefined();
+    expect(mcp.currentGeneration).toBe(0);
+    expect(mcp.rollbackCount).toBe(1);
+  });
+
+  test("retains the last-known-good generation when a reload introduces a reserved-ID collision", async () => {
+    const projectRoot = await projectFixture();
+    const host = new RecordingHost();
+    const mcp = new RecordingMcp();
+    const manager = await ProjectMountingManager.create({
+      projectRoot,
+      modelAliases: { resolveSpecialistModel: alias => `openai/${alias ?? "specialist-default"}` },
+      mcp,
+      currentTools: { snapshot: () => ({ host_read: tool("host_read") }) },
+      reservedToolIds: ["workflow_shadow"],
+      host,
+    });
+    const first = manager.snapshot();
+    await writeFile(join(projectRoot, ".mastracode", "workflow", "shadow.ts"), workflow("shadow", true));
+
+    await expect(manager.reload()).rejects.toThrow("Duplicate published tool ID: workflow_shadow");
+
+    expect(manager.snapshot()).toBe(first);
+    expect(host.current?.generation.id).toBe(1);
+    expect(mcp.currentGeneration).toBe(1);
+    expect(mcp.rollbackCount).toBe(1);
+    expect(manager.diagnostics().at(-1)?.phase).toBe("prepare");
+  });
+
+  test("refuses a project specialist that asks for a reserved host tool by name", async () => {
+    const projectRoot = await projectFixture();
+    await writeFile(
+      join(projectRoot, ".github", "agents", "review.md"),
+      "---\ndescription: Review the project\ntools: [dynamic_workflow]\n---\n\nReview the current project.",
+    );
+
+    await expect(ProjectMountingManager.create({
+      projectRoot,
+      modelAliases: { resolveSpecialistModel: alias => `openai/${alias ?? "specialist-default"}` },
+      mcp: new RecordingMcp(),
+      currentTools: { snapshot: () => ({ host_read: tool("host_read") }) },
+      reservedToolIds: ["dynamic_workflow"],
+      host: new RecordingHost(),
+    })).rejects.toThrow("Reserved host tool cannot be granted to specialist review: dynamic_workflow");
+  });
+
   test("returns the value produced by Standard Schema output transformation", async () => {
     const projectRoot = await projectFixture();
     await writeFile(


### PR DESCRIPTION
Answers "should a dynamic workflow be one `.ts` file or several?" — several already worked; this PR locks that in, contains it, and documents it. No change was needed to the layout rule itself.

Two containment defects are fixed here: **bundled workflow files were never checked against the project root**, and **reserved host tool IDs reached project specialists**. Both are described in full below.

## Security: bundled files were never contained

**Only the workflow entrypoint was checked against the project root.** `assertWorkflowContained` ran on the entrypoint, and the esbuild externalizing filter `/^[^./]|^@/` intercepted only non-relative specifiers — it never matched `../…`, and it excludes a leading `/` too, so absolute specifiers escaped identically. Everything a workflow imported relatively was therefore bundled with **no realpath check**:

```ts
// .mastracode/workflow/flow.ts — bundled and executed before this PR
import { helperValue } from "../../../outside/evil.js";
import { other } from "/etc/anything.js";
```

The pre-fix contract test confirmed this rather than assuming it: discovery **resolved successfully** and returned a workflow carrying `helperValue: "evil"` read from outside the project root. The top-level symlink rejection covered only directory entries, so `steps/link.ts` symlinked out of the project escaped the same way. This code runs in the **MCode host process at discovery time** (see the recorded asymmetry below), so the escape is a host-process read of arbitrary paths, not a sandboxed one.

Containment now applies to every bundled file, in two layers:

1. **Before esbuild reads anything** — relative and absolute specifiers are resolved and gated against the project root, so a path that escapes is rejected even when the file does not exist (`/etc/anything.js` rejects with `escapes the project root`, not `Could not resolve`).
2. **After the build** — every `metafile` input is realpath-checked, catching files that only escape once symlinks are resolved.

Both the host loader and `SANDBOX_PROJECT_WORKFLOW_RUNNER` enforce this, so host and Factory now agree on what a valid multi-file workflow is.

## The sanctioned layout

Flat entrypoint plus helper subdirectory. This is a loader-enforced convention, not a manifest — adding a project manifest would violate `packages/project-mounting-manager/AGENTS.md`.

```text
.mastracode/workflow/
├── flow.ts        # entrypoint — default-exports a committed Workflow, optionally exports agentTool
└── steps/         # helpers — bundled into the entrypoint, never entrypoints themselves
    ├── one.ts
    └── two.ts
```

```ts
// .mastracode/workflow/steps/one.ts
export const helperValue = "first";

// .mastracode/workflow/flow.ts
import { helperValue } from "./steps/one.js";
import { createStep, createWorkflow } from "@mastra/core/workflows";

export const agentTool = { description: "Run flow" };
export default createWorkflow({ id: "flow", inputSchema, outputSchema }).then(step).commit();
```

- Every file **directly** in `.mastracode/workflow` is an entrypoint and must default-export a committed Workflow. Subdirectories are skipped as entrypoints.
- Relative imports are bundled into the entrypoint, so editing `steps/one.ts` changes the entrypoint's generation hash and the workflow reloads. The positive test asserts exactly one workflow, id taken from the entrypoint, and a changed generation after a helper edit.
- Bare specifiers are externalized and resolved from **the importing file's own directory first**, then the entrypoint's, then this package's.

## Other fixes

- **Resolution scope (broke multi-file specifically).** The plugin ignored `args.importer`/`args.resolveDir` and resolved every bare specifier through `createRequire(<entrypoint>)`, so a helper in a subdirectory could not rely on its own resolution scope. Now scoped per `resolveDir` with entrypoint and package fallbacks. Unresolvable specifiers previously surfaced a raw `MODULE_NOT_FOUND`; they now name the importer and state that tsconfig `paths` aliases are unsupported — an alias like `@steps/foo` matches the bare-specifier filter and is indistinguishable from a package name at this layer.
- **Actionable flat-helper failure.** A helper beside the entrypoint passes `entry.isFile()` and the extension regex, gets compiled and imported, fails `isCommittedWorkflow`, and **takes down the whole generation including specialists and MCP**. The error now names the supported layout.
- **Extension filter gap.** `isWorkflowEntry` excluded `.d.ts` but not `.d.mts`/`.d.cts`, so a stray `types.d.mts` bricked the generation identically. Now all three are skipped.

## Security: reserved host tools reached project specialists

Added after review, closing a hole that only this package can close. A companion lane (#178) stopped `dynamic_workflow` leaking to canonical agents by filtering the `getTools()` bridge in MCode. **That filter cannot reach project specialists.**

`manager.ts` builds specialists from `publishedTools` **directly**, while `getTools()` returns `{ ...publishedTools, project_specialist }`. The two are **siblings, not parent and child**, so no bridge-side filter affects specialists:

```
                    ┌─ createSpecialistAgents({ tools: publishedTools })   ← filter never reaches here
publishedTools ─────┤
                    └─ snapshot().tools = { ...publishedTools, project_specialist } ─→ getTools()  ← filtered by #178
```

Measured blast radius before that lane's fix: an unrestricted project specialist's **entire tool map was `['dynamic_workflow']`**. Project specialists are defined by project content — untrusted input — so a reserved host orchestration tool reaching them is the sharper half of the original defect.

`packages/mcode/src/runtime.ts:367` already documented the *intended* contract — "Reported, not published: the mounting manager rejects a project workflow that would shadow a reserved host tool id" — but the mechanism it used (`currentTools`) publishes everything it carries. This PR makes the code match that comment.

**The seam:**

```ts
readonly reservedToolIds?: readonly string[];
```

Reserved IDs are claimed in `mergeToolSnapshots` before any snapshot is merged, so they take part in collision detection **without entering `publishedTools`** — and therefore reach neither `createSpecialistAgents` nor `getTools()`. Hosts migrate a reserved ID from `currentTools` to `reservedToolIds`; anything left in `currentTools` is still published to unrestricted specialists, which is what that port is for.

- **Shadow-rejection preserved.** A project workflow whose tool ID collides with a reserved ID is still rejected. The message keeps its existing `Duplicate published tool ID: <id>` prefix and only appends `(reserved by the host)`, so substring assertions on the old text still match.
- **Rollback preserved.** `reservedToolIds` is a static option read during the `prepare` phase and touches no staging path. A dedicated test reloads a project into a reserved-ID collision and asserts the last-known-good generation is retained by identity, with MCP and host resources rolled back. Emptying `currentTools` — the approach that loses rollback — was not used.
- A specialist naming a reserved ID is now refused **as reserved** rather than misdiagnosed as an unknown tool.

Test fixtures use a specialist with **no `tools:` key**; a fixture writing `tools: []` takes the restricted branch and would pass vacuously.

## Recorded, not closed (see `packages/project-mounting-manager/CONTEXT.md`)

- **Host-vs-Factory asymmetry.** Loading a project workflow executes its top-level module code in the MCode host process at discovery time with **no approval and no sandbox**; only the subsequent run is approval-gated. Factory requires approval before even *listing*, for exactly that reason. Multi-file widens the code an entrypoint can pull in without a reviewer seeing it in one file. Containment bounds *where* that code comes from, not *whether* it runs.
- **Shared compilation cache.** Compiled bundles land in one unversioned temp directory keyed by entrypoint basename plus content hash, so same-basename workflows from different projects with identical content share one file, and stale bundles are never cleaned.

## Contract-test order

Per `AGENTS.md` ("Add or update a failing contract test before changing production behavior"), commit 1 adds the workflow-layout tests and they fail; commits 2–3 make them pass. Commit 5 adds the `reservedToolIds` tests and they fail; commit 6 makes them pass. No test anywhere in the repo previously covered a multi-file or subdirectory workflow, nor reserved-tool publication scope.

For the reserved-tool set, 3 of 5 tests fail at runtime before the fix (the shadowing workflow is accepted because the option is ignored). The two publication-scope tests fail at **typecheck** instead — `TS2353`, the option does not exist — and pass vacuously at runtime; they are contract locks on the property MCode depends on, not runtime reds. Called out rather than papered over.

## Brief contradiction, resolved toward the safer reading

The brief asked for a stray `types.d.mts` to reject with the helper-subdirectory message, but its own work item 4 asks to exclude `.d.mts`/`.d.cts` from the entry filter and notes that the helper message "would misdiagnose it". These cannot both hold. Implemented as item 4 describes: declaration files are **skipped**, and the test asserts the generation survives them. The helper-subdirectory message is asserted on the flat non-workflow sibling, where it is the correct diagnosis.

## Validation

| Check | Result |
| --- | --- |
Rebased onto current `origin/main` (`d541642`), clean.

| Check | Result |
| --- | --- |
| `npm run typecheck` | pass, no output |
| `npm test` | pass — 41 files, 292 tests |
| `npm test --workspace @rlabs/project-mounting-manager` | pass — 2 files, 21 tests |
| `git diff --check` | clean |
| `npm run build` | **known pre-existing failure, not chased** |

`npm run build` fails from a clean install with `Failed to analyze Mastra application: packages/mcode/src/index.ts (30:7): Expected ',', got 'ident'`. Pre-existing on `main` and in a package this branch does not touch — the diff is confined to `packages/project-mounting-manager/{src/contract.ts,src/discovery.ts,src/manager.ts,CONTEXT.md,test/discovery-and-watcher.test.ts,test/manager.test.ts}` and `packages/factory-integration/test/project-workflow.test.ts`. Reported as known-blocked; separate lane.

Test-run stderr shows `✘ [ERROR] Project workflow escapes the project root: …` lines — that is esbuild echoing the containment rejections it was handed, from the passing negative tests, not failures.

Docs are owned by another lane; no `docs/` or `README.md` file was edited. The layout convention above is ready to be lifted into user-facing documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
