### PR TITLE
fix(agent-tools): make every dynamic-workflow ceiling actually bind

### DIFF
--- a/packages/agent-tools/src/capabilities.ts
+++ b/packages/agent-tools/src/capabilities.ts
@@ -115,8 +115,40 @@ function isDeduplicatedTool(toolName: string): boolean {
     || isExternalWriteTool(toolName);
 }
 
+/**
+ * Tools whose cost is exactly one delegation per call.
+ *
+ * `dynamic_workflow` is deliberately absent. Its cost is the number of agents
+ * its graph dispatches, which is one for a single agent entry and up to the
+ * fan-out ceiling for a `foreach`, and that number is known only after the
+ * graph has been validated and clamped inside the tool. It charges itself
+ * through `chargeRunDelegations` instead of being counted once here.
+ */
 function isDelegationTool(toolName: string): boolean {
   return toolName === "subagent" || /^agent-[a-z0-9][a-z0-9_-]*$/i.test(toolName);
+}
+
+/**
+ * Charges delegations against the live run budget from outside the tool hook.
+ *
+ * `beforeToolCall` sees a tool's name and its authored input, so it can only
+ * charge a fixed cost per call. A tool that dispatches a variable number of
+ * agents knows its real cost only once it has validated its own request, and
+ * the agents it dispatches never pass back through the hook — a workflow's
+ * agent steps invoke the agent directly rather than through a tool. Such a
+ * tool is the only thing that can report its own cost, so it charges here.
+ *
+ * No-ops when the host installed no run budget, matching the hook: an
+ * unmetered host stays unmetered rather than gaining state from a charge.
+ */
+export function chargeRunDelegations(requestContext: RequestContext, count: number): void {
+  if (count <= 0) return;
+  const state = requestContext.get(RUN_BUDGET_CONTEXT_KEY) as RunBudgetState | undefined;
+  if (!state) return;
+  state.delegations += count;
+  if (state.delegations > RUN_MAX_DELEGATIONS) {
+    throw new Error("Run budget exhausted: aggregate delegation limit reached");
+  }
 }
 
 function isExternalWriteTool(toolName: string): boolean {

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -27,14 +27,15 @@ const MAX_RETAINED_CHARS = 24_000;
 const MAX_INSPECT_RUNS = 20;
 
 /**
- * Bumped whenever any ceiling above changes. The value is digested with the
- * graph, so a definition stored under one policy can never be mistaken for the
- * same graph clamped under another, and `resume` can say which policy a
- * suspended run belongs to instead of reporting a bare digest mismatch.
+ * Bump when a ceiling change should orphan outstanding suspended runs even
+ * though the numbers alone would not say so. `ceilingPolicyDrift` compares
+ * every field, so a forgotten bump still produces the named error rather than
+ * an opaque digest mismatch; the version exists to name the generation.
  */
 const CEILING_POLICY_VERSION = 1;
 
-export const DYNAMIC_WORKFLOW_CEILING_POLICY = Object.freeze({
+/** Persisted in each definition's metadata, so a stored graph carries the ceilings it was admitted under. */
+const CEILING_POLICY = Object.freeze({
   version: CEILING_POLICY_VERSION,
   maxGraphEntries: MAX_GRAPH_ENTRIES,
   maxFanOut: MAX_FAN_OUT,
@@ -42,10 +43,8 @@ export const DYNAMIC_WORKFLOW_CEILING_POLICY = Object.freeze({
   maxSleepMs: MAX_SLEEP_MS,
 });
 
-const CEILING_POLICY = DYNAMIC_WORKFLOW_CEILING_POLICY;
-
 /** Named so a model that cannot resume learns why, and that the run is unrecoverable rather than mistyped. */
-export const DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH = "ceiling_policy_mismatch";
+const CEILING_POLICY_MISMATCH = "ceiling_policy_mismatch";
 
 /**
  * Three bounds used to be set independently and could not all hold at once.
@@ -55,25 +54,15 @@ export const DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH = "ceiling_policy_mismatch
  * `cancel()` is still in flight and the run is never contained. The harness
  * bound in turn has to fit inside the aggregate run budget, or a single
  * dynamic workflow can outlive the wall clock that is supposed to contain the
- * whole agent run. `timeBoundsInvariant` is the executable statement of that
- * ordering.
+ * whole agent run.
+ *
+ * The harness bound is therefore derived from the authored cap rather than set
+ * beside it, so the two cannot drift apart, and the package test asserts the
+ * remaining leg against `RUN_CONTAINMENT_POLICY.maxWallClockMs`.
  */
 const MAX_TIMEOUT_MS = 600_000;
 const CANCELLATION_GRACE_MS = 30_000;
 const BACKGROUND_TIMEOUT_MS = MAX_TIMEOUT_MS + CANCELLATION_GRACE_MS;
-
-export const DYNAMIC_WORKFLOW_TIME_BOUNDS = Object.freeze({
-  maxTimeoutMs: MAX_TIMEOUT_MS,
-  cancellationGraceMs: CANCELLATION_GRACE_MS,
-  backgroundTimeoutMs: BACKGROUND_TIMEOUT_MS,
-  runBudgetWallClockMs: RUN_CONTAINMENT_POLICY.maxWallClockMs,
-});
-
-/** True only while every authored timeout can still be cancelled and reported inside the run budget. */
-export function timeBoundsInvariant(): boolean {
-  return MAX_TIMEOUT_MS < BACKGROUND_TIMEOUT_MS
-    && BACKGROUND_TIMEOUT_MS <= RUN_CONTAINMENT_POLICY.maxWallClockMs;
-}
 
 const identifier = z.string().min(1).max(64).regex(/^[A-Za-z0-9_-]+$/);
 const jsonSchemaObject = z.record(z.string(), z.unknown());
@@ -482,8 +471,10 @@ function checkEntry(entry: DynamicWorkflowGraphEntry, path: string, check: Check
       checkEntry(entry.step, `${path}.step`, check);
       return;
     case "parallel":
+      entry.steps.forEach((step, index) => checkEntry(step, `${path}.steps.${index}`, check));
+      return;
     case "conditional":
-      if (entry.type === "conditional" && entry.predicates.length !== entry.steps.length) {
+      if (entry.predicates.length !== entry.steps.length) {
         check.issues.push(`${path}: predicates must align one-to-one with steps`);
       }
       entry.steps.forEach((step, index) => checkEntry(step, `${path}.steps.${index}`, check));
@@ -687,7 +678,7 @@ async function resume(
   if (drift) {
     return fail(
       "resume",
-      `${DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH}: run was suspended under ceiling policy `
+      `${CEILING_POLICY_MISMATCH}: run was suspended under ceiling policy `
       + `v${drift.storedVersion ?? "unversioned"}, and this runtime enforces v${CEILING_POLICY_VERSION} `
       + `(${drift.changed.join(", ")}). Ceilings changed while the run was suspended, so it cannot be `
       + "resumed under them. Author the graph again.",
@@ -770,8 +761,8 @@ async function runBelongsToWorkflow(
   return { ok: true };
 }
 
-function emptyInspect(truncated = false): Output {
-  return { version: 1 as const, action: "inspect" as const, runs: [], resumable: false, truncated };
+function emptyInspect(): Output {
+  return { version: 1 as const, action: "inspect" as const, runs: [], resumable: false, truncated: false };
 }
 
 /**

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -24,6 +24,7 @@ const MAX_CONCURRENCY = 3;
 const MAX_SLEEP_MS = 60_000;
 const MAX_ROW_CHARS = 2_000;
 const MAX_RETAINED_CHARS = 24_000;
+const MAX_INSPECT_RUNS = 20;
 
 /**
  * Bumped whenever any ceiling above changes. The value is digested with the
@@ -206,7 +207,9 @@ const outputSchema = z.object({
     workflowId: z.string(),
     runId: z.string(),
     status: z.string(),
-  }).passthrough()).max(20).optional(),
+    /** Resumable step paths, so a caller can resume from `inspect` alone. */
+    suspended: z.array(z.array(z.string())).max(8).optional(),
+  }).passthrough()).max(MAX_INSPECT_RUNS).optional(),
   resumable: z.boolean(),
   truncated: z.boolean(),
 }).strict();
@@ -753,31 +756,82 @@ async function runBelongsToWorkflow(
   return { ok: true };
 }
 
+function emptyInspect(truncated = false): Output {
+  return { version: 1 as const, action: "inspect" as const, runs: [], resumable: false, truncated };
+}
+
+/**
+ * Pages per dynamic workflow id rather than paging the whole runs table and
+ * filtering afterwards: a shared table's first page belongs to whichever
+ * workflow ran most recently, so a dynamic run behind any busier workflow used
+ * to be silently absent from its own inspection.
+ */
 async function inspect(
   host: DynamicWorkflowHost,
   input: { workflowId?: string | undefined; runId?: string | undefined },
 ): Promise<Output> {
   const store = await definitionsStore(host);
-  if (!store) return { version: 1 as const, action: "inspect" as const, runs: [], resumable: false, truncated: false };
+  if (!store) return emptyInspect();
   const { definitions } = await store.list({ status: "archived" });
-  const workflowIds = new Set(definitions
+  const workflowIds = definitions
     .filter(definition => definition.metadata?.origin === DYNAMIC_WORKFLOW_ORIGIN)
     .filter(definition => !input.workflowId || definition.id === input.workflowId)
-    .map(definition => definition.id));
+    .map(definition => definition.id);
   const runsStore = await workflowRunsStore(host);
-  if (!runsStore || workflowIds.size === 0) {
-    return { version: 1 as const, action: "inspect" as const, runs: [], resumable: false, truncated: false };
+  if (!runsStore || workflowIds.length === 0) return emptyInspect();
+
+  const collected: WorkflowRunRow[] = [];
+  let pageTruncated = false;
+  for (const workflowId of workflowIds) {
+    const listed = await runsStore.listWorkflowRuns({ workflowName: workflowId, perPage: MAX_INSPECT_RUNS });
+    // Defensive: a store that ignores `workflowName` must not widen the result.
+    const owned = listed.runs.filter(run => run.workflowName === workflowId);
+    if (typeof listed.total === "number" && listed.total > owned.length) pageTruncated = true;
+    collected.push(...owned);
   }
-  const listed = await runsStore.listWorkflowRuns({
-    ...(input.workflowId ? { workflowName: input.workflowId } : {}),
-    perPage: 20,
+
+  const matching = input.runId ? collected.filter(run => run.runId === input.runId) : collected;
+  const runs = matching.slice(0, MAX_INSPECT_RUNS).map(run => {
+    const suspended = suspendedStepPaths(run.snapshot);
+    return {
+      workflowId: run.workflowName,
+      runId: run.runId,
+      status: workflowRunStatus(run.snapshot),
+      ...(suspended.length > 0 ? { suspended: suspended.slice(0, 8) } : {}),
+    };
   });
-  const runs = listed.runs
-    .filter(run => workflowIds.has(run.workflowName))
-    .filter(run => !input.runId || run.runId === input.runId)
-    .slice(0, 20)
-    .map(run => ({ workflowId: run.workflowName, runId: run.runId, status: workflowRunStatus(run.snapshot) }));
-  return { version: 1 as const, action: "inspect" as const, runs, resumable: false, truncated: false };
+  return {
+    version: 1 as const,
+    action: "inspect" as const,
+    runs,
+    resumable: runs.some(run => run.status === "suspended"),
+    // A located run is a complete answer; otherwise a cut page may have hidden it.
+    truncated: input.runId
+      ? matching.length === 0 && pageTruncated
+      : pageTruncated || matching.length > MAX_INSPECT_RUNS,
+  };
+}
+
+/**
+ * The resumable step paths upstream derives from a suspended snapshot, so a
+ * model that lost its transcript can pass one straight back as `step`.
+ */
+function suspendedStepPaths(snapshot: unknown): string[][] {
+  const parsed = parseSnapshot(snapshot);
+  const suspendedPaths = parsed?.suspendedPaths;
+  if (!suspendedPaths || typeof suspendedPaths !== "object") return [];
+  const context = (parsed.context ?? {}) as Record<string, unknown>;
+  const paths: string[][] = [];
+  for (const stepId of Object.keys(suspendedPaths as Record<string, unknown>)) {
+    const stepResult = context[stepId] as {
+      status?: unknown;
+      suspendPayload?: { __workflow_meta?: { path?: unknown } };
+    } | undefined;
+    if (stepResult?.status !== "suspended") continue;
+    const nested = stepResult.suspendPayload?.__workflow_meta?.path;
+    paths.push(Array.isArray(nested) ? [stepId, ...nested.map(String)] : [stepId]);
+  }
+  return paths;
 }
 
 interface RunMeta {
@@ -797,8 +851,12 @@ async function execute(
   const signal = context.abortSignal ? AbortSignal.any([context.abortSignal, timeout]) : timeout;
   let rejectAbort: ((reason: Error) => void) | undefined;
   const aborted = new Promise<never>((_resolve, reject) => { rejectAbort = reject; });
+  // Held so the caller's `finally` can wait for containment to settle before
+  // unregistering. Cancelling and unregistering concurrently would drop a live
+  // workflow out of the registry while it is still executing.
+  let cancellation: Promise<void> | undefined;
   const cancel = () => {
-    void workflowRun.cancel().catch(() => undefined);
+    cancellation ??= workflowRun.cancel().catch(() => undefined);
     rejectAbort?.(new Error(context.abortSignal?.aborted ? "Dynamic workflow was cancelled" : "Dynamic workflow timed out"));
   };
   signal.addEventListener("abort", cancel, { once: true });
@@ -834,7 +892,18 @@ async function execute(
     };
   } finally {
     signal.removeEventListener("abort", cancel);
+    // Bounded, because an upstream `cancel()` that never settles must not pin
+    // the tool call open past the harness deadline. A stale registration is
+    // the lesser failure once the grace has elapsed.
+    if (cancellation) await Promise.race([cancellation, grace(CANCELLATION_GRACE_MS)]);
   }
+}
+
+function grace(ms: number): Promise<void> {
+  return new Promise<void>(resolve => {
+    const timer = setTimeout(resolve, ms);
+    (timer as unknown as { unref?: () => void }).unref?.();
+  });
 }
 
 /**
@@ -919,13 +988,23 @@ async function workflowRunsStore(host: DynamicWorkflowHost): Promise<WorkflowRun
   return store?.listWorkflowRuns ? store : undefined;
 }
 
-function workflowRunStatus(snapshot: unknown): string {
+interface RunSnapshot {
+  readonly status?: unknown;
+  readonly suspendedPaths?: unknown;
+  readonly context?: unknown;
+}
+
+/** Snapshots arrive as objects from some stores and as JSON text from others. */
+function parseSnapshot(snapshot: unknown): RunSnapshot | undefined {
   let value = snapshot;
   if (typeof value === "string") {
-    try { value = JSON.parse(value) as unknown; } catch { return "unknown"; }
+    try { value = JSON.parse(value) as unknown; } catch { return undefined; }
   }
-  if (!value || typeof value !== "object") return "unknown";
-  const status = (value as { status?: unknown }).status;
+  return value && typeof value === "object" ? value as RunSnapshot : undefined;
+}
+
+function workflowRunStatus(snapshot: unknown): string {
+  const status = parseSnapshot(snapshot)?.status;
   return typeof status === "string" ? status : "unknown";
 }
 

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -683,13 +683,14 @@ async function resume(
   // digest of every graph clamped under the old one. Without this the run
   // would fail as a content mismatch, which reads as corruption rather than as
   // a deliberate policy change nobody can resume across.
-  const storedVersion = ceilingPolicyVersion(definition.metadata.ceilingPolicy);
-  if (storedVersion !== CEILING_POLICY_VERSION) {
+  const drift = ceilingPolicyDrift(definition.metadata.ceilingPolicy);
+  if (drift) {
     return fail(
       "resume",
       `${DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH}: run was suspended under ceiling policy `
-      + `v${storedVersion ?? "unversioned"}, and this runtime enforces v${CEILING_POLICY_VERSION}. `
-      + "Ceilings changed while the run was suspended, so it cannot be resumed. Author the graph again.",
+      + `v${drift.storedVersion ?? "unversioned"}, and this runtime enforces v${CEILING_POLICY_VERSION} `
+      + `(${drift.changed.join(", ")}). Ceilings changed while the run was suspended, so it cannot be `
+      + "resumed under them. Author the graph again.",
     );
   }
   const prepared = prepare(parsed.data, allowedAgents, allowedWorkflows);
@@ -723,10 +724,23 @@ async function resume(
   }
 }
 
-function ceilingPolicyVersion(value: unknown): number | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const version = (value as { version?: unknown }).version;
-  return typeof version === "number" ? version : undefined;
+/**
+ * Compares the whole stored policy rather than its version alone, so lowering
+ * a ceiling without remembering to bump `CEILING_POLICY_VERSION` still yields
+ * the named error instead of an opaque digest mismatch. Returns `undefined`
+ * when the stored policy matches this runtime's exactly.
+ */
+function ceilingPolicyDrift(
+  value: unknown,
+): { storedVersion: number | undefined; changed: string[] } | undefined {
+  const stored = (value && typeof value === "object" ? value : {}) as Record<string, unknown>;
+  const storedVersion = typeof stored.version === "number" ? stored.version : undefined;
+  const changed = Object.entries(CEILING_POLICY)
+    .filter(([key, current]) => stored[key] !== current)
+    .map(([key, current]) => `${key}: ${String(stored[key] ?? "absent")} -> ${String(current)}`);
+  const extra = Object.keys(stored).filter(key => !(key in CEILING_POLICY));
+  if (changed.length === 0 && extra.length === 0) return undefined;
+  return { storedVersion, changed: [...changed, ...extra.map(key => `${key}: removed`)] };
 }
 
 /**

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -378,7 +378,7 @@ export function createDynamicWorkflowTool(options: DynamicWorkflowToolOptions) {
       // Charged before anything is registered or started, so an over-budget
       // graph dispatches nothing. Throws like the other containment guards.
       chargeRunDelegations(context.requestContext, graphDelegationCost(prepared.graph, input.input));
-      return run(host, prepared, input, context, childRequestContext);
+      return run(host, prepared, input, context, childRequestContext, resumable);
     },
   });
 }
@@ -718,6 +718,7 @@ async function run(
   input: { description: string; input: unknown; timeoutMs: number },
   context: ToolContext,
   childRequestContext: RequestContext,
+  resumable: boolean,
 ): Promise<Output> {
   try {
     await register(host, prepared.workflowId, prepared.stored);
@@ -743,7 +744,7 @@ async function run(
         ...writerBridge(context),
       }),
       workflowRun,
-      { action: "run", workflowId: prepared.workflowId, digest: prepared.digest, timeoutMs: input.timeoutMs },
+      { action: "run", workflowId: prepared.workflowId, digest: prepared.digest, timeoutMs: input.timeoutMs, resumable },
       context,
     );
   } finally {
@@ -827,7 +828,7 @@ async function resume(
         ...writerBridge(context),
       }),
       workflowRun,
-      { action: "resume", workflowId: input.workflowId, timeoutMs: input.timeoutMs },
+      { action: "resume", workflowId: input.workflowId, timeoutMs: input.timeoutMs, resumable: true },
       context,
     );
   } finally {
@@ -968,6 +969,8 @@ interface RunMeta {
   readonly workflowId: string;
   readonly digest?: string;
   readonly timeoutMs: number;
+  /** Whether this host permits resume, so a suspended run reports what the caller can actually do. */
+  readonly resumable: boolean;
 }
 
 async function execute(
@@ -994,6 +997,11 @@ async function execute(
     const result = await Promise.race([start(), aborted]);
     const bounded = boundSteps(result.steps);
     const boundedOutput = boundOutput(result.result);
+    // A run that suspended on a host with resume disabled is finished, not
+    // paused. Reporting only `resumable: false` would leave the model to infer
+    // that from a "suspended" status, so the reason is stated outright.
+    const stranded = result.status === "suspended" && !meta.resumable;
+    const error = errorText(result, stranded);
     return {
       version: 1 as const,
       action: meta.action,
@@ -1002,10 +1010,12 @@ async function execute(
       runId: workflowRun.runId,
       status: result.status as Output["status"],
       ...(boundedOutput.output === undefined ? {} : { output: boundedOutput.output }),
-      ...(result.error ? { error: String(result.error.message ?? result.error).slice(0, 2_000) } : {}),
+      ...(error ? { error } : {}),
+      // Kept even when stranded: the paths say where the graph stopped, which
+      // is what re-authoring needs, while `resumable` carries the bad news.
       ...(result.suspended ? { suspended: result.suspended.map(path => ({ path })).slice(0, 8) } : {}),
       steps: bounded.steps,
-      resumable: result.status === "suspended",
+      resumable: result.status === "suspended" && meta.resumable,
       truncated: bounded.truncated || boundedOutput.truncated,
     };
   } catch (error) {
@@ -1026,6 +1036,15 @@ async function execute(
     // the lesser failure once the grace has elapsed.
     if (cancellation) await Promise.race([cancellation, grace(CANCELLATION_GRACE_MS)]);
   }
+}
+
+/** The workflow's own error, or the reason a suspended run can never continue here. */
+function errorText(result: WorkflowResultLike, stranded: boolean): string | undefined {
+  if (result.error) return String(result.error.message ?? result.error).slice(0, 2_000);
+  if (!stranded) return undefined;
+  return "Run suspended, but this host does not support resuming a dynamic workflow run. "
+    + "It cannot be continued, and its workflowId and runId are not usable for recovery. "
+    + "Re-author the graph without a suspending step.";
 }
 
 function grace(ms: number): Promise<void> {

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -4,7 +4,7 @@ import type { Workspace } from "@mastra/core/workspace";
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { validateStoredWorkflow } from "@mastra/core/workflows";
-import { RUN_BUDGET_CONTEXT_KEY } from "./capabilities.js";
+import { RUN_BUDGET_CONTEXT_KEY, RUN_CONTAINMENT_POLICY } from "./capabilities.js";
 
 /**
  * Marks a dispatched run so a delegated agent cannot author another graph.
@@ -21,10 +21,58 @@ const DYNAMIC_WORKFLOW_ID_PATTERN = /^dyn_[0-9a-f]{16}$/;
 const MAX_GRAPH_ENTRIES = 16;
 const MAX_FAN_OUT = 8;
 const MAX_CONCURRENCY = 3;
-const MAX_NESTING_DEPTH = 2;
 const MAX_SLEEP_MS = 60_000;
 const MAX_ROW_CHARS = 2_000;
 const MAX_RETAINED_CHARS = 24_000;
+
+/**
+ * Bumped whenever any ceiling above changes. The value is digested with the
+ * graph, so a definition stored under one policy can never be mistaken for the
+ * same graph clamped under another, and `resume` can say which policy a
+ * suspended run belongs to instead of reporting a bare digest mismatch.
+ */
+const CEILING_POLICY_VERSION = 1;
+
+export const DYNAMIC_WORKFLOW_CEILING_POLICY = Object.freeze({
+  version: CEILING_POLICY_VERSION,
+  maxGraphEntries: MAX_GRAPH_ENTRIES,
+  maxFanOut: MAX_FAN_OUT,
+  maxConcurrency: MAX_CONCURRENCY,
+  maxSleepMs: MAX_SLEEP_MS,
+});
+
+const CEILING_POLICY = DYNAMIC_WORKFLOW_CEILING_POLICY;
+
+/** Named so a model that cannot resume learns why, and that the run is unrecoverable rather than mistyped. */
+export const DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH = "ceiling_policy_mismatch";
+
+/**
+ * Three bounds used to be set independently and could not all hold at once.
+ *
+ * The tool's own `timeoutMs` must expire strictly before the background
+ * harness reclaims the call, or the harness kills the invocation while
+ * `cancel()` is still in flight and the run is never contained. The harness
+ * bound in turn has to fit inside the aggregate run budget, or a single
+ * dynamic workflow can outlive the wall clock that is supposed to contain the
+ * whole agent run. `timeBoundsInvariant` is the executable statement of that
+ * ordering.
+ */
+const MAX_TIMEOUT_MS = 600_000;
+const CANCELLATION_GRACE_MS = 30_000;
+const BACKGROUND_TIMEOUT_MS = MAX_TIMEOUT_MS + CANCELLATION_GRACE_MS;
+
+export const DYNAMIC_WORKFLOW_TIME_BOUNDS = Object.freeze({
+  maxTimeoutMs: MAX_TIMEOUT_MS,
+  cancellationGraceMs: CANCELLATION_GRACE_MS,
+  backgroundTimeoutMs: BACKGROUND_TIMEOUT_MS,
+  runBudgetWallClockMs: RUN_CONTAINMENT_POLICY.maxWallClockMs,
+});
+
+/** True only while every authored timeout can still be cancelled and reported inside the run budget. */
+export function timeBoundsInvariant(): boolean {
+  return MAX_TIMEOUT_MS < BACKGROUND_TIMEOUT_MS
+    && BACKGROUND_TIMEOUT_MS <= RUN_CONTAINMENT_POLICY.maxWallClockMs;
+}
 
 const identifier = z.string().min(1).max(64).regex(/^[A-Za-z0-9_-]+$/);
 const jsonSchemaObject = z.record(z.string(), z.unknown());
@@ -75,11 +123,15 @@ const parallelEntrySchema = z.object({
   steps: z.array(agentEntrySchema).min(1).max(MAX_CONCURRENCY),
 }).strict();
 
-const suspendableInnerSchema = z.discriminatedUnion("type", [agentEntrySchema, workflowEntrySchema]);
-
+/**
+ * Branch bodies are agents only, matching `foreach` and `parallel`. Every
+ * container therefore holds leaf entries exclusively, so a container can never
+ * hold another container and graph nesting is bounded by the union itself
+ * rather than by a depth counter that has to be trusted and kept in sync.
+ */
 const conditionalEntrySchema = z.object({
   type: z.literal("conditional"),
-  steps: z.array(suspendableInnerSchema).min(1).max(MAX_CONCURRENCY),
+  steps: z.array(agentEntrySchema).min(1).max(MAX_CONCURRENCY),
   // Predicates are upstream's declarative language; `validateStoredWorkflow` is their authority.
   predicates: z.array(z.unknown()).min(1),
 }).strict();
@@ -116,7 +168,7 @@ const inputSchema = z.discriminatedUnion("action", [
       "A Mastra workflow graph as data. Agents and nested workflows are referenced by id and resolved against this runtime.",
     ),
     input: z.unknown().default({}).describe("Validated at run time against the definition's own inputSchema."),
-    timeoutMs: z.number().int().min(1_000).max(600_000).default(300_000),
+    timeoutMs: z.number().int().min(1_000).max(MAX_TIMEOUT_MS).default(300_000),
     dryRun: z.boolean().default(false).describe("Validate and content-address only. No approval, no execution, no persistence."),
   }).strict(),
   z.object({
@@ -126,7 +178,7 @@ const inputSchema = z.discriminatedUnion("action", [
     runId: z.string().min(1).max(200),
     step: z.array(z.string().min(1)).min(1).max(8).optional(),
     resumeData: z.unknown().default({}),
-    timeoutMs: z.number().int().min(1_000).max(600_000).default(300_000),
+    timeoutMs: z.number().int().min(1_000).max(MAX_TIMEOUT_MS).default(300_000),
   }).strict(),
   z.object({
     action: z.literal("inspect"),
@@ -198,10 +250,18 @@ interface WorkflowDefinitionsStore {
   list(args?: { status?: "active" | "archived" }): Promise<{ definitions: WorkflowDefinitionRow[] }>;
 }
 
+interface WorkflowRunRow {
+  readonly workflowName: string;
+  readonly runId: string;
+  readonly snapshot: unknown;
+}
+
 interface WorkflowRunsStore {
   listWorkflowRuns(args?: { workflowName?: string; perPage?: number }): Promise<{
-    runs: Array<{ workflowName: string; runId: string; snapshot: unknown }>;
+    runs: WorkflowRunRow[];
+    total?: number;
   }>;
+  getWorkflowRunById?(args: { runId: string; workflowName?: string }): Promise<WorkflowRunRow | null>;
 }
 
 /**
@@ -232,7 +292,7 @@ export function createDynamicWorkflowTool(options: DynamicWorkflowToolOptions) {
     outputSchema,
     requireApproval: input =>
       input.action === "run" ? !input.dryRun : input.action === "resume",
-    background: { enabled: true, timeoutMs: 600_000 },
+    background: { enabled: true, timeoutMs: BACKGROUND_TIMEOUT_MS },
     mcp: {
       annotations: {
         title: "Dynamic Workflow",
@@ -270,6 +330,22 @@ export function createDynamicWorkflowTool(options: DynamicWorkflowToolOptions) {
           action: "run" as const,
           status: "invalid" as const,
           issues: prepared.issues.slice(0, 24),
+          resumable: false,
+          truncated: false,
+        };
+      }
+      // Width is checked on the dry-run path too, so a graph validated for free
+      // with its real input cannot still be refused once an approval is spent.
+      const widthIssues: string[] = [];
+      checkInputWidth(prepared.stored.inputSchema, input.input, "input", widthIssues);
+      if (widthIssues.length > 0) {
+        return {
+          version: 1 as const,
+          action: "run" as const,
+          workflowId: prepared.workflowId,
+          graphDigest: prepared.digest,
+          status: "invalid" as const,
+          issues: widthIssues.slice(0, 24),
           resumable: false,
           truncated: false,
         };
@@ -326,25 +402,31 @@ function prepare(
   const issues: string[] = [];
   const ids = new Set<string>();
   definition.graph.forEach((entry, index) => {
-    checkEntry(entry, `graph.${index}`, 0, { allowedAgents, allowedWorkflows, ids, issues, topLevel: true });
+    checkEntry(entry, `graph.${index}`, { allowedAgents, allowedWorkflows, ids, issues });
   });
+  checkForeachSources(definition, issues);
   if (issues.length > 0) return { ok: false, issues };
 
   const graph = definition.graph.map(clampEntry);
   const inputSchema = boundArraySchema(definition.inputSchema);
   const outputSchema = boundArraySchema(definition.outputSchema);
+  const stateSchema = definition.stateSchema ? boundArraySchema(definition.stateSchema) : undefined;
   const digest = createHash("sha256")
-    .update(canonicalJson({ inputSchema, outputSchema, stateSchema: definition.stateSchema, graph }))
+    .update(canonicalJson({ ceilingPolicy: CEILING_POLICY, inputSchema, outputSchema, stateSchema, graph }))
     .digest("hex");
   const workflowId = `dyn_${digest.slice(0, 16)}`;
   const stored = {
     id: workflowId,
     inputSchema,
     outputSchema,
-    ...(definition.stateSchema ? { stateSchema: definition.stateSchema } : {}),
+    ...(stateSchema ? { stateSchema } : {}),
     graph,
     ...(definition.description ? { description: definition.description } : {}),
-    metadata: { origin: DYNAMIC_WORKFLOW_ORIGIN, graphDigest: `sha256:${digest}` },
+    metadata: {
+      origin: DYNAMIC_WORKFLOW_ORIGIN,
+      graphDigest: `sha256:${digest}`,
+      ceilingPolicy: CEILING_POLICY,
+    },
   };
   const upstreamIssues = validateStoredWorkflow(stored as never, {
     agents: Object.fromEntries([...allowedAgents].map(id => [id, {}])),
@@ -369,14 +451,9 @@ interface CheckContext {
   readonly allowedWorkflows: ReadonlySet<string>;
   readonly ids: Set<string>;
   readonly issues: string[];
-  readonly topLevel: boolean;
 }
 
-function checkEntry(entry: DynamicWorkflowGraphEntry, path: string, depth: number, check: CheckContext): void {
-  if (depth > MAX_NESTING_DEPTH) {
-    check.issues.push(`${path}: container nesting exceeds depth ${MAX_NESTING_DEPTH}`);
-    return;
-  }
+function checkEntry(entry: DynamicWorkflowGraphEntry, path: string, check: CheckContext): void {
   switch (entry.type) {
     case "agent":
       claimId(entry.id, path, check);
@@ -397,24 +474,92 @@ function checkEntry(entry: DynamicWorkflowGraphEntry, path: string, depth: numbe
           `${path}.workflowId: nested workflow "${entry.workflowId}" is not allowlisted for dynamic use`,
         );
       }
-      if (!check.topLevel && depth > 0) {
-        check.issues.push(`${path}: a nested workflow may only appear at the top level or as a loop body`);
-      }
       return;
     case "foreach":
-      checkEntry(entry.step, `${path}.step`, depth + 1, { ...check, topLevel: false });
+      checkEntry(entry.step, `${path}.step`, check);
       return;
     case "parallel":
-      entry.steps.forEach((step, index) =>
-        checkEntry(step, `${path}.steps.${index}`, depth + 1, { ...check, topLevel: false }));
-      return;
     case "conditional":
-      if (entry.predicates.length !== entry.steps.length) {
+      if (entry.type === "conditional" && entry.predicates.length !== entry.steps.length) {
         check.issues.push(`${path}: predicates must align one-to-one with steps`);
       }
-      entry.steps.forEach((step, index) =>
-        checkEntry(step, `${path}.steps.${index}`, depth + 1, { ...check, topLevel: false }));
+      entry.steps.forEach((step, index) => checkEntry(step, `${path}.steps.${index}`, check));
       return;
+  }
+}
+
+/**
+ * Rejects rather than clamps. Concurrency is a scheduling knob the host may
+ * silently rewrite, but the iteration source is the author's declared unit of
+ * work: quietly reducing a declared `maxItems: 50` to 8 would run a twelfth of
+ * the requested fan-out and report success, so an over-wide source is refused
+ * with the ceiling named instead.
+ */
+function checkForeachSources(definition: DynamicWorkflowDefinition, issues: string[]): void {
+  definition.graph.forEach((entry, index) => {
+    if (entry.type !== "foreach") return;
+    const source = foreachSourceSchema(definition, index);
+    const declared = declaredMaxItems(source);
+    if (declared === undefined || declared <= MAX_FAN_OUT) return;
+    issues.push(
+      `graph.${index}: foreach iterates a source declaring maxItems ${declared}, `
+      + `above the ${MAX_FAN_OUT}-iteration ceiling. Narrow the source or split the work across runs.`,
+    );
+  });
+}
+
+/**
+ * The schema feeding a `foreach`, for the positions where it is statically
+ * knowable. A nested workflow's or mapping's output shape lives outside this
+ * definition, so those predecessors yield `undefined` and the run-time width
+ * check in `checkInputWidth` remains the binding control.
+ */
+function foreachSourceSchema(definition: DynamicWorkflowDefinition, index: number): unknown {
+  if (index === 0) return definition.inputSchema;
+  const previous = definition.graph[index - 1];
+  if (previous?.type === "agent") return previous.outputSchema;
+  return undefined;
+}
+
+function declaredMaxItems(schema: unknown): number | undefined {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return undefined;
+  const record = schema as Record<string, unknown>;
+  if (record.type !== "array") return undefined;
+  return typeof record.maxItems === "number" ? record.maxItems : undefined;
+}
+
+/**
+ * Counts elements at every array-typed path of the clamped input schema.
+ *
+ * This is the fan-out ceiling. Upstream's `jsonSchemaToZod` builds array
+ * schemas as `z.array(walk(items))` and never reads `maxItems` — the keyword
+ * is not even in its `UNSUPPORTED_SCHEMA_KEYS`, so a stamped ceiling is
+ * silently discarded rather than rejected. Nothing downstream of `start()`
+ * counts elements, so an unchecked 200-element input would turn one approval
+ * into 200 agent invocations.
+ */
+function checkInputWidth(schema: unknown, value: unknown, path: string, issues: string[]): void {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return;
+  const record = schema as Record<string, unknown>;
+  if (record.type === "array" && Array.isArray(value)) {
+    const limit = typeof record.maxItems === "number" ? Math.min(record.maxItems, MAX_FAN_OUT) : MAX_FAN_OUT;
+    if (value.length > limit) {
+      issues.push(
+        `${path}: ${value.length} elements exceeds the ${limit}-element fan-out ceiling. `
+        + "Split the work across runs.",
+      );
+      return;
+    }
+    value.forEach((element, index) => checkInputWidth(record.items, element, `${path}[${index}]`, issues));
+    return;
+  }
+  if (record.type === "object" && value && typeof value === "object" && !Array.isArray(value)) {
+    const properties = record.properties;
+    if (!properties || typeof properties !== "object") return;
+    for (const [key, child] of Object.entries(properties as Record<string, unknown>)) {
+      if (!(key in (value as Record<string, unknown>))) continue;
+      checkInputWidth(child, (value as Record<string, unknown>)[key], `${path}.${key}`, issues);
+    }
   }
 }
 
@@ -443,8 +588,14 @@ function clampAgent(entry: z.infer<typeof agentEntrySchema>): z.infer<typeof age
 }
 
 /**
- * A `maxItems` ceiling on every array schema is the only static bound on
- * fan-out width, and `jsonSchemaToZod` enforces it at run time.
+ * Stamps a `maxItems` ceiling on every array schema, so the persisted
+ * definition states the width it was admitted under.
+ *
+ * This is documentation, not enforcement. Upstream's `jsonSchemaToZod` builds
+ * `z.array(walk(items))` and never reads `maxItems`, and the keyword is absent
+ * from its `UNSUPPORTED_SCHEMA_KEYS`, so a rehydrated definition drops the
+ * ceiling silently rather than refusing it. `checkInputWidth` is what actually
+ * binds, before `start()`.
  */
 function boundArraySchema(schema: unknown): unknown {
   if (!schema || typeof schema !== "object") return schema;
@@ -525,11 +676,26 @@ async function resume(
     ...(definition.description ? { description: definition.description } : {}),
   });
   if (!parsed.success) return fail("resume", "Stored definition no longer satisfies the authoring contract");
+  // Checked before re-preparing, because lowering any ceiling changes the
+  // digest of every graph clamped under the old one. Without this the run
+  // would fail as a content mismatch, which reads as corruption rather than as
+  // a deliberate policy change nobody can resume across.
+  const storedVersion = ceilingPolicyVersion(definition.metadata.ceilingPolicy);
+  if (storedVersion !== CEILING_POLICY_VERSION) {
+    return fail(
+      "resume",
+      `${DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH}: run was suspended under ceiling policy `
+      + `v${storedVersion ?? "unversioned"}, and this runtime enforces v${CEILING_POLICY_VERSION}. `
+      + "Ceilings changed while the run was suspended, so it cannot be resumed. Author the graph again.",
+    );
+  }
   const prepared = prepare(parsed.data, allowedAgents, allowedWorkflows);
   if (!prepared.ok) return fail("resume", `Stored definition is outside current authority: ${prepared.issues.join("; ")}`);
   if (prepared.workflowId !== input.workflowId || definition.metadata.graphDigest !== prepared.digest) {
     return fail("resume", "Stored definition identity or digest does not match its content");
   }
+  const owned = await runBelongsToWorkflow(host, input.workflowId, input.runId);
+  if (!owned.ok) return fail("resume", owned.error);
   try {
     await register(host, input.workflowId, prepared.stored);
   } catch (error) {
@@ -552,6 +718,39 @@ async function resume(
   } finally {
     await unregister(host, input.workflowId);
   }
+}
+
+function ceilingPolicyVersion(value: unknown): number | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const version = (value as { version?: unknown }).version;
+  return typeof version === "number" ? version : undefined;
+}
+
+/**
+ * `createRun({ runId })` mints a fresh run for an id it does not recognise, so
+ * an unverified resume would silently start a second run of the graph under
+ * the caller's chosen id instead of continuing the suspended one. Fails closed
+ * when the runtime cannot answer, because an unverifiable id is exactly the
+ * case this guards.
+ */
+async function runBelongsToWorkflow(
+  host: DynamicWorkflowHost,
+  workflowId: string,
+  runId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const runsStore = await workflowRunsStore(host);
+  if (!runsStore?.getWorkflowRunById) {
+    return { ok: false, error: "This runtime cannot verify run ownership, so resume is refused" };
+  }
+  const row = await runsStore.getWorkflowRunById({ runId, workflowName: workflowId });
+  if (!row || row.workflowName !== workflowId) {
+    return { ok: false, error: `Run ${runId} does not exist for ${workflowId}` };
+  }
+  const status = workflowRunStatus(row.snapshot);
+  if (status !== "suspended") {
+    return { ok: false, error: `Run ${runId} is ${status}, not suspended, so there is nothing to resume` };
+  }
+  return { ok: true };
 }
 
 async function inspect(

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -4,7 +4,7 @@ import type { Workspace } from "@mastra/core/workspace";
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { validateStoredWorkflow } from "@mastra/core/workflows";
-import { RUN_BUDGET_CONTEXT_KEY, RUN_CONTAINMENT_POLICY } from "./capabilities.js";
+import { chargeRunDelegations, RUN_BUDGET_CONTEXT_KEY } from "./capabilities.js";
 
 /**
  * Marks a dispatched run so a delegated agent cannot author another graph.
@@ -353,6 +353,9 @@ export function createDynamicWorkflowTool(options: DynamicWorkflowToolOptions) {
           truncated: false,
         };
       }
+      // Charged before anything is registered or started, so an over-budget
+      // graph dispatches nothing. Throws like the other containment guards.
+      chargeRunDelegations(context.requestContext, graphDelegationCost(prepared.graph, input.input));
       return run(host, prepared, input, context, childRequestContext);
     },
   });
@@ -382,6 +385,8 @@ interface PreparedDefinition {
   readonly workflowId: string;
   readonly digest: string;
   readonly stored: Record<string, unknown>;
+  /** The clamped graph, so its delegation cost is charged against the real ceilings. */
+  readonly graph: DynamicWorkflowGraphEntry[];
 }
 
 type PrepareResult = PreparedDefinition | { readonly ok: false; readonly issues: string[] };
@@ -435,6 +440,7 @@ function prepare(
     workflowId,
     digest: `sha256:${digest}`,
     stored,
+    graph,
   };
 }
 
@@ -520,6 +526,49 @@ function declaredMaxItems(schema: unknown): number | undefined {
   const record = schema as Record<string, unknown>;
   if (record.type !== "array") return undefined;
   return typeof record.maxItems === "number" ? record.maxItems : undefined;
+}
+
+/**
+ * How many agent dispatches a clamped graph authorizes.
+ *
+ * This is what one approval actually buys, and it is charged against the
+ * aggregate delegation ceiling before anything starts. Counting the tool call
+ * as a single delegation would under-count badly: `MAX_GRAPH_ENTRIES` alone
+ * lets a sequential graph dispatch sixteen agents, and a `foreach` multiplies
+ * one entry by the fan-out ceiling.
+ *
+ * Two positions are upper bounds rather than exact. A `conditional` charges
+ * every branch, because which predicates hold is a run-time fact. A `foreach`
+ * charges its real iteration count when the source is this graph's own input
+ * and that input is in hand, and the fan-out ceiling otherwise.
+ *
+ * One position under-counts and cannot do better here: a nested `workflow`
+ * charges one, though the allowlisted workflow it names may dispatch agents of
+ * its own. Those live outside this definition, and the host chose to allowlist
+ * them.
+ */
+function graphDelegationCost(
+  graph: readonly DynamicWorkflowGraphEntry[],
+  input: unknown,
+): number {
+  return graph.reduce((total, entry, index) => total + entryDelegationCost(entry, index, input), 0);
+}
+
+function entryDelegationCost(entry: DynamicWorkflowGraphEntry, index: number, input: unknown): number {
+  switch (entry.type) {
+    case "agent":
+      return 1;
+    case "workflow":
+      return 1;
+    case "parallel":
+    case "conditional":
+      return entry.steps.length;
+    case "foreach":
+      return index === 0 && Array.isArray(input) ? Math.min(input.length, MAX_FAN_OUT) : MAX_FAN_OUT;
+    case "mapping":
+    case "sleep":
+      return 0;
+  }
 }
 
 /**
@@ -691,6 +740,10 @@ async function resume(
   }
   const owned = await runBelongsToWorkflow(host, input.workflowId, input.runId);
   if (!owned.ok) return fail("resume", owned.error);
+  // The whole graph, not the unexecuted remainder: which steps already ran is
+  // a property of the snapshot, not of the definition, so this is an upper
+  // bound. Over-charging a resume is the safe direction.
+  chargeRunDelegations(context.requestContext, graphDelegationCost(prepared.graph, undefined));
   try {
     await register(host, input.workflowId, prepared.stored);
   } catch (error) {

--- a/packages/agent-tools/src/dynamic-workflow.ts
+++ b/packages/agent-tools/src/dynamic-workflow.ts
@@ -46,6 +46,9 @@ const CEILING_POLICY = Object.freeze({
 /** Named so a model that cannot resume learns why, and that the run is unrecoverable rather than mistyped. */
 const CEILING_POLICY_MISMATCH = "ceiling_policy_mismatch";
 
+/** Named so a cross-tenant attempt is never mistaken for a ceiling change or for corruption. */
+const SCOPE_MISMATCH = "scope_mismatch";
+
 /**
  * Three bounds used to be set independently and could not all hold at once.
  *
@@ -214,6 +217,17 @@ export interface DynamicWorkflowToolOptions {
   /** Registered workflow ids a graph may nest; all other workflow references fail closed. */
   readonly nestedWorkflows?: readonly string[];
   readonly authorize?: (context: DynamicWorkflowAuthorizationContext) => Promise<void> | void;
+  /**
+   * Host-derived, request-scoped tenant key.
+   *
+   * Opaque here: this package never interprets it, only hashes it. Supplying
+   * it makes the workflow id content-addressed over the scope as well as the
+   * graph, so two tenants authoring an identical graph no longer collapse onto
+   * one id, and confines `inspect` and `resume` to the caller's own tenant.
+   * Throwing fails the call closed. Omitting it leaves every id, digest, and
+   * stored row exactly as it was before scoping existed.
+   */
+  readonly scope?: (context: DynamicWorkflowAuthorizationContext) => Promise<string> | string;
   /** Hosts without durable request-context reconstruction may disable resume. */
   readonly resumable?: boolean;
 }
@@ -297,25 +311,33 @@ export function createDynamicWorkflowTool(options: DynamicWorkflowToolOptions) {
       if (context.requestContext.get(DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY) === 1) {
         throw new Error("Nested dynamic_workflow calls are not allowed");
       }
-      await options.authorize?.({
+      const authorizationContext = {
         requestContext: context.requestContext,
         ...(context.workspace ? { workspace: context.workspace } : {}),
-      });
+      };
+      await options.authorize?.(authorizationContext);
+      // Resolved before any action so `inspect` is confined too, and before
+      // any host call so a scope the host cannot derive stops the call here.
+      const authority: GraphAuthority = {
+        allowedAgents,
+        allowedWorkflows,
+        scopeDigest: await resolveScopeDigest(options.scope, authorizationContext),
+      };
       const host = context.mastra as unknown as DynamicWorkflowHost | undefined;
       if (!host?.addStoredWorkflow) throw new Error("dynamic_workflow requires an active Mastra runtime");
       const childRequestContext = dispatchContext(
         context.requestContext,
       );
 
-      if (input.action === "inspect") return inspect(host, input);
+      if (input.action === "inspect") return inspect(host, input, authority.scopeDigest);
       if (input.action === "resume") {
         if (!resumable) {
           return fail("resume", "This host does not support resuming a dynamic workflow run");
         }
-        return resume(host, input, context, childRequestContext, allowedAgents, allowedWorkflows);
+        return resume(host, input, context, childRequestContext, authority);
       }
 
-      const prepared = prepare(input.definition, allowedAgents, allowedWorkflows);
+      const prepared = prepare(input.definition, authority);
       if (!prepared.ok) {
         return {
           version: 1 as const,
@@ -391,11 +413,37 @@ interface PreparedDefinition {
 
 type PrepareResult = PreparedDefinition | { readonly ok: false; readonly issues: string[] };
 
+/** What a caller is allowed to reference, and which tenant it acts for. */
+interface GraphAuthority {
+  readonly allowedAgents: ReadonlySet<string>;
+  readonly allowedWorkflows: ReadonlySet<string>;
+  /** `sha256(scope)`, or undefined when the host configured no scope. */
+  readonly scopeDigest: string | undefined;
+}
+
+/**
+ * Hashes the host's tenant key so the raw value never reaches storage, a
+ * digest, or an error message. An empty key is refused rather than hashed,
+ * because it would silently place every caller of a misconfigured host into
+ * one shared scope.
+ */
+async function resolveScopeDigest(
+  scope: DynamicWorkflowToolOptions["scope"],
+  context: DynamicWorkflowAuthorizationContext,
+): Promise<string | undefined> {
+  if (!scope) return undefined;
+  const value = await scope(context);
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("dynamic_workflow scope resolved to an empty value");
+  }
+  return createHash("sha256").update(value).digest("hex");
+}
+
 function prepare(
   definition: DynamicWorkflowDefinition,
-  allowedAgents: ReadonlySet<string>,
-  allowedWorkflows: ReadonlySet<string>,
+  authority: GraphAuthority,
 ): PrepareResult {
+  const { allowedAgents, allowedWorkflows, scopeDigest } = authority;
   const issues: string[] = [];
   const ids = new Set<string>();
   definition.graph.forEach((entry, index) => {
@@ -408,8 +456,20 @@ function prepare(
   const inputSchema = boundArraySchema(definition.inputSchema);
   const outputSchema = boundArraySchema(definition.outputSchema);
   const stateSchema = definition.stateSchema ? boundArraySchema(definition.stateSchema) : undefined;
+  // `scopeDigest` is a sibling of the graph rather than part of the ceiling
+  // policy: a tenant boundary and a containment ceiling drift for unrelated
+  // reasons, and folding them together would let a cross-tenant call report
+  // itself as a ceiling change. `canonicalJson` drops undefined entries, so an
+  // unscoped host hashes exactly the bytes it hashed before scoping existed.
   const digest = createHash("sha256")
-    .update(canonicalJson({ ceilingPolicy: CEILING_POLICY, inputSchema, outputSchema, stateSchema, graph }))
+    .update(canonicalJson({
+      ceilingPolicy: CEILING_POLICY,
+      scopeDigest,
+      inputSchema,
+      outputSchema,
+      stateSchema,
+      graph,
+    }))
     .digest("hex");
   const workflowId = `dyn_${digest.slice(0, 16)}`;
   const stored = {
@@ -423,6 +483,7 @@ function prepare(
       origin: DYNAMIC_WORKFLOW_ORIGIN,
       graphDigest: `sha256:${digest}`,
       ceilingPolicy: CEILING_POLICY,
+      ...(scopeDigest ? { scopeDigest } : {}),
     },
   };
   const upstreamIssues = validateStoredWorkflow(stored as never, {
@@ -701,8 +762,7 @@ async function resume(
   },
   context: ToolContext,
   childRequestContext: RequestContext,
-  allowedAgents: ReadonlySet<string>,
-  allowedWorkflows: ReadonlySet<string>,
+  authority: GraphAuthority,
 ): Promise<Output> {
   const store = await definitionsStore(host);
   if (!store) return fail("resume", "This runtime has no workflow definition storage");
@@ -710,6 +770,13 @@ async function resume(
   if (!definition) return fail("resume", `No stored definition for ${input.workflowId}`);
   if (definition.metadata?.origin !== DYNAMIC_WORKFLOW_ORIGIN) {
     return fail("resume", "Stored definition is outside dynamic_workflow authority");
+  }
+  // Ahead of every other check, so a caller that guessed an id learns nothing
+  // about another tenant's row — not its ceilings, not its content. A row
+  // stored without a scopeDigest matches only an unscoped caller, so turning
+  // scoping on retires legacy rows rather than sharing them with everyone.
+  if (definition.metadata.scopeDigest !== authority.scopeDigest) {
+    return fail("resume", `${SCOPE_MISMATCH}: this run belongs to a different scope`);
   }
   const parsed = definitionSchema.safeParse({
     inputSchema: definition.inputSchema,
@@ -733,7 +800,7 @@ async function resume(
       + "resumed under them. Author the graph again.",
     );
   }
-  const prepared = prepare(parsed.data, allowedAgents, allowedWorkflows);
+  const prepared = prepare(parsed.data, authority);
   if (!prepared.ok) return fail("resume", `Stored definition is outside current authority: ${prepared.issues.join("; ")}`);
   if (prepared.workflowId !== input.workflowId || definition.metadata.graphDigest !== prepared.digest) {
     return fail("resume", "Stored definition identity or digest does not match its content");
@@ -827,12 +894,16 @@ function emptyInspect(): Output {
 async function inspect(
   host: DynamicWorkflowHost,
   input: { workflowId?: string | undefined; runId?: string | undefined },
+  scopeDigest: string | undefined,
 ): Promise<Output> {
   const store = await definitionsStore(host);
   if (!store) return emptyInspect();
   const { definitions } = await store.list({ status: "archived" });
   const workflowIds = definitions
     .filter(definition => definition.metadata?.origin === DYNAMIC_WORKFLOW_ORIGIN)
+    // Existence, count, and status are the leak here, so the tenant filter has
+    // to sit on the definition list rather than on the runs it produces.
+    .filter(definition => definition.metadata?.scopeDigest === scopeDigest)
     .filter(definition => !input.workflowId || definition.id === input.workflowId)
     .map(definition => definition.id);
   const runsStore = await workflowRunsStore(host);

--- a/packages/agent-tools/test/agent-tools.test.ts
+++ b/packages/agent-tools/test/agent-tools.test.ts
@@ -8,6 +8,9 @@ import {
   createToolAuditHooks,
   RUN_CONTAINMENT_POLICY,
 } from "../src/index.js";
+// Not on the package facade: only `dynamic-workflow.ts` charges this way, and
+// widening the root export surface is a separate decision.
+import { chargeRunDelegations } from "../src/capabilities.js";
 
 describe("agent tool policies", () => {
   test("exports the canonical run containment policy used by host descriptors", () => {
@@ -112,6 +115,27 @@ describe("agent tool policies", () => {
       ...retainedCall,
       output: "x".repeat(256_001),
     })).toThrow(/retained tool output limit/);
+  });
+
+  test("charges a variable-cost delegation against the same aggregate ceiling", async () => {
+    const hooks = createRunBudgetHooks(() => 1_000);
+    const requestContext = new RequestContext();
+    const context = { requestContext };
+
+    // A tool whose fan-out is known only after it validates its own request
+    // charges itself, because the hook sees a name and an authored input and
+    // the agents it dispatches never pass back through the hook.
+    await hooks.beforeToolCall?.({ toolName: "dynamic_workflow", input: { action: "run" }, context });
+    chargeRunDelegations(requestContext, 6);
+    expect(() => hooks.beforeToolCall?.({ toolName: "subagent", input: { task: "a" }, context }))
+      .not.toThrow();
+    expect(() => chargeRunDelegations(requestContext, 2)).toThrow(/delegation limit/);
+  });
+
+  test("ignores a delegation charge when the host installed no run budget", () => {
+    // Hosts without the budget hooks are unmetered by design; charging must
+    // not invent state that the hooks would otherwise own.
+    expect(() => chargeRunDelegations(new RequestContext(), 4)).not.toThrow();
   });
 
   test("does not import role, Code SDK, or Factory code", async () => {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -8,9 +8,13 @@ import { z } from "zod";
 import {
   createDynamicWorkflowTool,
   createRunBudgetHooks,
+  DYNAMIC_WORKFLOW_CEILING_POLICY,
+  DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH,
   DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY,
   DYNAMIC_WORKFLOW_ORIGIN,
+  DYNAMIC_WORKFLOW_TIME_BOUNDS,
   reconcileDynamicWorkflowDefinitions,
+  timeBoundsInvariant,
 } from "../src/index.js";
 
 const helper = createWorkflow({
@@ -35,22 +39,58 @@ const largeOutput = createWorkflow({
   execute: async () => ({ value: `head-${"x".repeat(40_000)}-tail` }),
 })).commit();
 
+/** Suspends until resumed, so the durable resume path can be exercised end to end. */
+const pausing = createWorkflow({
+  id: "pausing",
+  inputSchema: z.object({ task: z.string() }),
+  outputSchema: z.object({ done: z.string() }),
+}).then(createStep({
+  id: "await-approval",
+  inputSchema: z.object({ task: z.string() }),
+  outputSchema: z.object({ done: z.string() }),
+  resumeSchema: z.object({ approved: z.string() }),
+  suspendSchema: z.object({}),
+  execute: async ({ inputData, resumeData, suspend }) => {
+    if (!resumeData) return await suspend({});
+    return { done: `${resumeData.approved}:${inputData.task}` };
+  },
+})).commit();
+
+/** Streams a chunk through the tool writer so the writer bridge is observable. */
+const streaming = createWorkflow({
+  id: "streaming",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ done: z.string() }),
+}).then(createStep({
+  id: "emit",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ done: z.string() }),
+  execute: async ({ writer }) => {
+    await writer?.write({ note: "streamed" });
+    return { done: "streamed" };
+  },
+})).commit();
+
 function harness() {
   const flux = new Agent({ id: "flux", name: "flux", instructions: "test", model: "openai/gpt-4o-mini" });
   const mastra = new Mastra({
     agents: { flux },
-    workflows: { helper, largeOutput },
+    workflows: { helper, largeOutput, pausing, streaming },
     storage: new InMemoryStore(),
     logger: false as never,
   });
   const tool = createDynamicWorkflowTool({
     agents: ["flux"],
-    nestedWorkflows: ["helper", "large-output"],
+    nestedWorkflows: ["helper", "large-output", "pausing", "streaming"],
   });
-  const invoke = (input: unknown, requestContext = new RequestContext()) =>
+  const invoke = (
+    input: unknown,
+    requestContext = new RequestContext(),
+    extra: Record<string, unknown> = {},
+  ) =>
     (tool as unknown as {
       execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
-    }).execute(input, { mastra, requestContext });
+    }).execute(input, { mastra, requestContext, ...extra });
   return { mastra, flux, tool, invoke };
 }
 
@@ -793,6 +833,368 @@ describe("dynamic_workflow", () => {
     expect(result.truncated).toBe(true);
     expect(result.resumable).toBe(true);
     expect((result.runs as Array<{ suspended?: string[][] }>)[0]?.suspended).toEqual([["paused"]]);
+  });
+
+  test("suspends a durable run and resumes it to completion", async () => {
+    const { invoke } = harness();
+    const definition = {
+      inputSchema: objectSchema,
+      outputSchema: doneSchema,
+      graph: [{ type: "workflow", id: "p", workflowId: "pausing" }],
+    };
+
+    const started = await invoke({
+      action: "run",
+      description: "await approval",
+      definition,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+
+    expect(started.status).toBe("suspended");
+    expect(started.resumable).toBe(true);
+    const suspended = started.suspended as Array<{ path: string[] }>;
+    expect(suspended.length).toBeGreaterThan(0);
+
+    const resumed = await invoke({
+      action: "resume",
+      description: "approve",
+      workflowId: started.workflowId,
+      runId: started.runId,
+      step: suspended[0]?.path,
+      resumeData: { approved: "yes" },
+      timeoutMs: 30_000,
+    });
+
+    expect(resumed.status).toBe("success");
+    expect(resumed.output).toEqual({ done: "yes:ship" });
+  });
+
+  test("refuses to resume a run id that does not belong to the workflow", async () => {
+    const { invoke } = harness();
+    const started = await invoke({
+      action: "run",
+      description: "await approval",
+      definition: {
+        inputSchema: objectSchema,
+        outputSchema: doneSchema,
+        graph: [{ type: "workflow", id: "p", workflowId: "pausing" }],
+      },
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+    expect(started.status).toBe("suspended");
+
+    const result = await invoke({
+      action: "resume",
+      description: "resume a stranger",
+      workflowId: started.workflowId,
+      runId: "never-existed",
+      resumeData: { approved: "yes" },
+      timeoutMs: 1_000,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/does not exist/i);
+  });
+
+  test("names the ceiling policy when a suspended run outlives it", async () => {
+    const { mastra, invoke } = harness();
+    const started = await invoke({
+      action: "run",
+      description: "await approval",
+      definition: {
+        inputSchema: objectSchema,
+        outputSchema: doneSchema,
+        graph: [{ type: "workflow", id: "p", workflowId: "pausing" }],
+      },
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+    expect(started.status).toBe("suspended");
+
+    const store = await (mastra.getStorage() as unknown as {
+      getStore(name: string): Promise<{
+        get(id: string): Promise<Record<string, unknown> | null>;
+        upsert(input: Record<string, unknown>): Promise<unknown>;
+      }>;
+    }).getStore("workflowDefinitions");
+    const stored = await store.get(started.workflowId as string);
+    // Stands in for a runtime that lowered a ceiling while the run was
+    // suspended, and did so without remembering to bump the policy version.
+    await store.upsert({
+      ...stored,
+      status: "archived",
+      metadata: {
+        ...(stored?.metadata as Record<string, unknown>),
+        ceilingPolicy: { ...DYNAMIC_WORKFLOW_CEILING_POLICY, maxFanOut: 64 },
+      },
+    });
+
+    const result = await invoke({
+      action: "resume",
+      description: "approve",
+      workflowId: started.workflowId,
+      runId: started.runId,
+      resumeData: { approved: "yes" },
+      timeoutMs: 1_000,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain(DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH);
+    expect(result.error).toContain("maxFanOut");
+    // The opaque content mismatch was what orphaned suspended runs before.
+    expect(result.error).not.toMatch(/digest does not match/i);
+  });
+
+  test("runs a conditional branch and a parallel fan-out over authored agents", async () => {
+    const { flux, invoke } = harness();
+    const stream = stubAgentStream(flux);
+    const predicate = { op: "truthy", value: { literal: true } };
+
+    const conditional = await invoke({
+      action: "run",
+      description: "conditional",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: { prompt: "go" },
+      definition: {
+        inputSchema: promptSchema,
+        outputSchema: { type: "object" },
+        graph: [{
+          type: "conditional",
+          steps: [{ type: "agent", id: "branch", agentId: "flux" }],
+          predicates: [predicate],
+        }],
+      },
+    });
+
+    expect(conditional.status).toBe("success");
+    expect(stream.calls).toBe(1);
+
+    const parallel = await invoke({
+      action: "run",
+      description: "parallel",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: { prompt: "go" },
+      definition: {
+        inputSchema: promptSchema,
+        outputSchema: { type: "object" },
+        graph: [{
+          type: "parallel",
+          steps: [
+            { type: "agent", id: "left", agentId: "flux" },
+            { type: "agent", id: "right", agentId: "flux" },
+          ],
+        }],
+      },
+    });
+
+    expect(parallel.status).toBe("success");
+    expect(stream.calls).toBe(3);
+  });
+
+  test("bridges workflow chunks to the caller's writer", async () => {
+    const { invoke } = harness();
+    const chunks: unknown[] = [];
+
+    const result = await invoke({
+      action: "run",
+      description: "stream",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: {},
+      definition: {
+        inputSchema: { type: "object" },
+        outputSchema: doneSchema,
+        graph: [{ type: "workflow", id: "s", workflowId: "streaming" }],
+      },
+    }, new RequestContext(), {
+      writer: { write: async (chunk: unknown) => { chunks.push(chunk); } },
+    });
+
+    expect(result.status).toBe("success");
+    // Chunks arrive in the workflow's own step-output envelope, not raw.
+    expect(chunks).toContainEqual(expect.objectContaining({
+      type: "workflow-step-output",
+      payload: expect.objectContaining({ stepName: "emit", output: { note: "streamed" } }),
+    }));
+  });
+
+  test("cancels when the caller aborts rather than when the timeout expires", async () => {
+    const tool = createDynamicWorkflowTool({ agents: ["flux"], nestedWorkflows: ["helper"] });
+    let cancellations = 0;
+    const host = {
+      addStoredWorkflow: async () => undefined,
+      getStorage: () => ({ getStore: async () => ({ upsert: async () => undefined }) }),
+      getWorkflow: () => ({
+        createRun: async () => ({
+          runId: "aborted-run",
+          start: async () => new Promise(() => undefined),
+          cancel: async () => { cancellations += 1; },
+        }),
+      }),
+      removeWorkflow: () => true,
+    };
+    const controller = new AbortController();
+    const pending = (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute({
+      action: "run",
+      description: "caller abort",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      // Far beyond the abort, so a timeout cannot be mistaken for the cause.
+      timeoutMs: 300_000,
+    }, { mastra: host, requestContext: new RequestContext(), abortSignal: controller.signal });
+
+    controller.abort();
+    const result = await pending;
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/cancelled/i);
+    expect(cancellations).toBe(1);
+  });
+
+  test("refuses a graph with more entries than the ceiling allows", () => {
+    const { tool } = harness();
+    const schema = (tool as unknown as {
+      inputSchema: { safeParse(value: unknown): { success: boolean } };
+    }).inputSchema;
+    const graphOf = (entries: number) => Array.from({ length: entries }, (_, index) => ({
+      type: "agent",
+      id: `a${index}`,
+      agentId: "flux",
+    }));
+    const parse = (entries: number) => schema.safeParse({
+      action: "run",
+      description: "d",
+      definition: { ...nestedGraph, graph: graphOf(entries) },
+    }).success;
+
+    expect(parse(16)).toBe(true);
+    expect(parse(17)).toBe(false);
+  });
+
+  test("truncates a single oversized step row and still reports later rows", async () => {
+    const tool = createDynamicWorkflowTool({ agents: ["flux"], nestedWorkflows: ["helper"] });
+    const host = {
+      addStoredWorkflow: async () => undefined,
+      getStorage: () => ({ getStore: async () => ({ upsert: async () => undefined }) }),
+      getWorkflow: () => ({
+        createRun: async () => ({
+          runId: "wide-rows",
+          start: async () => ({
+            status: "success",
+            result: {},
+            steps: {
+              wide: { status: "success", output: { value: "w".repeat(5_000) } },
+              narrow: { status: "success", output: { value: "n" } },
+            },
+          }),
+          cancel: async () => undefined,
+        }),
+      }),
+      removeWorkflow: () => true,
+    };
+
+    const result = await (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute({
+      action: "run",
+      description: "wide rows",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    }, { mastra: host, requestContext: new RequestContext() });
+
+    const steps = result.steps as Array<{ id: string; output?: string }>;
+    const wide = steps.find(step => step.id === "wide");
+    const narrow = steps.find(step => step.id === "narrow");
+
+    expect(result.truncated).toBe(true);
+    expect(wide?.output?.length).toBeLessThanOrEqual(2_000);
+    expect(wide?.output).toContain("output truncated");
+    // The per-row cap must not consume the aggregate budget of later rows.
+    expect(narrow?.output).toBe(JSON.stringify({ value: "n" }));
+  });
+
+  test("stops spending step-row output once the aggregate budget is exhausted", async () => {
+    const tool = createDynamicWorkflowTool({ agents: ["flux"], nestedWorkflows: ["helper"] });
+    const host = {
+      addStoredWorkflow: async () => undefined,
+      getStorage: () => ({ getStore: async () => ({ upsert: async () => undefined }) }),
+      getWorkflow: () => ({
+        createRun: async () => ({
+          runId: "budget",
+          start: async () => ({
+            status: "success",
+            result: {},
+            steps: Object.fromEntries(Array.from({ length: 20 }, (_, index) => [
+              `step-${index}`,
+              { status: "success", output: { value: "x".repeat(3_000) } },
+            ])),
+          }),
+          cancel: async () => undefined,
+        }),
+      }),
+      removeWorkflow: () => true,
+    };
+
+    const result = await (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute({
+      action: "run",
+      description: "aggregate budget",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    }, { mastra: host, requestContext: new RequestContext() });
+
+    const steps = result.steps as Array<{ id: string; output?: string }>;
+    const spent = steps.reduce((total, step) => total + (step.output?.length ?? 0), 0);
+
+    expect(result.truncated).toBe(true);
+    expect(steps).toHaveLength(20);
+    expect(spent).toBeLessThanOrEqual(24_000);
+    // Every row is still reported by id and status once the budget runs out.
+    expect(steps.at(-1)?.output ?? "").toBe("");
+  });
+
+  test("pins the tool timeout inside the harness deadline and the run budget", () => {
+    expect(timeBoundsInvariant()).toBe(true);
+    expect(DYNAMIC_WORKFLOW_TIME_BOUNDS.maxTimeoutMs)
+      .toBeLessThan(DYNAMIC_WORKFLOW_TIME_BOUNDS.backgroundTimeoutMs);
+    expect(DYNAMIC_WORKFLOW_TIME_BOUNDS.backgroundTimeoutMs)
+      .toBeLessThanOrEqual(DYNAMIC_WORKFLOW_TIME_BOUNDS.runBudgetWallClockMs);
+  });
+
+  test("leaves an active definition this tool did not author alone", async () => {
+    const { mastra } = harness();
+    const store = await (mastra.getStorage() as unknown as {
+      getStore(name: string): Promise<{
+        upsert(input: Record<string, unknown>): Promise<unknown>;
+        list(args?: { status?: string }): Promise<{ definitions: Array<{ id: string }> }>;
+      }>;
+    }).getStore("workflowDefinitions");
+    await store.upsert({
+      id: "dyn_0000000000000000",
+      inputSchema: objectSchema,
+      outputSchema: doneSchema,
+      graph: [],
+      metadata: { origin: "external" },
+    });
+
+    await expect(reconcileDynamicWorkflowDefinitions(mastra)).resolves.toBe(0);
+    expect((await store.list({ status: "active" })).definitions.map(row => row.id))
+      .toEqual(["dyn_0000000000000000"]);
   });
 
   test("archives a stray active definition at boot", async () => {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -8,13 +8,10 @@ import { z } from "zod";
 import {
   createDynamicWorkflowTool,
   createRunBudgetHooks,
-  DYNAMIC_WORKFLOW_CEILING_POLICY,
-  DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH,
   DYNAMIC_WORKFLOW_DEPTH_CONTEXT_KEY,
   DYNAMIC_WORKFLOW_ORIGIN,
-  DYNAMIC_WORKFLOW_TIME_BOUNDS,
   reconcileDynamicWorkflowDefinitions,
-  timeBoundsInvariant,
+  RUN_CONTAINMENT_POLICY,
 } from "../src/index.js";
 
 const helper = createWorkflow({
@@ -619,10 +616,6 @@ describe("dynamic_workflow", () => {
 
   test("clamps author-supplied fan-out concurrency to the host ceiling", async () => {
     const { mastra, invoke } = harness();
-    // `createStep(agent)` pins the step input to `{ prompt }` and its default
-    // output to `{ text }`, so a fan-out array must carry that element shape.
-    const promptSchema = { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] };
-    const textSchema = { type: "object", properties: { text: { type: "string" } }, required: ["text"] };
 
     const result = await invoke({
       action: "run",
@@ -631,8 +624,7 @@ describe("dynamic_workflow", () => {
       timeoutMs: 30_000,
       input: [],
       definition: {
-        inputSchema: { type: "array", items: promptSchema },
-        outputSchema: { type: "array", items: textSchema },
+        ...fanOutGraph,
         graph: [{
           type: "foreach",
           step: { type: "agent", id: "fan", agentId: "flux" },
@@ -649,7 +641,9 @@ describe("dynamic_workflow", () => {
     const stored = await store.get(result.workflowId as string);
 
     expect((stored?.graph[0] as { opts?: { concurrency?: number } })?.opts?.concurrency).toBe(3);
-    // A maxItems ceiling is the only static bound on fan-out width.
+    // The stamped ceiling records the width the definition was admitted under.
+    // It does not enforce it — upstream's converter discards `maxItems` — which
+    // is why the run-time width check above is the control that binds.
     expect(stored?.inputSchema.maxItems).toBe(8);
   });
 
@@ -923,15 +917,15 @@ describe("dynamic_workflow", () => {
       }>;
     }).getStore("workflowDefinitions");
     const stored = await store.get(started.workflowId as string);
+    const metadata = stored?.metadata as { ceilingPolicy?: Record<string, unknown> };
+    // The definition records the ceilings it was admitted under.
+    expect(metadata.ceilingPolicy).toMatchObject({ version: 1, maxFanOut: 8 });
     // Stands in for a runtime that lowered a ceiling while the run was
     // suspended, and did so without remembering to bump the policy version.
     await store.upsert({
       ...stored,
       status: "archived",
-      metadata: {
-        ...(stored?.metadata as Record<string, unknown>),
-        ceilingPolicy: { ...DYNAMIC_WORKFLOW_CEILING_POLICY, maxFanOut: 64 },
-      },
+      metadata: { ...metadata, ceilingPolicy: { ...metadata.ceilingPolicy, maxFanOut: 64 } },
     });
 
     const result = await invoke({
@@ -944,7 +938,7 @@ describe("dynamic_workflow", () => {
     });
 
     expect(result.status).toBe("failed");
-    expect(result.error).toContain(DYNAMIC_WORKFLOW_CEILING_POLICY_MISMATCH);
+    expect(result.error).toContain("ceiling_policy_mismatch");
     expect(result.error).toContain("maxFanOut");
     // The opaque content mismatch was what orphaned suspended runs before.
     expect(result.error).not.toMatch(/digest does not match/i);
@@ -1168,12 +1162,28 @@ describe("dynamic_workflow", () => {
     expect(steps.at(-1)?.output ?? "").toBe("");
   });
 
-  test("pins the tool timeout inside the harness deadline and the run budget", () => {
-    expect(timeBoundsInvariant()).toBe(true);
-    expect(DYNAMIC_WORKFLOW_TIME_BOUNDS.maxTimeoutMs)
-      .toBeLessThan(DYNAMIC_WORKFLOW_TIME_BOUNDS.backgroundTimeoutMs);
-    expect(DYNAMIC_WORKFLOW_TIME_BOUNDS.backgroundTimeoutMs)
-      .toBeLessThanOrEqual(DYNAMIC_WORKFLOW_TIME_BOUNDS.runBudgetWallClockMs);
+  test("pins the authored timeout inside the harness deadline and the run budget", () => {
+    const { tool } = harness();
+    const { inputSchema, background } = tool as unknown as {
+      inputSchema: { safeParse(value: unknown): { success: boolean } };
+      background: { timeoutMs: number };
+    };
+    const accepts = (timeoutMs: number) => inputSchema.safeParse({
+      action: "run",
+      description: "d",
+      definition: nestedGraph,
+      timeoutMs,
+    }).success;
+
+    // The largest timeout a caller can author.
+    expect(accepts(600_000)).toBe(true);
+    expect(accepts(600_001)).toBe(false);
+    // It must expire before the harness reclaims the call, or cancellation
+    // never runs and the workflow is never contained.
+    expect(background.timeoutMs).toBeGreaterThan(600_000);
+    // And the harness bound must fit inside the aggregate run budget, or one
+    // dynamic workflow can outlive the wall clock containing the whole run.
+    expect(background.timeoutMs).toBeLessThanOrEqual(RUN_CONTAINMENT_POLICY.maxWallClockMs);
   });
 
   test("leaves an active definition this tool did not author alone", async () => {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -76,6 +76,49 @@ function stubAgentStream(agent: Agent): { calls: number } {
   return state;
 }
 
+interface StubRun {
+  readonly runId: string;
+  readonly snapshot: unknown;
+}
+
+/**
+ * A runs store that honours `workflowName` the way a real one does, so a test
+ * can tell filtering-before-paging apart from paging-then-filtering.
+ */
+function inspectHarness(runsByWorkflow: Record<string, StubRun[]>) {
+  const calls: Array<{ workflowName?: string; perPage?: number }> = [];
+  const flat = Object.entries(runsByWorkflow)
+    .flatMap(([workflowName, runs]) => runs.map(run => ({ workflowName, ...run })));
+  const runsStore = {
+    listWorkflowRuns: async (args?: { workflowName?: string; perPage?: number }) => {
+      calls.push({ ...args });
+      const matching = args?.workflowName
+        ? flat.filter(run => run.workflowName === args.workflowName)
+        : flat;
+      const perPage = typeof args?.perPage === "number" ? args.perPage : matching.length;
+      return { runs: matching.slice(0, perPage), total: matching.length };
+    },
+  };
+  const definitionsStore = {
+    upsert: async () => undefined,
+    get: async () => null,
+    list: async () => ({
+      definitions: Object.keys(runsByWorkflow)
+        .filter(id => id.startsWith("dyn_"))
+        .map(id => ({ id, metadata: { origin: DYNAMIC_WORKFLOW_ORIGIN } })),
+    }),
+  };
+  const host = {
+    addStoredWorkflow: async () => undefined,
+    getWorkflow: () => { throw new Error("inspect must not execute a graph"); },
+    removeWorkflow: () => true,
+    getStorage: () => ({
+      getStore: async (name: string) => (name === "workflows" ? runsStore : definitionsStore),
+    }),
+  };
+  return { tool: createDynamicWorkflowTool({ agents: ["flux"], nestedWorkflows: ["helper"] }), host, calls };
+}
+
 const fanOutGraph = {
   inputSchema: { type: "array", items: promptSchema },
   outputSchema: { type: "array", items: textSchema },
@@ -668,6 +711,88 @@ describe("dynamic_workflow", () => {
       steps: [{ type: "agent", id: "a", agentId: "flux" }],
       predicates: [predicate],
     })).toBe(true);
+  });
+
+  test("keeps a timed-out definition registered until its cancellation settles", async () => {
+    const tool = createDynamicWorkflowTool({ agents: ["flux"], nestedWorkflows: ["helper"] });
+    const order: string[] = [];
+    let releaseCancel: (() => void) | undefined;
+    const host = {
+      addStoredWorkflow: async () => undefined,
+      getStorage: () => ({ getStore: async () => ({ upsert: async () => undefined }) }),
+      getWorkflow: () => ({
+        createRun: async () => ({
+          runId: "stuck-run",
+          start: async () => new Promise(() => undefined),
+          cancel: async () => {
+            order.push("cancel:start");
+            await new Promise<void>(resolve => {
+              releaseCancel = () => { order.push("cancel:end"); resolve(); };
+            });
+          },
+        }),
+      }),
+      removeWorkflow: () => { order.push("unregister"); return true; },
+    };
+
+    const pending = (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute({
+      action: "run",
+      description: "timeout race",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 1_000,
+    }, { mastra: host, requestContext: new RequestContext() });
+
+    await vi.waitFor(() => expect(releaseCancel).toBeTypeOf("function"), { timeout: 5_000 });
+    // The live workflow must not leave the registry while it is still running.
+    expect(order).toEqual(["cancel:start"]);
+    releaseCancel?.();
+
+    const result = await pending;
+    expect(result.status).toBe("failed");
+    expect(order).toEqual(["cancel:start", "cancel:end", "unregister"]);
+  });
+
+  test("inspects a dynamic run that a busier workflow's runs would otherwise displace", async () => {
+    const { tool, host, calls } = inspectHarness({
+      "dyn_1111111111111111": [{ runId: "wanted", snapshot: { status: "success" } }],
+      noise: Array.from({ length: 20 }, (_, index) => ({ runId: `n${index}`, snapshot: { status: "success" } })),
+    });
+
+    const result = await (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute({ action: "inspect" }, { mastra: host, requestContext: new RequestContext() });
+
+    expect(result.runs).toEqual([
+      expect.objectContaining({ workflowId: "dyn_1111111111111111", runId: "wanted", status: "success" }),
+    ]);
+    // Paging the whole runs table and filtering afterwards drops dynamic runs
+    // behind any busier workflow, so the filter has to reach the store.
+    expect(calls.every(call => call.workflowName !== undefined)).toBe(true);
+  });
+
+  test("reports inspect truncation honestly and surfaces suspended step paths", async () => {
+    const { tool, host } = inspectHarness({
+      "dyn_1111111111111111": Array.from({ length: 21 }, (_, index) => ({
+        runId: `r${index}`,
+        snapshot: {
+          status: "suspended",
+          suspendedPaths: { paused: [0] },
+          context: { paused: { status: "suspended" } },
+        },
+      })),
+    });
+
+    const result = await (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute({ action: "inspect" }, { mastra: host, requestContext: new RequestContext() });
+
+    expect(result.truncated).toBe(true);
+    expect(result.resumable).toBe(true);
+    expect((result.runs as Array<{ suspended?: string[][] }>)[0]?.suspended).toEqual([["paused"]]);
   });
 
   test("archives a stray active definition at boot", async () => {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -56,6 +56,31 @@ function harness() {
 
 const objectSchema = { type: "object", properties: { task: { type: "string" } }, required: ["task"] };
 const doneSchema = { type: "object", properties: { done: { type: "string" } }, required: ["done"] };
+// `createStep(agent)` pins the step input to `{ prompt }` and its default output
+// to `{ text }`, so any fan-out array must carry that element shape.
+const promptSchema = { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] };
+const textSchema = { type: "object", properties: { text: { type: "string" } }, required: ["text"] };
+
+/** Counts real agent dispatches so a ceiling can be proven to bind before one happens. */
+function stubAgentStream(agent: Agent): { calls: number } {
+  const state = { calls: 0 };
+  vi.spyOn(agent, "getModel").mockResolvedValue({ specificationVersion: "v2" } as never);
+  vi.spyOn(agent, "stream").mockImplementation((async (...args: unknown[]) => {
+    state.calls += 1;
+    const options = args[1] as { onFinish?: (result: { text: string }) => void } | undefined;
+    const fullStream = (async function* () {
+      options?.onFinish?.({ text: "ok" } as never);
+    })();
+    return { text: Promise.resolve("ok"), fullStream } as never;
+  }) as never);
+  return state;
+}
+
+const fanOutGraph = {
+  inputSchema: { type: "array", items: promptSchema },
+  outputSchema: { type: "array", items: textSchema },
+  graph: [{ type: "foreach", step: { type: "agent", id: "fan", agentId: "flux" } }],
+};
 
 const nestedGraph = {
   inputSchema: objectSchema,
@@ -543,6 +568,106 @@ describe("dynamic_workflow", () => {
     expect((stored?.graph[0] as { opts?: { concurrency?: number } })?.opts?.concurrency).toBe(3);
     // A maxItems ceiling is the only static bound on fan-out width.
     expect(stored?.inputSchema.maxItems).toBe(8);
+  });
+
+  test("refuses a run whose input exceeds the fan-out ceiling before any agent step executes", async () => {
+    const { flux, invoke } = harness();
+    const stream = stubAgentStream(flux);
+    const run = (elements: number) => invoke({
+      action: "run",
+      description: "fan out",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: Array.from({ length: elements }, (_, index) => ({ prompt: `p${index}` })),
+      definition: fanOutGraph,
+    });
+
+    const allowed = await run(8);
+    expect(allowed.status).toBe("success");
+    expect(stream.calls).toBe(8);
+
+    const refused = await run(9);
+    expect(refused.status).toBe("invalid");
+    expect((refused.issues as string[]).join(" ")).toContain("8");
+    // The ceiling has to bind before dispatch, not by truncating mid-run.
+    expect(stream.calls).toBe(8);
+  });
+
+  test("rejects a foreach whose declared iteration source exceeds the ceiling", async () => {
+    const { invoke } = harness();
+
+    const result = await invoke({
+      action: "run",
+      description: "wide fan out",
+      dryRun: true,
+      timeoutMs: 1_000,
+      input: [],
+      definition: { ...fanOutGraph, inputSchema: { type: "array", items: promptSchema, maxItems: 50 } },
+    });
+
+    expect(result.status).toBe("invalid");
+    expect((result.issues as string[]).join(" ")).toMatch(/iterat/i);
+    expect((result.issues as string[]).join(" ")).toContain("8");
+  });
+
+  test("clamps an authored stateSchema and keeps the digest stable across identical submissions", async () => {
+    const { mastra, invoke } = harness();
+    const definition = {
+      ...nestedGraph,
+      stateSchema: {
+        type: "object",
+        properties: { seen: { type: "array", items: { type: "string" }, maxItems: 500 } },
+      },
+    };
+
+    const first = await invoke({ action: "run", description: "d", definition, input: {}, dryRun: true, timeoutMs: 1_000 });
+    const again = await invoke({ action: "run", description: "d", definition, input: {}, dryRun: true, timeoutMs: 1_000 });
+    expect(first.graphDigest).toBe(again.graphDigest);
+    expect(first.workflowId).toBe(again.workflowId);
+
+    const ran = await invoke({
+      action: "run",
+      description: "d",
+      definition,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+    expect(ran.status).toBe("success");
+
+    const store = await (mastra.getStorage() as unknown as {
+      getStore(name: string): Promise<{ get(id: string): Promise<{ stateSchema?: Record<string, unknown> } | null> }>;
+    }).getStore("workflowDefinitions");
+    const stored = await store.get(ran.workflowId as string);
+    const seen = (stored?.stateSchema?.properties as { seen?: { maxItems?: number } } | undefined)?.seen;
+
+    expect(seen?.maxItems).toBe(8);
+  });
+
+  test("refuses a nested workflow inside a conditional at the schema layer", () => {
+    const { tool } = harness();
+    const schema = (tool as unknown as {
+      inputSchema: { safeParse(value: unknown): { success: boolean } };
+    }).inputSchema;
+    const withGraph = (entry: unknown) => schema.safeParse({
+      action: "run",
+      description: "d",
+      definition: { ...nestedGraph, graph: [entry] },
+    }).success;
+    const predicate = { op: "truthy", value: { literal: true } };
+
+    // A nested workflow is a top-level entry only; admitting one here would
+    // contradict the graph checker, which has always refused it.
+    expect(withGraph({
+      type: "conditional",
+      steps: [{ type: "workflow", id: "w", workflowId: "helper" }],
+      predicates: [predicate],
+    })).toBe(false);
+    expect(withGraph({
+      type: "conditional",
+      steps: [{ type: "agent", id: "a", agentId: "flux" }],
+      predicates: [predicate],
+    })).toBe(true);
   });
 
   test("archives a stray active definition at boot", async () => {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -1207,6 +1207,96 @@ describe("dynamic_workflow", () => {
       .toEqual(["dyn_0000000000000000"]);
   });
 
+  test("charges a dynamic workflow's agent fan-out against the delegation ceiling", async () => {
+    const { flux, invoke } = harness();
+    stubAgentStream(flux);
+    const hooks = createRunBudgetHooks(() => 0);
+    const requestContext = new RequestContext();
+    const enter = (toolName: string, input: unknown) =>
+      hooks.beforeToolCall?.({ toolName, input, context: { requestContext } } as never);
+
+    enter("dynamic_workflow", { action: "run" });
+    const result = await invoke({
+      action: "run",
+      description: "fan out",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: Array.from({ length: 8 }, (_, index) => ({ prompt: `p${index}` })),
+      definition: fanOutGraph,
+    }, requestContext);
+
+    expect(result.status).toBe("success");
+    // Eight agents ran under one approval. The aggregate ceiling is eight, so
+    // the run has spent it and no further delegation may follow.
+    expect(() => enter("subagent", { task: "one more" })).toThrow(/delegation limit/);
+  });
+
+  test("charges each dispatching graph position, not one per tool call", async () => {
+    const { flux, invoke } = harness();
+    stubAgentStream(flux);
+    const hooks = createRunBudgetHooks(() => 0);
+    const requestContext = new RequestContext();
+    const enter = (toolName: string, input: unknown) =>
+      hooks.beforeToolCall?.({ toolName, input, context: { requestContext } } as never);
+
+    enter("dynamic_workflow", { action: "run" });
+    const result = await invoke({
+      action: "run",
+      description: "parallel fan-out",
+      dryRun: false,
+      timeoutMs: 30_000,
+      input: { prompt: "go" },
+      definition: {
+        inputSchema: promptSchema,
+        outputSchema: { type: "object" },
+        graph: [{
+          type: "parallel",
+          steps: [
+            { type: "agent", id: "a", agentId: "flux" },
+            { type: "agent", id: "b", agentId: "flux" },
+            { type: "agent", id: "c", agentId: "flux" },
+          ],
+        }],
+      },
+    }, requestContext);
+
+    expect(result.status).toBe("success");
+    // Three agents ran, so five of the eight delegations remain.
+    for (let index = 0; index < 5; index += 1) {
+      expect(() => enter("subagent", { task: `scope-${index}` })).not.toThrow();
+    }
+    expect(() => enter("subagent", { task: "over" })).toThrow(/delegation limit/);
+  });
+
+  test("charges nothing for actions that dispatch no agent", async () => {
+    const { invoke } = harness();
+    const hooks = createRunBudgetHooks(() => 0);
+    const requestContext = new RequestContext();
+    const enter = (toolName: string, input: unknown) =>
+      hooks.beforeToolCall?.({ toolName, input, context: { requestContext } } as never);
+
+    for (let index = 0; index < 8; index += 1) {
+      enter("subagent", { task: `scope-${index}` });
+    }
+
+    // Validation and inspection run no agent, so neither may spend the last
+    // of an already-exhausted delegation budget.
+    enter("dynamic_workflow", { action: "run" });
+    const validated = await invoke({
+      action: "run",
+      description: "validate only",
+      definition: nestedGraph,
+      input: {},
+      dryRun: true,
+      timeoutMs: 1_000,
+    }, requestContext);
+    expect(validated.status).toBe("validated");
+
+    enter("dynamic_workflow", { action: "inspect" });
+    const inspected = await invoke({ action: "inspect" }, requestContext);
+    expect(inspected.runs).toEqual([]);
+  });
+
   test("archives a stray active definition at boot", async () => {
     const { mastra } = harness();
     const store = await (mastra.getStorage() as unknown as {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -1268,6 +1268,44 @@ describe("dynamic_workflow", () => {
     expect(() => enter("subagent", { task: "over" })).toThrow(/delegation limit/);
   });
 
+  test("charges a resume, which re-enters the graph under the same approval", async () => {
+    const { invoke } = harness();
+    const hooks = createRunBudgetHooks(() => 0);
+    const requestContext = new RequestContext();
+    const enter = (toolName: string, input: unknown) =>
+      hooks.beforeToolCall?.({ toolName, input, context: { requestContext } } as never);
+    const definition = {
+      inputSchema: objectSchema,
+      outputSchema: doneSchema,
+      graph: [{ type: "workflow", id: "p", workflowId: "pausing" }],
+    };
+
+    enter("dynamic_workflow", { action: "run" });
+    const started = await invoke({
+      action: "run",
+      description: "await approval",
+      definition,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    }, requestContext);
+    expect(started.status).toBe("suspended");
+
+    for (let index = 0; index < 7; index += 1) {
+      enter("subagent", { task: `scope-${index}` });
+    }
+
+    enter("dynamic_workflow", { action: "resume" });
+    await expect(invoke({
+      action: "resume",
+      description: "approve",
+      workflowId: started.workflowId,
+      runId: started.runId,
+      resumeData: { approved: "yes" },
+      timeoutMs: 1_000,
+    }, requestContext)).rejects.toThrow(/delegation limit/);
+  });
+
   test("charges nothing for actions that dispatch no agent", async () => {
     const { invoke } = harness();
     const hooks = createRunBudgetHooks(() => 0);

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -113,6 +113,35 @@ function stubAgentStream(agent: Agent): { calls: number } {
   return state;
 }
 
+/** One runtime shared by several tenant-scoped tools, so isolation is observable. */
+function scopedHarness() {
+  const flux = new Agent({ id: "flux", name: "flux", instructions: "test", model: "openai/gpt-4o-mini" });
+  const mastra = new Mastra({
+    agents: { flux },
+    workflows: { helper, largeOutput, pausing, streaming },
+    storage: new InMemoryStore(),
+    logger: false as never,
+  });
+  const toolFor = (scope?: string | (() => string)) => createDynamicWorkflowTool({
+    agents: ["flux"],
+    nestedWorkflows: ["helper", "large-output", "pausing", "streaming"],
+    ...(scope ? { scope: typeof scope === "function" ? scope : () => scope } : {}),
+  });
+  const invokeWith = (tool: ReturnType<typeof toolFor>, input: unknown) =>
+    (tool as unknown as {
+      execute(input: unknown, context: unknown): Promise<Record<string, unknown>>;
+    }).execute(input, { mastra, requestContext: new RequestContext() });
+  return { mastra, flux, toolFor, invokeWith };
+}
+
+const definitionsStoreOf = (mastra: Mastra) => (mastra.getStorage() as unknown as {
+  getStore(name: string): Promise<{
+    get(id: string): Promise<Record<string, unknown> | null>;
+    upsert(input: Record<string, unknown>): Promise<unknown>;
+    list(args?: { status?: string }): Promise<{ definitions: Array<{ id: string; metadata?: Record<string, unknown> }> }>;
+  }>;
+}).getStore("workflowDefinitions");
+
 interface StubRun {
   readonly runId: string;
   readonly snapshot: unknown;
@@ -1333,6 +1362,212 @@ describe("dynamic_workflow", () => {
     enter("dynamic_workflow", { action: "inspect" });
     const inspected = await invoke({ action: "inspect" }, requestContext);
     expect(inspected.runs).toEqual([]);
+  });
+
+  test("derives a different id for the same graph under a different scope", async () => {
+    const { toolFor, invokeWith } = scopedHarness();
+    const validate = (tool: ReturnType<typeof toolFor>) => invokeWith(tool, {
+      action: "run",
+      description: "d",
+      definition: nestedGraph,
+      input: {},
+      dryRun: true,
+      timeoutMs: 1_000,
+    });
+
+    const a = await validate(toolFor("project-a"));
+    const b = await validate(toolFor("project-b"));
+    const againA = await validate(toolFor("project-a"));
+
+    expect(a.workflowId).toMatch(/^dyn_[0-9a-f]{16}$/);
+    // Two tenants authoring the same graph must not collapse onto one id.
+    expect(b.workflowId).not.toBe(a.workflowId);
+    expect(b.graphDigest).not.toBe(a.graphDigest);
+    // Still content-addressed within a scope.
+    expect(againA.workflowId).toBe(a.workflowId);
+  });
+
+  test("keeps an unscoped host byte-identical to its pre-scope behaviour", async () => {
+    const { mastra, invoke } = harness();
+
+    const validated = await invoke({
+      action: "run",
+      description: "d",
+      definition: nestedGraph,
+      input: {},
+      dryRun: true,
+      timeoutMs: 1_000,
+    });
+    // Pinned literal: a host that supplies no scope must derive exactly the id
+    // it derived before scoping existed, or every MCode and Studio run in
+    // flight is orphaned by this change.
+    expect(validated.workflowId).toBe("dyn_7a37e1229cc6d39f");
+
+    const ran = await invoke({
+      action: "run",
+      description: "d",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+    const store = await definitionsStoreOf(mastra);
+    const stored = await store.get(ran.workflowId as string);
+
+    expect(ran.workflowId).toBe("dyn_7a37e1229cc6d39f");
+    expect(stored?.metadata).not.toHaveProperty("scopeDigest");
+  });
+
+  test("never lists another scope's runs from inspect", async () => {
+    const { toolFor, invokeWith } = scopedHarness();
+    const toolA = toolFor("project-a");
+    const toolB = toolFor("project-b");
+    const run = (tool: ReturnType<typeof toolFor>) => invokeWith(tool, {
+      action: "run",
+      description: "shared graph",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+
+    const ranA = await run(toolA);
+    const ranB = await run(toolB);
+    expect(ranA.status).toBe("success");
+    expect(ranB.status).toBe("success");
+
+    const seenByA = await invokeWith(toolA, { action: "inspect" });
+    const seenByB = await invokeWith(toolB, { action: "inspect" });
+
+    expect((seenByA.runs as Array<{ workflowId: string }>).map(run => run.workflowId))
+      .toEqual([ranA.workflowId]);
+    expect((seenByB.runs as Array<{ workflowId: string }>).map(run => run.workflowId))
+      .toEqual([ranB.workflowId]);
+  });
+
+  test("rejects a resume whose caller scope differs from the stored one", async () => {
+    const { toolFor, invokeWith } = scopedHarness();
+    const toolA = toolFor("project-a");
+    const toolB = toolFor("project-b");
+
+    const started = await invokeWith(toolA, {
+      action: "run",
+      description: "await approval",
+      definition: {
+        inputSchema: objectSchema,
+        outputSchema: doneSchema,
+        graph: [{ type: "workflow", id: "p", workflowId: "pausing" }],
+      },
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+    expect(started.status).toBe("suspended");
+
+    const stolen = await invokeWith(toolB, {
+      action: "resume",
+      description: "resume another tenant's run",
+      workflowId: started.workflowId,
+      runId: started.runId,
+      resumeData: { approved: "yes" },
+      timeoutMs: 1_000,
+    });
+
+    expect(stolen.status).toBe("failed");
+    expect(stolen.error).toContain("scope_mismatch");
+    // A cross-tenant attempt is not a ceiling change and not corruption.
+    expect(stolen.error).not.toContain("ceiling_policy_mismatch");
+    expect(stolen.error).not.toMatch(/digest does not match/i);
+    // The owning scope's key must not leak to the caller that guessed the id.
+    expect(stolen.error).not.toContain("project-a");
+
+    // The rightful owner is unaffected.
+    const resumed = await invokeWith(toolA, {
+      action: "resume",
+      description: "approve",
+      workflowId: started.workflowId,
+      runId: started.runId,
+      resumeData: { approved: "yes" },
+      timeoutMs: 30_000,
+    });
+    expect(resumed.status).toBe("success");
+  });
+
+  test("hides a legacy unscoped definition from every scoped caller", async () => {
+    const { mastra, toolFor, invokeWith } = scopedHarness();
+    const unscoped = await invokeWith(toolFor(), {
+      action: "run",
+      description: "legacy row",
+      definition: nestedGraph,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+    expect(unscoped.status).toBe("success");
+
+    const scoped = toolFor("project-a");
+    const seen = await invokeWith(scoped, { action: "inspect" });
+    // A row written before scoping existed carries no scopeDigest, and must
+    // not become readable from every scope by default.
+    expect(seen.runs).toEqual([]);
+
+    const resumed = await invokeWith(scoped, {
+      action: "resume",
+      description: "resume a legacy row",
+      workflowId: unscoped.workflowId,
+      runId: unscoped.runId,
+      resumeData: {},
+      timeoutMs: 1_000,
+    });
+    expect(resumed.status).toBe("failed");
+    expect(resumed.error).toContain("scope_mismatch");
+  });
+
+  test("fails closed when the host cannot derive a scope", async () => {
+    const { toolFor, invokeWith } = scopedHarness();
+    const unbound = toolFor(() => { throw new Error("no project session bound"); });
+
+    await expect(invokeWith(unbound, {
+      action: "run",
+      description: "unbound",
+      definition: nestedGraph,
+      input: {},
+      dryRun: true,
+      timeoutMs: 1_000,
+    })).rejects.toThrow("no project session bound");
+
+    const empty = toolFor(() => "");
+    await expect(invokeWith(empty, { action: "inspect" })).rejects.toThrow(/scope/i);
+  });
+
+  test("archives every scope's stray definitions at boot", async () => {
+    const { mastra, toolFor, invokeWith } = scopedHarness();
+    const store = await definitionsStoreOf(mastra);
+    const validated = await Promise.all(["project-a", "project-b"].map(scope =>
+      invokeWith(toolFor(scope), {
+        action: "run",
+        description: "d",
+        definition: nestedGraph,
+        input: {},
+        dryRun: true,
+        timeoutMs: 1_000,
+      })));
+    // Stand in for definitions left active by a crash between write and archive.
+    for (const row of validated) {
+      await store.upsert({
+        id: row.workflowId,
+        inputSchema: objectSchema,
+        outputSchema: doneSchema,
+        graph: [],
+        metadata: { origin: DYNAMIC_WORKFLOW_ORIGIN },
+      });
+    }
+    expect((await store.list({ status: "active" })).definitions).toHaveLength(2);
+
+    // Boot recovery is host-wide. Scoping it would strand one tenant's
+    // crashed definition auto-mounting at startWorkers().
+    await expect(reconcileDynamicWorkflowDefinitions(mastra)).resolves.toBe(2);
+    expect((await store.list({ status: "active" })).definitions).toHaveLength(0);
   });
 
   test("archives a stray active definition at boot", async () => {

--- a/packages/agent-tools/test/dynamic-workflow.test.ts
+++ b/packages/agent-tools/test/dynamic-workflow.test.ts
@@ -68,7 +68,7 @@ const streaming = createWorkflow({
   },
 })).commit();
 
-function harness() {
+function harness(toolOptions: { resumable?: boolean } = {}) {
   const flux = new Agent({ id: "flux", name: "flux", instructions: "test", model: "openai/gpt-4o-mini" });
   const mastra = new Mastra({
     agents: { flux },
@@ -79,6 +79,7 @@ function harness() {
   const tool = createDynamicWorkflowTool({
     agents: ["flux"],
     nestedWorkflows: ["helper", "large-output", "pausing", "streaming"],
+    ...toolOptions,
   });
   const invoke = (
     input: unknown,
@@ -1568,6 +1569,50 @@ describe("dynamic_workflow", () => {
     // crashed definition auto-mounting at startWorkers().
     await expect(reconcileDynamicWorkflowDefinitions(mastra)).resolves.toBe(2);
     expect((await store.list({ status: "active" })).definitions).toHaveLength(0);
+  });
+
+  test("reports a suspended run as resumable only when the host permits resume", async () => {
+    const suspending = {
+      inputSchema: objectSchema,
+      outputSchema: doneSchema,
+      graph: [{ type: "workflow", id: "p", workflowId: "pausing" }],
+    };
+    const start = (invoke: ReturnType<typeof harness>["invoke"]) => invoke({
+      action: "run",
+      description: "await approval",
+      definition: suspending,
+      input: { task: "ship" },
+      dryRun: false,
+      timeoutMs: 30_000,
+    });
+
+    const permitted = await start(harness().invoke);
+    expect(permitted.status).toBe("suspended");
+    expect(permitted.resumable).toBe(true);
+    expect(permitted.error).toBeUndefined();
+
+    const restricted = harness({ resumable: false });
+    const refused = await start(restricted.invoke);
+
+    expect(refused.status).toBe("suspended");
+    // The host has resume disabled, so this runId can never be used. Saying
+    // otherwise makes the model hold state for a recovery it cannot perform.
+    expect(refused.resumable).toBe(false);
+    expect(refused.error).toMatch(/cannot be continued/i);
+    // Step paths still explain where the graph stopped, which is what a
+    // re-author needs even though recovery is impossible.
+    expect(refused.suspended).toBeTruthy();
+
+    const attempted = await restricted.invoke({
+      action: "resume",
+      description: "approve",
+      workflowId: refused.workflowId,
+      runId: refused.runId,
+      resumeData: { approved: "yes" },
+      timeoutMs: 1_000,
+    });
+    expect(attempted.status).toBe("failed");
+    expect(attempted.error).toMatch(/does not support resuming/i);
   });
 
   test("archives a stray active definition at boot", async () => {


### PR DESCRIPTION
Makes every ceiling `dynamic_workflow` advertises actually bind. Scope is `packages/agent-tools/src/{dynamic-workflow,capabilities}.ts` and their package tests. Also lands the tenant-scoping seam specified by the Factory lane (#180).

## Security impact: the fan-out ceiling did not exist

`boundArraySchema` stamped `maxItems ≤ 8` on every array schema and its comment claimed `jsonSchemaToZod` enforced it at run time. **It did not.** The converter's array case is `z.array(walk(schema.items ?? {}, opts))` and never reads `maxItems`, and `maxItems` is not in `UNSUPPORTED_SCHEMA_KEYS` either, so the stamped ceiling was silently discarded rather than rejected (`node_modules/@mastra/core/dist/validate-BWdo4oEz.js:83-86`, verified in this tree at `@mastra/core@1.57.0`).

Nothing downstream of `start()` counted elements, and `foreach` capped concurrency but never iterations. **A single approved `dynamic_workflow` run could therefore fan out to an arbitrary number of agent invocations** — a 200-element input parsed clean and dispatched 200 agents. The delegation ceiling did not catch it either: `isDelegationTool` matches only `subagent` and `agent-*`, so `dynamic_workflow` never counted against the 8-delegation budget.

The RED test proves it: before this change, a 9-element input returned `status: "success"` with 9 real agent dispatches.

## Second security gap: the delegation ceiling did not apply either

`isDelegationTool` matched only `subagent` and `agent-*`, so **`dynamic_workflow` did not count against the 8-delegation aggregate ceiling at all** — an agent could spend unlimited turns dispatching graphs. The agents a graph dispatches did not close the gap from the other side either: workflow agent steps call `agent.stream()` directly through `createStepFromAgent` rather than through a tool, so they never reach `beforeToolCall`.

Simply adding the name to `isDelegationTool` would still under-count badly. `MAX_GRAPH_ENTRIES` alone lets a sequential graph dispatch 16 agents under one approval, and a `foreach` multiplies a single entry by the fan-out ceiling — both above the ceiling of 8.

So the tool charges its **real** cost through `chargeRunDelegations`, because it is the only thing that can see it. The charge lands after the graph is validated and clamped and before anything is registered or started, so an over-budget graph dispatches nothing.

| Clamped graph position | Charge |
| --- | --- |
| `agent` | 1 |
| `workflow` | 1 — **under-counts**, see below |
| `parallel` | `steps.length` |
| `conditional` | `steps.length` — upper bound; which predicates hold is a run-time fact |
| `foreach` | real iteration count when the source is this graph's own input and that input is in hand, else the fan-out ceiling |
| `mapping`, `sleep` | 0 |

`dryRun` and `inspect` charge nothing, because neither dispatches an agent. `resume` charges the whole graph rather than its unexecuted remainder, since which steps already ran is a property of the snapshot rather than the definition; over-charging a resume is the safe direction.

**Where it still under-counts:** a nested `workflow` charges 1, though the allowlisted workflow it names may dispatch agents of its own. Those live outside this definition and cannot be counted from it. The host chose to allowlist them, which is a different trust position from a model-authored graph — but it is an under-count and is stated rather than hidden.

`RUN_CONTAINMENT_POLICY` is deliberately left untouched: `test/mastra-primitives-export.test.ts` pins its exact shape and it feeds a content-addressed runtime capability digest, so adding a field would invalidate published digests. `chargeRunDelegations` is exported from `capabilities.ts` but not from the package facade.

## Ceilings now enforced, and how

| Ceiling | Enforcement |
| --- | --- |
| Fan-out width (8) | `checkInputWidth` counts elements at every array-typed path of the clamped input schema **before `start()`**, on the run and dry-run paths. Does not rely on `jsonSchemaToZod`. |
| `foreach` iterations (8) | `checkForeachSources` **rejects** at prepare, naming the ceiling, when the iteration source declares `maxItems` above it. Rejected rather than clamped: silently reducing a declared 50 to 8 would run a fraction of the requested work and report success. |
| `foreach` concurrency (3) | Unchanged — still rewritten by `clampEntry`, because concurrency is a scheduling knob, not a unit of work. |
| Schema clamping | `stateSchema` now goes through `boundArraySchema` alongside input and output. It was hashed and stored raw, so the digest's "clamped" claim was false for one of three schemas. |
| Graph nesting | `MAX_NESTING_DEPTH = 2` was unreachable and is deleted. Conditional branches are now agents only, so every container holds leaf entries exclusively and container nesting is structurally impossible. |
| Tenant isolation | Optional host `scope` participates in id derivation; `inspect` and `resume` are confined to the caller's scope. |
| Delegation budget | One `dynamic_workflow` call charges the number of agents its clamped graph dispatches, not one per call. |
| Time bounds | `background.timeoutMs` is derived as `MAX_TIMEOUT_MS + CANCELLATION_GRACE_MS` rather than set beside it, so the authored cap always expires before the harness reclaims the call. The remaining leg (harness bound ≤ `RUN_CONTAINMENT_POLICY.maxWallClockMs`) is asserted by test. |
| Ceiling policy identity | The policy is digested with the graph and persisted in definition metadata. `resume` reports the named `ceiling_policy_mismatch` with the ceilings that moved. |

## Tenant scoping seam (for the Factory lane, PR #180)

The workflow id was content-addressed over the graph alone, so **two projects authoring an identical graph collapsed onto one `dyn_<16hex>` id**, and `inspect` filtered only on `origin` and therefore listed every project's workflow ids, run ids, and statuses. A host could close neither from outside, because `authorize` receives no parsed input and there is no post-run hook.

`DynamicWorkflowToolOptions` gains an optional `scope`:

```ts
/** Host-derived, request-scoped tenant key. Opaque here. Throwing fails closed. */
readonly scope?: (context: DynamicWorkflowAuthorizationContext) => Promise<string> | string;
```

The key is opaque to this package — never interpreted, only hashed — so no host identity enters `agent-tools`. When supplied, the id is content-addressed over `sha256(scope)` as well as the graph, `metadata.scopeDigest` is stamped beside `metadata.origin`, `inspect` filters the definition list on it, and `resume` refuses a row from another scope. The `registrations` map keys on the id, so registrations become scoped as a consequence.

### The three interactions, resolved

**Scope sits beside the ceiling policy, not inside it.** A tenant boundary and a containment ceiling drift for unrelated reasons. The scope check also runs *ahead of* the ceiling-drift check and the digest comparison, so a caller that guessed an id learns nothing about another tenant's row — not its ceilings, not its content — and it carries its own `scope_mismatch` name. Verified by disabling it: the rejection then falls through to `"Stored definition identity or digest does not match its content"`, which reads as corruption rather than as a cross-tenant attempt. The error also never echoes the owning scope back to the caller.

**`reconcileDynamicWorkflowDefinitions` stays scope-blind.** It is host-wide crash recovery; scoping it would leave one tenant's crashed definition auto-mounting at `startWorkers()`. Pinned by a test that seeds stray active rows under two scopes and asserts both are archived.

**Legacy rows are retired, not shared.** A definition written before this change carries no `scopeDigest`, and matches only a caller that supplies no scope. Turning scoping on makes such a row unreadable and unresumable from every scope rather than readable from all of them.

**Unscoped hosts are unchanged byte for byte.** `canonicalJson` drops undefined entries, so the digest input is identical and no `scopeDigest` is written. A pinned literal (`dyn_7a37e1229cc6d39f`) guards it, so MCode and Studio runs in flight are not orphaned. An empty scope string is refused rather than hashed, since it would place every caller of a misconfigured host into one shared scope.

## Contradictions resolved

**Conditional vs. workflow.** Zod admitted a `workflow` entry inside a `conditional` that `checkEntry` always refused, citing "a loop body" that cannot exist because `loop` is not in the union. Resolved by tightening: conditional branches are agents only, matching `foreach` and `parallel`, and the dead validator arm is gone. There is no longer a path where zod admits what the validator refuses.

**Cross-version resume.** The id digests the *clamped* graph and resume re-clamps under current constants, so lowering any ceiling orphaned every outstanding suspended run behind `"Stored definition identity or digest does not match its content"`. `ceilingPolicyDrift` now compares the whole stored policy — not just its version — and returns `ceiling_policy_mismatch` naming which ceilings changed. A forgotten version bump still produces the named error.

## Other fixes

- **Timeout/unregister race.** `unregister` ran in the run's `finally` even on the timeout path, where `cancel()` was fire-and-forget, so a live workflow could leave the registry while still executing. `execute` now holds the cancellation promise and awaits it before returning, bounded by the cancellation grace so an upstream `cancel()` that never settles cannot pin the call open.
- **`inspect`.** It fetched the first 20 runs of *all* workflows then filtered, so a dynamic run behind any busier workflow was silently absent. It now pages per dynamic workflow id. `truncated` was hardcoded `false` on every return and is now derived from whether a page was cut or the result cap hit; `resumable` reflects whether any listed run is suspended; and each suspended run carries the step paths upstream derives from its snapshot, so a model that lost its transcript can resume from `inspect` alone.
- **Resumability was reported without consulting the host.** `execute` computed `resumable` from the run status alone, so on a host with `resumable: false` a suspended run advertised itself as recoverable and handed back ids that the resume guard rejects on every use — the model held state for a recovery the host had disabled. The flag now requires both. Such a run is finished rather than paused, so `error` says so outright instead of leaving the model to infer it from a `suspended` status and a bare `false`; the `suspended` step paths stay, because they say where the graph stopped and that is what re-authoring needs.
- **Resume ownership.** `createRun({ runId })` mints a fresh run for an unrecognized id, so an unverified resume would start a *second* run of the graph under the caller's chosen id. Resume now verifies the run exists, belongs to that workflowId, and is actually suspended. Fails closed when the runtime cannot answer.

## Coverage

Closed every named hole: successful resume (the only resume test was foreign-origin rejection), conditional, parallel, caller-abort (only timeout was covered), `writerBridge`, `MAX_GRAPH_ENTRIES`, the per-row 2,000-char truncation branch, the aggregate 24,000-char budget, the pinned time-bound ordering, and reconcile leaving foreign-origin active rows alone.

Both new resume guards were checked to be load-bearing by disabling each in turn: without the ownership check the runId test reports upstream's "This workflow run was not suspended"; without the policy check the resume succeeds outright.

## Validation

| Check | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm test` | pass — 305 tests, 41 files |
| `npm test --workspace @rlabs/agent-tools` | pass — 57 tests, 2 files |
| `git diff --check` | clean |
| `npm run build` | **known-blocked, pre-existing on `main`** |

`npm run build` fails from a clean install with `Failed to analyze Mastra application: packages/mastra-primitives-export/src/index.ts (5:7): Expected ',', got 'ident'`. The Mastra deployer parses workspace `src/index.ts` as JavaScript and dies on the first inline `export { type X }`. Unrelated to this change and untouched by it.

The package facade is deliberately unchanged: `index.ts` re-exports this module wholesale and `test/agents.test.ts` pins the public export surface, so the new ceiling machinery is module-private and asserted through observable behaviour instead.

## Upstream gap to file separately

`jsonSchemaToZod` in `@mastra/core` silently drops `maxItems` and `minItems`. Because the keywords are absent from `UNSUPPORTED_SCHEMA_KEYS`, `validateStorableJsonSchema` does not warn either — a stored workflow declaring an array bound is accepted, persisted, and rehydrated without it. Any consumer trusting a persisted `maxItems` has no bound. Either honour the keywords in the `array` case or list them as unsupported so the write path warns.

## Residual, stated plainly

The run-time width check binds on the workflow's own input, which is the model-controlled surface. A `foreach` fed by an *interior* step's output is bounded statically — an over-wide declared source is rejected, and agent output schemas are clamped — but there is no run-time element count at that position, because the tool does not observe intermediate step values before `start()` and upstream's rehydrated foreach carries only `{ concurrency }`. In practice such a source must be an allowlisted nested workflow's declared array output, which is a host choice rather than a model one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



