### PR TITLE
perf(runtime): use economic observational memory models

### DIFF
--- a/packages/factory-integration/test/factory.test.ts
+++ b/packages/factory-integration/test/factory.test.ts
@@ -193,7 +193,7 @@ describe("single-project Factory composition", () => {
           // The default agent's preset card sets this; 180k is the retuned
           // canonical activation threshold, and reflection is a separate
           // upstream setting that the retune left alone.
-          observationThreshold: 180_000,
+          observationThreshold: 90_000,
           reflectionThreshold: 60_000,
         },
         persistedPrecedence: "memory-settings-over-startup-defaults",

--- a/packages/mastra-primitives-export/test/primitives.test.ts
+++ b/packages/mastra-primitives-export/test/primitives.test.ts
@@ -24,13 +24,11 @@ describe("ToolkitRuntimeContract", () => {
     expect(first).not.toHaveProperty("controller");
     expect(Object.isFrozen(first.roles.definitions.cortex.model)).toBe(true);
 
-    // Preset cards are behaviour, not annotation: the default agent's card sets
-    // the observational-memory thresholds every host resolves, so a card edit
-    // must move the shared capability digest. This replaces the older
-    // `memory.contextBudgetTokens` probe, which now only reaches an alias that
-    // declares no card and therefore no longer perturbs the digest.
+    // Preset cards are behaviour, not annotation: the selected Observer's card
+    // caps the batch every host resolves, so a card edit must move the shared
+    // capability digest.
     const changedProfile = structuredClone(profile);
-    changedProfile.modelCards["code-frontier-high"]!.observation!.messageTokens = 170_000;
+    changedProfile.modelCards[profile.roles.observer]!.observation!.messageTokens = 80_000;
     expect(createToolkitRuntimeContract({ profile: changedProfile }).capability.digest)
       .not.toBe(first.capability.digest);
     expect(createToolkitRuntimeContract({

--- a/packages/runtime-config/CONTEXT.md
+++ b/packages/runtime-config/CONTEXT.md
@@ -17,7 +17,9 @@ This package owns the secret-free model profile, its typed loader and model ID p
 
 `aliases` remains a flat `string[]` and is the catalog of resolvable model IDs. `modelCards` is a sibling map keyed by alias in which every field is optional, so a card is an override layer rather than a second catalog. An alias with no card falls back to the profile-level `memory` budget. This shape was chosen over replacing `aliases` with card objects because `RuntimeDefaultsV1` already exposes a `models` object holding `providerId`/`aliases`/`roles`; promoting cards to the top level would put two different `models` shapes in one contract and would change `ModelAlias` at every import site.
 
-Cards make the context window and the observational-memory budgets per-model properties. The canonical observation and reflection thresholds resolve from the **default agent's** card, because the conversation the Observer watches belongs to that agent. `RuntimeDefaultsV1` therefore needed no new key and no shape change.
+Cards make the context window and the observational-memory budgets per-model properties. The reflection threshold resolves from the **default agent's** card. The observation threshold is the lower of the default agent's cadence and the selected Observer's message budget, because Mastra sends the unobserved conversation to that model without truncating it. `RuntimeDefaultsV1` therefore needed no new key and no shape change.
+
+Fresh or unset Observer and Reflector selections both resolve through `code-economic`. These memory roles run after tool-heavy turns and favor response latency and cost; changing them does not change the active agent model. The economic Observer caps the effective observation threshold at 90,000 tokens so its 128,000-token context retains room for the observation prompt and prior observations. Existing explicit or persisted model selections remain authoritative.
 
 ### Observational memory: what is wired and what is not
 
@@ -25,7 +27,7 @@ Upstream reads exactly one of the three settings issue #174 asked for. Verified 
 
 | Target | Status | Upstream site |
 | --- | --- | --- |
-| `observation.messageTokens: 180_000` | **wired** | `@mastra/code-sdk/dist/agents/memory.js:93` reads `obsThreshold` (`memory.js:68`), fed by the `observationThreshold` setting (`@mastra/code-sdk/dist/schema.d.ts:51`) |
+| `observation.messageTokens: 90_000` | **wired** | `@mastra/code-sdk/dist/agents/memory.js:93` reads `obsThreshold` (`memory.js:68`), fed by the `observationThreshold` setting (`@mastra/code-sdk/dist/schema.d.ts:51`); the 180,000-token active-agent cadence is capped by the economic Observer's card |
 | `observation.bufferTokens: 30_000` | **upstream-blocked** | hardcoded literal `isResourceScope ? false : 1 / 5` at `@mastra/code-sdk/dist/agents/memory.js:90` |
 | `observation.bufferActivation: 0.8` | **upstream-blocked** | hardcoded literal `isResourceScope ? void 0 : 2e3` at `@mastra/code-sdk/dist/agents/memory.js:91` |
 
@@ -41,5 +43,5 @@ Studio, Factory, and Code can migrate to this package without acquiring sandbox 
 
 Two follow-ups are open and are not owned here:
 
-- **The retune does not reach an existing install.** Both hosts prefer a persisted value over the profile default: `packages/mcode/src/runtime.ts:132-133` resolves `existingModels.omObservationThreshold ?? defaults.observationThreshold`, and `packages/factory-integration/src/config.ts:426-431` patches only null fields. Any machine that already persisted 120_000 keeps it. A migration must distinguish a deliberate user override from a stale persisted default — the repo rule preserving explicit user model selections covers the former, not the latter. Both files belong to other lanes.
+- **The retune does not reach an existing install.** Both hosts prefer a persisted value over the profile default: `packages/mcode/src/runtime.ts:132-133` resolves `existingModels.omObservationThreshold ?? defaults.observationThreshold`, and `packages/factory-integration/src/config.ts:426-431` patches only null fields. Any machine that already persisted another model or threshold keeps it. A migration must distinguish a deliberate user override from a stale persisted default — the repo rule preserving explicit user model selections covers the former, not the latter. Both files belong to other lanes.
 - **`bufferTokens` and `bufferActivation`** stay declared-only until a pinned Mastra Code SDK fork exposes them, at which point the card values are already in place.

--- a/packages/runtime-config/config/models.yaml
+++ b/packages/runtime-config/config/models.yaml
@@ -28,8 +28,10 @@ roles:
   # frontier tier rather than a cheaper one.
   ayra: code-frontier-high
   specialist: code-frontier-high
-  observer: code-workhorse-high
-  reflector: code-workhorse-high
+  # Observation and reflection run after tool-heavy turns and are latency-
+  # sensitive, so both memory roles use the economical tier.
+  observer: code-economic
+  reflector: code-economic
 code:
   defaultAgent: cortex
   defaultMode: build

--- a/packages/runtime-config/src/profile.ts
+++ b/packages/runtime-config/src/profile.ts
@@ -20,7 +20,7 @@ export const AGENT_BACKGROUND_TASK_POLICY = Object.freeze({
   concurrency: 1,
   waitTimeoutMs: 5_000,
 } as const);
-export const DEFAULT_OBSERVER_ALIAS = "code-workhorse-high";
+export const DEFAULT_OBSERVER_ALIAS = "code-economic";
 export const DEFAULT_MODEL_PROFILE_PATH = createRequire(import.meta.url).resolve("@rlabs/runtime-config/models.yaml");
 
 /**
@@ -343,13 +343,18 @@ export function resolveRuntimeDefaultsV1(profile: ModelProfile): RuntimeDefaults
       gatewayModelId: resolveProxyGatewayModelId(profile, alias),
     })]),
   ) as RuntimeDefaultsV1["models"]["roles"]);
-  // The conversation the Observer actually watches belongs to the default
-  // agent, so its card — not a global budget — sets both host thresholds.
-  // Upstream consumes them as two distinct settings: observationThreshold
-  // becomes `observation.messageTokens` (memory.js:93) and reflectionThreshold
-  // becomes `reflection.observationTokens` (memory.js:104).
+  // The Observer receives the active conversation as one model input, so the
+  // effective threshold must fit both the active agent's cadence and the
+  // Observer's declared input budget. This leaves the Observer card's context
+  // reserve available for its prompt and prior observations.
   const activeCard = resolveCard(profile, profile.roles[profile.code.defaultAgent]);
-  const observationThreshold = activeCard.observation.messageTokens;
+  const observerCard = resolveCard(profile, profile.roles.observer);
+  const observationThreshold = Math.min(
+    activeCard.observation.messageTokens,
+    observerCard.observation.messageTokens,
+  );
+  // Reflection observes the Observer's compacted output rather than the raw
+  // active conversation, so it retains the active conversation's cadence.
   const reflectionThreshold = activeCard.reflection.observationTokens;
   const observerModelId = roles.observer.providerModelId;
   const reflectorModelId = roles.reflector.providerModelId;

--- a/packages/runtime-config/test/profile.test.ts
+++ b/packages/runtime-config/test/profile.test.ts
@@ -86,7 +86,7 @@ describe("model profile", () => {
       },
       reflection: { observationTokens: 60_000 },
     });
-    expect(resolveModelCard(profile, DEFAULT_OBSERVER_ALIAS).contextWindowTokens).toBe(200_000);
+    expect(resolveModelCard(profile, DEFAULT_OBSERVER_ALIAS).contextWindowTokens).toBe(128_000);
     expect(() => resolveModelCard(profile, "openai/gpt-5.6-sol")).toThrow(/unknown model alias/i);
 
     // Per-model, not global: smaller tiers carry smaller budgets.
@@ -166,10 +166,25 @@ describe("model profile", () => {
     expect(() => resolveAliasModelId(profile, "openai/gpt-5.6-sol")).toThrow(/unknown model alias/i);
   });
 
-  test("projects observation and reflection thresholds from the default agent's card", () => {
+  test("caps the observation threshold at the selected Observer's input budget", () => {
     expect(resolveObservationalMemoryThresholds(loadModelProfile())).toEqual({
-      observationThreshold: 180_000,
+      observationThreshold: 90_000,
       reflectionThreshold: 60_000,
+    });
+  });
+
+  test("projects economical observation and reflection models to both hosts", () => {
+    const defaults = resolveRuntimeDefaultsV1(loadModelProfile());
+
+    expect(defaults.codeSdk).toMatchObject({
+      observerModelId: "a1-proxy/code-economic",
+      reflectorModelId: "a1-proxy/code-economic",
+      observationThreshold: 90_000,
+    });
+    expect(defaults.factory).toMatchObject({
+      observerModelId: "a1-proxy/code-economic",
+      reflectorModelId: "a1-proxy/code-economic",
+      observationThreshold: 90_000,
     });
   });
 
@@ -225,8 +240,8 @@ describe("model profile", () => {
             gatewayModelId: "proxy/a1-proxy/code-frontier-high",
           },
           observer: {
-            alias: "code-workhorse-high",
-            providerModelId: "a1-proxy/code-workhorse-high",
+            alias: "code-economic",
+            providerModelId: "a1-proxy/code-economic",
           },
         },
       },
@@ -236,15 +251,15 @@ describe("model profile", () => {
       },
       codeSdk: {
         activeModelId: "a1-proxy/code-frontier-high",
-        observerModelId: "a1-proxy/code-workhorse-high",
-        reflectorModelId: "a1-proxy/code-workhorse-high",
-        observationThreshold: 180_000,
+        observerModelId: "a1-proxy/code-economic",
+        reflectorModelId: "a1-proxy/code-economic",
+        observationThreshold: 90_000,
         reflectionThreshold: 60_000,
       },
       factory: {
-        observerModelId: "a1-proxy/code-workhorse-high",
-        reflectorModelId: "a1-proxy/code-workhorse-high",
-        observationThreshold: 180_000,
+        observerModelId: "a1-proxy/code-economic",
+        reflectorModelId: "a1-proxy/code-economic",
+        observationThreshold: 90_000,
         reflectionThreshold: 60_000,
       },
       gateway: { models: profile.aliases },
@@ -285,7 +300,7 @@ describe("model profile", () => {
     expect(JSON.stringify(defaults)).not.toMatch(/apiKey|secret|credential/i);
   });
 
-  test("derives host thresholds from the default agent's card, not a global budget", () => {
+  test("caps the active agent's observation cadence to the Observer card", () => {
     const profile = structuredClone(loadModelProfile());
     const card = profile.modelCards[DEFAULT_ACTIVE_ALIAS]!;
     card.contextWindowTokens = 300_000;
@@ -299,11 +314,11 @@ describe("model profile", () => {
       secondaryInputTokens: 40_000,
     });
     expect(defaults.codeSdk).toMatchObject({
-      observationThreshold: 150_000,
+      observationThreshold: 90_000,
       reflectionThreshold: 40_000,
     });
     expect(defaults.factory).toMatchObject({
-      observationThreshold: 150_000,
+      observationThreshold: 90_000,
       reflectionThreshold: 40_000,
     });
   });

--- a/test/code-sdk.test.ts
+++ b/test/code-sdk.test.ts
@@ -21,8 +21,8 @@ describe("Factory Code SDK configuration", () => {
     expect(parsed.onboarding).toMatchObject({ version: 1, completedAt: new Date(0).toISOString() });
     expect(Object.keys(parsed.models.modeDefaults)).toEqual(CODE_MODE_IDS);
     expect(new Set(Object.values(parsed.models.modeDefaults))).toEqual(new Set(["a1-proxy/code-frontier-high"]));
-    expect(parsed.models.observerModelOverride).toBe("a1-proxy/code-workhorse-high");
-    expect(parsed.models.reflectorModelOverride).toBe("a1-proxy/code-workhorse-high");
+    expect(parsed.models.observerModelOverride).toBe("a1-proxy/code-economic");
+    expect(parsed.models.reflectorModelOverride).toBe("a1-proxy/code-economic");
     expect(parsed.models.subagentModels).toEqual({
       cortex: "proxy/a1-proxy/code-frontier-high",
       flux: "proxy/a1-proxy/code-frontier-high",
@@ -31,7 +31,7 @@ describe("Factory Code SDK configuration", () => {
     });
     // 180k is the retuned canonical activation threshold from #174; the
     // reflection budget is a different upstream setting and is unchanged.
-    expect(parsed.models.omObservationThreshold).toBe(180_000);
+    expect(parsed.models.omObservationThreshold).toBe(90_000);
     expect(parsed.models.omReflectionThreshold).toBe(60_000);
     expect(parsed.customProviders).toEqual([{
       name: "A1 Proxy",
@@ -73,6 +73,7 @@ describe("Factory Code SDK configuration", () => {
         modeDefaults: { "cortex/build": "a1-proxy/code-frontier-max" },
         subagentModels: { cortex: "openai/gpt-5.4-mini" },
         observerModelOverride: "a1-proxy/fast-high",
+        reflectorModelOverride: "a1-proxy/fast-low",
         omObservationThreshold: 72_000,
         omReflectionThreshold: 48_000,
       },
@@ -87,6 +88,7 @@ describe("Factory Code SDK configuration", () => {
 
     expect(settings.models.modeDefaults["cortex/build"]).toBe("a1-proxy/code-frontier-max");
     expect(settings.models.observerModelOverride).toBe("a1-proxy/fast-high");
+    expect(settings.models.reflectorModelOverride).toBe("a1-proxy/fast-low");
     expect(settings.models.subagentModels).toEqual({
       cortex: "openai/gpt-5.4-mini",
       flux: "proxy/a1-proxy/code-frontier-high",
@@ -103,8 +105,8 @@ describe("Factory Code SDK configuration", () => {
     const profile = structuredClone(loadModelProfile());
     profile.roles.observer = "fast-high";
     profile.roles.reflector = "fast-low";
-    // Budgets are per-model now: they come from the default agent's card, not
-    // from the profile-level fallback, which every declared alias overrides.
+    // The active agent proposes the cadence, while the selected Observer's
+    // card caps the raw message batch it must accept.
     profile.modelCards["code-frontier-high"]!.observation!.messageTokens = 150_000;
     profile.modelCards["code-frontier-high"]!.reflection!.observationTokens = 110_000;
 
@@ -114,7 +116,7 @@ describe("Factory Code SDK configuration", () => {
     expect(settings.models).toMatchObject({
       observerModelOverride: "a1-proxy/fast-high",
       reflectorModelOverride: "a1-proxy/fast-low",
-      omObservationThreshold: 150_000,
+      omObservationThreshold: 90_000,
       omReflectionThreshold: 110_000,
     });
   });

--- a/test/local-code-runtime.test.ts
+++ b/test/local-code-runtime.test.ts
@@ -48,7 +48,7 @@ describe("local Mastra Code runtime", () => {
       // Retuned to 180k in #174; upstream reads this as
       // `observation.messageTokens`. reflectionThreshold is a separate
       // upstream setting (`reflection.observationTokens`) and is unchanged.
-      observationThreshold: 180_000,
+      observationThreshold: 90_000,
       reflectionThreshold: 60_000,
     });
     expect(runtime.mastra.getAgent("cortex").id).toBe(runtime.agents.cortex.id);

--- a/test/local-provider.test.ts
+++ b/test/local-provider.test.ts
@@ -106,12 +106,12 @@ describe("local A1 provider migration", () => {
       patch: {
         // Canonical activation threshold retuned to 180k in #174. The
         // reflection budget is a separate upstream setting and is unchanged.
-        observationThreshold: 180_000,
+        observationThreshold: 90_000,
         reflectionThreshold: 60_000,
       },
       fillIfUnset: {
-        observerModelId: "a1-proxy/code-workhorse-high",
-        reflectorModelId: "a1-proxy/code-workhorse-high",
+        observerModelId: "a1-proxy/code-economic",
+        reflectorModelId: "a1-proxy/code-economic",
       },
     });
   });
@@ -196,8 +196,8 @@ describe("local A1 provider migration", () => {
     expect(memoryPatch).toEqual({
       orgId: "local-org",
       userId: "local-user",
-      patch: { observationThreshold: 180_000 },
-      fillIfUnset: { reflectorModelId: "a1-proxy/code-workhorse-high" },
+      patch: { observationThreshold: 90_000 },
+      fillIfUnset: { reflectorModelId: "a1-proxy/code-economic" },
     });
   });
 
@@ -255,9 +255,9 @@ describe("local A1 provider migration", () => {
 
     expect(memoryPatches).toHaveLength(1);
     expect(memory).toEqual({
-      observerModelId: "a1-proxy/code-workhorse-high",
-      reflectorModelId: "a1-proxy/code-workhorse-high",
-      observationThreshold: 180_000,
+      observerModelId: "a1-proxy/code-economic",
+      reflectorModelId: "a1-proxy/code-economic",
+      observationThreshold: 90_000,
       reflectionThreshold: 60_000,
     });
   });

--- a/test/mastra-primitives-export.test.ts
+++ b/test/mastra-primitives-export.test.ts
@@ -64,13 +64,11 @@ describe("shared Mastra Toolkit runtime contract", () => {
     expect(createToolkitRuntimeContract({ profile: changedProfile }).capability.digest)
       .not.toBe(first.capability.digest);
 
-    // Preset cards are behaviour, not annotation: the default agent's card sets
-    // the observational-memory thresholds every host resolves, so a card edit
-    // must move the shared capability digest. This replaces the older
-    // `memory.contextBudgetTokens` probe, which now only reaches an alias that
-    // declares no card and therefore no longer perturbs the digest.
+    // Preset cards are behaviour, not annotation: the selected Observer's card
+    // caps the batch every host resolves, so a card edit must move the shared
+    // capability digest.
     const changedCard = structuredClone(profile);
-    changedCard.modelCards["code-frontier-high"]!.observation!.messageTokens = 170_000;
+    changedCard.modelCards[profile.roles.observer]!.observation!.messageTokens = 80_000;
     expect(createToolkitRuntimeContract({ profile: changedCard }).capability.digest)
       .not.toBe(first.capability.digest);
 

--- a/test/model-profile.test.ts
+++ b/test/model-profile.test.ts
@@ -72,7 +72,7 @@ describe("model profile", () => {
     expect(card.observation.bufferActivation).toBe(0.8);
     expect(card.reflection.observationTokens).toBe(60_000);
     expect(resolveObservationalMemoryThresholds(profile)).toEqual({
-      observationThreshold: 180_000,
+      observationThreshold: 90_000,
       reflectionThreshold: 60_000,
     });
   });

--- a/test/workspace-structure.test.ts
+++ b/test/workspace-structure.test.ts
@@ -280,6 +280,22 @@ describe("workspace ownership", () => {
     expect(factorySources).not.toMatch(/from "@rlabs\/[^"/]+\//);
   });
 
+  test("requires refreshed MCode and both local Factory instances in end-user acceptance", async () => {
+    const policy = await readFile(join(root, "vault/acceptance-test-before-merge.md"), "utf8");
+    const normalizedPolicy = policy.replace(/\s+/g, " ");
+
+    expect(normalizedPolicy).toContain(
+      "Refresh the local `ax mcode` installation from the branch under test before launching the PTY.",
+    );
+    expect(normalizedPolicy).toContain(
+      "`ax mcode` resolves to the refreshed executable built from the source commit under test.",
+    );
+    expect(normalizedPolicy).toContain("Run both the **Alpha Factory** and the **Agent Factory**.");
+    expect(normalizedPolicy).toContain(
+      "Each Factory instance must pass both a user-created session and a ticket session.",
+    );
+  });
+
   test("packs every canonical MCode recipe source", async () => {
     const { stdout } = await execFileAsync(
       "npm",

--- a/vault/acceptance-test-before-merge.md
+++ b/vault/acceptance-test-before-merge.md
@@ -64,12 +64,20 @@ launcher behaviour that has already broken in production: credential wrapping, b
 and the environment `ax` builds. Testing the inner command proves nothing about the one a person
 types. #decision/testing/foundational
 
+Refresh the local `ax mcode` installation from the branch under test before launching the PTY.
+#requirement/testing/critical
+
+Record the resolved executable path and its source commit. The evidence must prove that `ax mcode`
+resolves to the refreshed executable built from the source commit under test. A successful run of a
+stale local installation is not evidence for the proposed change. #validation/testing/inspection
+
 Steps:
 
-1. Open a terminal through CUA and run `ax mcode` in the repository under test.
-2. Wait for the TUI to draw. The status line, the mode indicator, and the input box must be visible.
-3. Send an acceptance prompt and confirm the agent answers in the TUI.
-4. Where the change engineers a specific tool or task, drive *that* capability in the same session
+1. Refresh the local installation, then verify the executable path and source commit.
+2. Open a terminal through CUA and run `ax mcode` in the repository under test.
+3. Wait for the TUI to draw. The status line, the mode indicator, and the input box must be visible.
+4. Send an acceptance prompt and confirm the agent answers in the TUI.
+5. Where the change engineers a specific tool or task, drive *that* capability in the same session
    rather than only exchanging a greeting.
 
 Evidence: a screenshot or captured pane showing the rendered TUI and the agent's reply.
@@ -82,12 +90,24 @@ A boot that reaches "no fatal error" but never renders is a failure, not a pass.
 
 Boot the Factory and drive it through the browser GUI. #requirement/testing/critical
 
+Run both the **Alpha Factory** and the **Agent Factory**. #requirement/testing/critical
+
+Each Factory instance must pass both a user-created session and a ticket session.
+#requirement/testing/high
+
+These deployments exercise the same Factory runtime through different persisted projects, model
+settings, repositories, and session histories. Passing one does not establish that the other can
+create a sandbox, route its configured model, or resume an existing session.
+#decision/testing/structural
+
 Steps:
 
-1. Start the Factory and open it in a browser.
-2. Send an acceptance prompt in a **user-created session** and confirm the agent answers.
-3. Send an acceptance prompt in a **ticket session** — one bound to an issue or pull request — and
-   confirm the agent answers.
+1. Start the Alpha Factory and Agent Factory, then open each in a browser.
+2. In the Alpha Factory, send an acceptance prompt in a **user-created session** and confirm the
+   agent answers.
+3. In the Alpha Factory, send an acceptance prompt in a **ticket session** — one bound to an issue
+   or pull request — and confirm the agent answers.
+4. Repeat the user-created and ticket-session checks in the Agent Factory.
 
 Both session kinds are required. #requirement/testing/high
 


### PR DESCRIPTION
## Outcome

Fresh or unset MCode and Factory memory roles now use `a1-proxy/code-economic`. The active Cortex model remains unchanged, and explicit persisted model choices still win.

Closes rlabs88/mastra-toolkit#189
Related to rlabs88/agentics-mono#143

## Failure and fix

| Boundary | Before | After |
| --- | --- | --- |
| Observer | `code-workhorse-high` | `code-economic` |
| Reflector | `code-workhorse-high` | `code-economic` |
| Raw observation batch | Active-agent cadence only: 180k | `min(active cadence, Observer budget)`: 90k |
| Explicit stored choices | Preserved | Preserved |

```mermaid
flowchart TB
  %% node: canonical_profile
  %% rationale: one source feeds both hosts
  canonical_profile["Canonical model profile"]
  active_card["Cortex card<br/>180k cadence"]
  observer_card["Economic Observer card<br/>90k batch / 128k context"]
  effective_threshold["Effective threshold<br/>min = 90k"]
  mcode["MCode defaults"]
  factory["Factory defaults"]

  canonical_profile --> active_card
  canonical_profile --> observer_card
  active_card --> effective_threshold
  observer_card --> effective_threshold
  effective_threshold --> mcode
  effective_threshold --> factory

  classDef service fill:#eef6ff,stroke:#2563eb,stroke-width:2px,color:#111827;
  classDef data fill:#ecfdf5,stroke:#059669,stroke-width:2px,color:#111827;
  classDef critical fill:#fff1f2,stroke:#e11d48,stroke-width:2px,color:#111827;
  class canonical_profile data;
  class active_card,observer_card service;
  class effective_threshold critical;
  class mcode,factory service;
```

<details>
<summary>Why the threshold changed</summary>

Mastra sends the unobserved raw message batch directly to the Observer. Pairing a 180k batch with the declared 128k `code-economic` context could fail before observation completed. The 90k card budget leaves 38k for the observation prompt and prior observations.

</details>

## Validation

- [x] Red test captured the unsafe 180k projection.
- [x] Focused host/runtime suite: 55 tests passed.
- [x] Root typecheck passed.
- [x] Root test: 44 files, 382 tests passed.
- [x] Root build passed.
- [x] Infisical secrets check passed.
- [x] `git diff --check` passed.
- [x] Independent test-integrity, structural, and SOLID audits completed.

> This PR does not claim to fix time spent inside `search_content`; that latency is being measured separately. It also does not expose the upstream-blocked `bufferTokens` or `bufferActivation` settings from rlabs88/agentics-mono#143.