### PR TITLE
fix(factory): reset any stored model id outside the declared alias catalog

### DIFF
--- a/packages/factory-integration/src/config.ts
+++ b/packages/factory-integration/src/config.ts
@@ -366,16 +366,29 @@ interface MemorySettingsDomain {
   }): Promise<unknown>;
 }
 
+/**
+ * What a stored model id is allowed to be. Built from the same declared alias list the gateway
+ * publishes, so storage and catalog cannot disagree about which ids exist.
+ */
+export interface StoredModelCatalog {
+  readonly aliases: ReadonlySet<string>;
+  readonly defaultModelId: string;
+}
+
 export async function prepareLocalA1Provider(
   storage: FactoryStorage,
   provider: A1ProviderOptions,
   defaults: RuntimeDefaultsV1,
 ): Promise<void> {
+  const catalog: StoredModelCatalog = {
+    aliases: new Set(provider.models),
+    defaultModelId: defaults.codeSdk.activeModelId,
+  };
   await seedProvider(storage, provider);
-  await migrateProjectDefaults(storage);
-  await migrateModelPacks(storage);
-  await migrateMemorySettings(storage, defaults);
-  await migrateThreadMetadata(storage);
+  await migrateProjectDefaults(storage, catalog);
+  await migrateModelPacks(storage, catalog);
+  await migrateMemorySettings(storage, defaults, catalog);
+  await migrateThreadMetadata(storage, catalog);
 }
 
 async function seedProvider(storage: FactoryStorage, provider: A1ProviderOptions): Promise<void> {
@@ -394,33 +407,33 @@ async function seedProvider(storage: FactoryStorage, provider: A1ProviderOptions
   });
 }
 
-async function migrateProjectDefaults(storage: FactoryStorage): Promise<void> {
+async function migrateProjectDefaults(storage: FactoryStorage, catalog: StoredModelCatalog): Promise<void> {
   const domain = getDomain<ProjectsDomain>(storage, "projects");
   await domain.ensureReady();
   for (const project of await domain.list({ orgId: LOCAL_ORG_ID })) {
-    const modelId = normalizeStoredModelId(project.defaultModelId);
+    const modelId = normalizeStoredModelId(project.defaultModelId, catalog);
     if (modelId && modelId !== project.defaultModelId) {
       await domain.update({ orgId: LOCAL_ORG_ID, id: project.id, input: { defaultModelId: modelId } });
     }
   }
 }
 
-async function migrateModelPacks(storage: FactoryStorage): Promise<void> {
+async function migrateModelPacks(storage: FactoryStorage, catalog: StoredModelCatalog): Promise<void> {
   const domain = getDomain<ModelPacksDomain>(storage, "model-packs");
   await domain.ensureReady();
   for (const pack of await domain.list({ orgId: LOCAL_ORG_ID })) {
-    const models = normalizeModeModels(pack.models);
+    const models = normalizeModeModels(pack.models, catalog);
     if (Object.keys(models).every(mode => models[mode as keyof ModeModels] === pack.models[mode as keyof ModeModels])) continue;
     await domain.upsert({ orgId: LOCAL_ORG_ID, userId: LOCAL_USER_ID, input: { name: pack.name, models } });
   }
 }
 
-async function migrateMemorySettings(storage: FactoryStorage, defaults: RuntimeDefaultsV1): Promise<void> {
+async function migrateMemorySettings(storage: FactoryStorage, defaults: RuntimeDefaultsV1, catalog: StoredModelCatalog): Promise<void> {
   const domain = getDomain<MemorySettingsDomain>(storage, "memory-settings");
   await domain.ensureReady();
   const memory = await domain.get({ orgId: LOCAL_ORG_ID, userId: LOCAL_USER_ID });
   const memoryDefaults = defaults.factory;
-  const normalizedModels = memory ? normalizeMemorySettings(memory) : {};
+  const normalizedModels = memory ? normalizeMemorySettings(memory, catalog) : {};
   const patch: ModelMemorySettingsPatch = {
     ...normalizedModels,
     ...(memory?.observationThreshold == null
@@ -448,61 +461,104 @@ async function migrateMemorySettings(storage: FactoryStorage, defaults: RuntimeD
   }
 }
 
-async function migrateThreadMetadata(storage: FactoryStorage): Promise<void> {
+async function migrateThreadMetadata(storage: FactoryStorage, catalog: StoredModelCatalog): Promise<void> {
   const domain = await storage.getMastraStorage().getStore("memory");
   if (!domain) return;
   await domain.init();
   const { threads } = await domain.listThreads({ perPage: false });
   for (const thread of threads) {
-    const metadata = normalizeModelReferences(thread.metadata ?? {});
+    const metadata = normalizeModelReferences(thread.metadata ?? {}, catalog);
     if (metadata.changed) {
       await domain.updateThread({ id: thread.id, title: thread.title ?? "", metadata: metadata.value });
     }
   }
 }
 
-function normalizeModeModels(models: ModeModels): ModeModels {
+function normalizeModeModels(models: ModeModels, catalog: StoredModelCatalog): ModeModels {
   return Object.fromEntries(
-    Object.entries(models).map(([mode, modelId]) => [mode, normalizeStoredModelId(modelId) ?? modelId]),
+    Object.entries(models).map(([mode, modelId]) => [mode, normalizeStoredModelId(modelId, catalog) ?? modelId]),
   ) as ModeModels;
 }
 
-function normalizeMemorySettings(memory: ModelMemorySettings): ModelMemorySettingsPatch {
-  const observerModelId = normalizeStoredModelId(memory.observerModelId);
-  const reflectorModelId = normalizeStoredModelId(memory.reflectorModelId);
+function normalizeMemorySettings(memory: ModelMemorySettings, catalog: StoredModelCatalog): ModelMemorySettingsPatch {
+  const observerModelId = normalizeStoredModelId(memory.observerModelId, catalog);
+  const reflectorModelId = normalizeStoredModelId(memory.reflectorModelId, catalog);
   return {
     ...(observerModelId && observerModelId !== memory.observerModelId ? { observerModelId } : {}),
     ...(reflectorModelId && reflectorModelId !== memory.reflectorModelId ? { reflectorModelId } : {}),
   };
 }
 
-export function normalizeStoredModelId(modelId: string | null | undefined): string | undefined {
+/**
+ * Rewrites a stored model id onto a declared alias, so nothing the proxy does not serve under a
+ * name we own can survive in storage.
+ *
+ * The rule is a catalog membership test, not a table of known-bad ids. The previous version mapped
+ * one upstream name (`gpt-5.6-luna`) back to one alias, which could never be complete — the proxy
+ * renames and re-points aliases, and each new upstream id it exposed produced the same bug again
+ * (`gpt-5.6-sol` reaching storage as `openai/gpt-5.6-sol`, resolving against the OpenAI provider,
+ * and failing with a missing `OPENAI_API_KEY`).
+ *
+ * Worse, that table could not be correct even in principle. The proxy distinguishes tiers by
+ * `reasoning.effort` over a shared upstream model, so the mapping is many-to-one: `gpt-5.6-luna`
+ * serves both `code-workhorse-high` and `-low`, and `gpt-5.6-sol` serves all three frontier tiers.
+ * Mapping an upstream id back to one alias silently re-tiers everything else that shared it.
+ *
+ * So an unrecognised id resets to the host's documented default rather than guessing. That is
+ * lossy on purpose: the tier is genuinely unrecoverable, and a caller that wants a specific tier
+ * must name a declared alias. Any prefix form the id already carries is preserved when the alias
+ * is valid, so a gateway-qualified id is not rewritten into a provider-qualified one.
+ */
+export function normalizeStoredModelId(
+  modelId: string | null | undefined,
+  catalog: StoredModelCatalog,
+): string | undefined {
   if (!modelId) return undefined;
-  if (/^(?:mastracode\/)?a1-proxy\/gpt-5\.6-luna$/.test(modelId) || modelId === "mastracode/gpt-5.6-luna") {
-    return getA1ProxyModelId("code-workhorse-high");
-  }
-  if (modelId.startsWith("mastracode/a1-proxy/")) return modelId.slice("mastracode/".length);
-  return modelId;
+  const hosted = modelId.startsWith("mastracode/") ? modelId.slice("mastracode/".length) : modelId;
+  const alias = hosted.split("/").at(-1);
+  if (alias && catalog.aliases.has(alias)) return hosted;
+  return catalog.defaultModelId;
 }
 
-export function normalizeModelReferences(input: Record<string, unknown>): {
+/**
+ * A key whose value is a model id: anything containing `model`, plus `modes`, which holds model ids
+ * without naming them. Observed live in thread metadata as `modeModelId_build`, `currentModelId`,
+ * `observerModelId`, and `subagentModels`.
+ */
+const MODEL_KEY = /model/i;
+const MODEL_KEY_EXACT = new Set(["modes"]);
+const isModelKey = (key: string): boolean => MODEL_KEY.test(key) || MODEL_KEY_EXACT.has(key);
+
+/**
+ * Rewrites the model references inside a stored metadata object, leaving everything else untouched.
+ *
+ * Selection is by key, never by value. `normalizeStoredModelId` maps anything outside the catalog
+ * onto the default, which is correct for a value already known to be a model id and destructive for
+ * anything else — applied to every string in the object it would turn thread titles, branch names,
+ * and ids into a model id. Arrays inherit the key that introduced them, so a list of model ids is
+ * still normalised.
+ */
+export function normalizeModelReferences(input: Record<string, unknown>, catalog: StoredModelCatalog): {
   value: Record<string, unknown>;
   changed: boolean;
 } {
   let changed = false;
-  const visit = (value: unknown): unknown => {
+  const visit = (value: unknown, underModelKey: boolean): unknown => {
     if (typeof value === "string") {
-      const normalized = normalizeStoredModelId(value);
+      if (!underModelKey) return value;
+      const normalized = normalizeStoredModelId(value, catalog);
       if (normalized && normalized !== value) changed = true;
       return normalized ?? value;
     }
-    if (Array.isArray(value)) return value.map(visit);
+    if (Array.isArray(value)) return value.map(entry => visit(entry, underModelKey));
     if (value && typeof value === "object") {
-      return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, visit(entry)]));
+      return Object.fromEntries(Object.entries(value).map(
+        ([key, entry]) => [key, visit(entry, isModelKey(key))],
+      ));
     }
     return value;
   };
-  return { value: visit(input) as Record<string, unknown>, changed };
+  return { value: visit(input, false) as Record<string, unknown>, changed };
 }
 
 function getDomain<T>(storage: FactoryStorage, name: string): T {

--- a/test/local-provider.test.ts
+++ b/test/local-provider.test.ts
@@ -7,30 +7,70 @@ import {
   prepareLocalA1Provider,
 } from "@rlabs/factory-integration";
 
+// prepareLocalA1Provider is always handed the full declared alias list in production
+// (`defaults.gateway.models`). A narrower list here would make every declared alias except one
+// look unrecognised, and the migration would rewrite settings it should leave alone.
+const DECLARED_ALIASES = [...resolveRuntimeDefaultsV1(loadModelProfile()).gateway.models];
+
+const CATALOG = {
+  aliases: new Set(["code-frontier-high", "code-workhorse-high", "code-economic"]),
+  defaultModelId: "a1-proxy/code-frontier-high",
+};
+
 describe("local A1 provider migration", () => {
   test.each([
-    ["a1-proxy/gpt-5.6-luna", "a1-proxy/code-workhorse-high"],
-    ["mastracode/a1-proxy/gpt-5.6-luna", "a1-proxy/code-workhorse-high"],
-    ["mastracode/gpt-5.6-luna", "a1-proxy/code-workhorse-high"],
+    // A declared alias survives in whatever prefix form it already carries.
     ["a1-proxy/code-frontier-high", "a1-proxy/code-frontier-high"],
-    ["openai/gpt-5.6-luna", "openai/gpt-5.6-luna"],
+    ["proxy/a1-proxy/code-workhorse-high", "proxy/a1-proxy/code-workhorse-high"],
+    ["mastracode/a1-proxy/code-economic", "a1-proxy/code-economic"],
+    // A raw upstream id is not a declared alias, whatever prefix it wears, so it resets to the
+    // documented default. The tier is unrecoverable: gpt-5.6-luna serves both workhorse tiers and
+    // gpt-5.6-sol serves all three frontier tiers, so there is nothing faithful to map back to.
+    ["a1-proxy/gpt-5.6-luna", "a1-proxy/code-frontier-high"],
+    ["mastracode/gpt-5.6-luna", "a1-proxy/code-frontier-high"],
+    // The one that shipped the bug: an OpenAI-prefixed upstream id used to pass through untouched,
+    // then resolved against the OpenAI provider and failed on a missing OPENAI_API_KEY.
+    ["openai/gpt-5.6-sol", "a1-proxy/code-frontier-high"],
+    ["openai/gpt-5.6-luna", "a1-proxy/code-frontier-high"],
   ])("normalizes %s to %s", (input, expected) => {
-    expect(normalizeStoredModelId(input)).toBe(expected);
+    expect(normalizeStoredModelId(input, CATALOG)).toBe(expected);
   });
 
   test("migrates nested thread model references without changing unrelated metadata", () => {
     const result = normalizeModelReferences({
       currentModelId: "mastracode/a1-proxy/gpt-5.6-luna",
+      // The key shape observed live in Factory thread metadata.
+      modeModelId_build: "openai/gpt-5.6-sol",
       modes: ["a1-proxy/gpt-5.6-luna"],
       projectPath: "/workspace/a1-proxy/example",
-    });
+    }, CATALOG);
 
     expect(result).toEqual({
       changed: true,
       value: {
-        currentModelId: "a1-proxy/code-workhorse-high",
-        modes: ["a1-proxy/code-workhorse-high"],
+        currentModelId: "a1-proxy/code-frontier-high",
+        modeModelId_build: "a1-proxy/code-frontier-high",
+        modes: ["a1-proxy/code-frontier-high"],
         projectPath: "/workspace/a1-proxy/example",
+      },
+    });
+  });
+
+  test("leaves a non-model string alone even when it looks like a model id", () => {
+    // Selection is by key. Normalising by value would rewrite every unrecognised string in the
+    // object to the default model id, destroying titles, branches, and paths.
+    const result = normalizeModelReferences({
+      title: "openai/gpt-5.6-sol",
+      branch: "factory/gpt-5.6-luna",
+      resourceId: "mastracode/a1-proxy/whatever",
+    }, CATALOG);
+
+    expect(result).toEqual({
+      changed: false,
+      value: {
+        title: "openai/gpt-5.6-sol",
+        branch: "factory/gpt-5.6-luna",
+        resourceId: "mastracode/a1-proxy/whatever",
       },
     });
   });
@@ -62,7 +102,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: ["code-frontier-high"],
+      models: DECLARED_ALIASES,
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(initialized).toBe(true);
@@ -97,7 +137,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: ["code-frontier-high"],
+      models: DECLARED_ALIASES,
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(memoryPatch).toEqual({
@@ -150,7 +190,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: ["code-frontier-high"],
+      models: DECLARED_ALIASES,
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(memoryPatch).toBeUndefined();
@@ -190,7 +230,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: ["code-frontier-high"],
+      models: DECLARED_ALIASES,
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(memoryPatch).toEqual({
@@ -246,7 +286,7 @@ describe("local A1 provider migration", () => {
     const provider = {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: ["code-frontier-high"],
+      models: DECLARED_ALIASES,
     };
     const defaults = resolveRuntimeDefaultsV1(loadModelProfile());
 


### PR DESCRIPTION
## What broke

Factory sessions were unusable. The composer read `GPT-5.6 Sol · not configured` and every send failed with:

```
Could not find API key process.env.OPENAI_API_KEY for model id openai/gpt-5.6-sol
```

Note the prefix. The stored id was resolving against the **OpenAI provider** and never reaching the a1-proxy at all — so the requirement that both hosts consume a1-proxy aliases was violated at the *storage* layer, not at the gateway. Eleven threads in `mastra_threads.metadata` held the value, which is why review sessions and user sessions failed alike while the proxy and the four canonical roles were healthy the whole time.

## Why the existing migration missed it

`prepareLocalA1Provider` already seeds the A1 provider and runs `migrateThreadMetadata` on every boot, and it *was* running — the WorkOS gate that would disable it is open locally. The migration simply could not recognise the value: `normalizeStoredModelId` matched one hardcoded upstream name (`gpt-5.6-luna`) and passed everything else through untouched.

## The change

Replaces that table with a **catalog membership test** against the declared alias list. Anything outside it resets to the host's documented default.

That is lossy on purpose. The proxy distinguishes tiers by `reasoning.effort` over a shared upstream model — `gpt-5.6-sol` serves all three frontier tiers, `gpt-5.6-luna` both workhorse tiers — so no mapping from an upstream id back to a tier can be faithful. The old branch was not merely incomplete but **wrong where it fired**, silently promoting `code-workhorse-low` traffic to `-high`.

`normalizeModelReferences` now selects **by key rather than by value**. This mattered: under the new rule a value-wise walk would have rewritten every unrecognised string in thread metadata — titles, branches, paths — into a model id. Key selection is verified against the live data, where the key is `modeModelId_build`.

## Verification

End to end, not just unit:

| Check | Result |
| --- | --- |
| Threads holding a raw upstream id | **11 → 0** after one restart |
| Factory user session | replied `ACCEPTANCE OK USER` on **Code Frontier High** |
| Factory ticket session (PR rlabs88/mastra-toolkit#123 review) | replied `ACCEPTANCE OK TICKET` on **Code Workhorse High**, factory-phase state snapshot bound |
| MCode via `ax mcode` in a real PTY | replied `ACCEPTANCE OK`, ran on `code-economic`, default restored |
| Suite | 370 tests, typecheck clean |

This is the procedure recorded in `vault/acceptance-test-before-merge.md`, run against this change.

## Tests

- A test that asserted `openai/gpt-5.6-luna` passes through **unchanged** encoded the bug; it is flipped.
- New: a raw upstream id resets to the default under any prefix (`a1-proxy/`, `mastracode/`, `openai/`).
- New: a declared alias survives in whatever prefix form it already carries.
- New: non-model strings that *look* like model ids are left alone.
- The migration tests now use the full declared alias list, matching what production passes.

## Caveat, deliberately not hidden

The ticket session failed on its **first** attempt with `Cannot connect to API` (`statusCode: undefined`, `isRetryable: true`) — but correctly routed via `provider: a1-proxy.chat`, `modelId: code-workhorse-high`, and the proxy answered HTTP 200 on probe seconds later. That is the intermittent mid-stream abort tracked in rlabs88/mastra-toolkit#183, not this bug. The retry succeeded.

Closes rlabs88/agentics-mono#142
Refs rlabs88/mastra-toolkit#183
