### PR TITLE
revert: undo accidentally merged Factory model migration

### DIFF
--- a/packages/factory-integration/src/config.ts
+++ b/packages/factory-integration/src/config.ts
@@ -366,29 +366,16 @@ interface MemorySettingsDomain {
   }): Promise<unknown>;
 }
 
-/**
- * What a stored model id is allowed to be. Built from the same declared alias list the gateway
- * publishes, so storage and catalog cannot disagree about which ids exist.
- */
-export interface StoredModelCatalog {
-  readonly aliases: ReadonlySet<string>;
-  readonly defaultModelId: string;
-}
-
 export async function prepareLocalA1Provider(
   storage: FactoryStorage,
   provider: A1ProviderOptions,
   defaults: RuntimeDefaultsV1,
 ): Promise<void> {
-  const catalog: StoredModelCatalog = {
-    aliases: new Set(provider.models),
-    defaultModelId: defaults.codeSdk.activeModelId,
-  };
   await seedProvider(storage, provider);
-  await migrateProjectDefaults(storage, catalog);
-  await migrateModelPacks(storage, catalog);
-  await migrateMemorySettings(storage, defaults, catalog);
-  await migrateThreadMetadata(storage, catalog);
+  await migrateProjectDefaults(storage);
+  await migrateModelPacks(storage);
+  await migrateMemorySettings(storage, defaults);
+  await migrateThreadMetadata(storage);
 }
 
 async function seedProvider(storage: FactoryStorage, provider: A1ProviderOptions): Promise<void> {
@@ -407,33 +394,33 @@ async function seedProvider(storage: FactoryStorage, provider: A1ProviderOptions
   });
 }
 
-async function migrateProjectDefaults(storage: FactoryStorage, catalog: StoredModelCatalog): Promise<void> {
+async function migrateProjectDefaults(storage: FactoryStorage): Promise<void> {
   const domain = getDomain<ProjectsDomain>(storage, "projects");
   await domain.ensureReady();
   for (const project of await domain.list({ orgId: LOCAL_ORG_ID })) {
-    const modelId = normalizeStoredModelId(project.defaultModelId, catalog);
+    const modelId = normalizeStoredModelId(project.defaultModelId);
     if (modelId && modelId !== project.defaultModelId) {
       await domain.update({ orgId: LOCAL_ORG_ID, id: project.id, input: { defaultModelId: modelId } });
     }
   }
 }
 
-async function migrateModelPacks(storage: FactoryStorage, catalog: StoredModelCatalog): Promise<void> {
+async function migrateModelPacks(storage: FactoryStorage): Promise<void> {
   const domain = getDomain<ModelPacksDomain>(storage, "model-packs");
   await domain.ensureReady();
   for (const pack of await domain.list({ orgId: LOCAL_ORG_ID })) {
-    const models = normalizeModeModels(pack.models, catalog);
+    const models = normalizeModeModels(pack.models);
     if (Object.keys(models).every(mode => models[mode as keyof ModeModels] === pack.models[mode as keyof ModeModels])) continue;
     await domain.upsert({ orgId: LOCAL_ORG_ID, userId: LOCAL_USER_ID, input: { name: pack.name, models } });
   }
 }
 
-async function migrateMemorySettings(storage: FactoryStorage, defaults: RuntimeDefaultsV1, catalog: StoredModelCatalog): Promise<void> {
+async function migrateMemorySettings(storage: FactoryStorage, defaults: RuntimeDefaultsV1): Promise<void> {
   const domain = getDomain<MemorySettingsDomain>(storage, "memory-settings");
   await domain.ensureReady();
   const memory = await domain.get({ orgId: LOCAL_ORG_ID, userId: LOCAL_USER_ID });
   const memoryDefaults = defaults.factory;
-  const normalizedModels = memory ? normalizeMemorySettings(memory, catalog) : {};
+  const normalizedModels = memory ? normalizeMemorySettings(memory) : {};
   const patch: ModelMemorySettingsPatch = {
     ...normalizedModels,
     ...(memory?.observationThreshold == null
@@ -461,104 +448,61 @@ async function migrateMemorySettings(storage: FactoryStorage, defaults: RuntimeD
   }
 }
 
-async function migrateThreadMetadata(storage: FactoryStorage, catalog: StoredModelCatalog): Promise<void> {
+async function migrateThreadMetadata(storage: FactoryStorage): Promise<void> {
   const domain = await storage.getMastraStorage().getStore("memory");
   if (!domain) return;
   await domain.init();
   const { threads } = await domain.listThreads({ perPage: false });
   for (const thread of threads) {
-    const metadata = normalizeModelReferences(thread.metadata ?? {}, catalog);
+    const metadata = normalizeModelReferences(thread.metadata ?? {});
     if (metadata.changed) {
       await domain.updateThread({ id: thread.id, title: thread.title ?? "", metadata: metadata.value });
     }
   }
 }
 
-function normalizeModeModels(models: ModeModels, catalog: StoredModelCatalog): ModeModels {
+function normalizeModeModels(models: ModeModels): ModeModels {
   return Object.fromEntries(
-    Object.entries(models).map(([mode, modelId]) => [mode, normalizeStoredModelId(modelId, catalog) ?? modelId]),
+    Object.entries(models).map(([mode, modelId]) => [mode, normalizeStoredModelId(modelId) ?? modelId]),
   ) as ModeModels;
 }
 
-function normalizeMemorySettings(memory: ModelMemorySettings, catalog: StoredModelCatalog): ModelMemorySettingsPatch {
-  const observerModelId = normalizeStoredModelId(memory.observerModelId, catalog);
-  const reflectorModelId = normalizeStoredModelId(memory.reflectorModelId, catalog);
+function normalizeMemorySettings(memory: ModelMemorySettings): ModelMemorySettingsPatch {
+  const observerModelId = normalizeStoredModelId(memory.observerModelId);
+  const reflectorModelId = normalizeStoredModelId(memory.reflectorModelId);
   return {
     ...(observerModelId && observerModelId !== memory.observerModelId ? { observerModelId } : {}),
     ...(reflectorModelId && reflectorModelId !== memory.reflectorModelId ? { reflectorModelId } : {}),
   };
 }
 
-/**
- * Rewrites a stored model id onto a declared alias, so nothing the proxy does not serve under a
- * name we own can survive in storage.
- *
- * The rule is a catalog membership test, not a table of known-bad ids. The previous version mapped
- * one upstream name (`gpt-5.6-luna`) back to one alias, which could never be complete — the proxy
- * renames and re-points aliases, and each new upstream id it exposed produced the same bug again
- * (`gpt-5.6-sol` reaching storage as `openai/gpt-5.6-sol`, resolving against the OpenAI provider,
- * and failing with a missing `OPENAI_API_KEY`).
- *
- * Worse, that table could not be correct even in principle. The proxy distinguishes tiers by
- * `reasoning.effort` over a shared upstream model, so the mapping is many-to-one: `gpt-5.6-luna`
- * serves both `code-workhorse-high` and `-low`, and `gpt-5.6-sol` serves all three frontier tiers.
- * Mapping an upstream id back to one alias silently re-tiers everything else that shared it.
- *
- * So an unrecognised id resets to the host's documented default rather than guessing. That is
- * lossy on purpose: the tier is genuinely unrecoverable, and a caller that wants a specific tier
- * must name a declared alias. Any prefix form the id already carries is preserved when the alias
- * is valid, so a gateway-qualified id is not rewritten into a provider-qualified one.
- */
-export function normalizeStoredModelId(
-  modelId: string | null | undefined,
-  catalog: StoredModelCatalog,
-): string | undefined {
+export function normalizeStoredModelId(modelId: string | null | undefined): string | undefined {
   if (!modelId) return undefined;
-  const hosted = modelId.startsWith("mastracode/") ? modelId.slice("mastracode/".length) : modelId;
-  const alias = hosted.split("/").at(-1);
-  if (alias && catalog.aliases.has(alias)) return hosted;
-  return catalog.defaultModelId;
+  if (/^(?:mastracode\/)?a1-proxy\/gpt-5\.6-luna$/.test(modelId) || modelId === "mastracode/gpt-5.6-luna") {
+    return getA1ProxyModelId("code-workhorse-high");
+  }
+  if (modelId.startsWith("mastracode/a1-proxy/")) return modelId.slice("mastracode/".length);
+  return modelId;
 }
 
-/**
- * A key whose value is a model id: anything containing `model`, plus `modes`, which holds model ids
- * without naming them. Observed live in thread metadata as `modeModelId_build`, `currentModelId`,
- * `observerModelId`, and `subagentModels`.
- */
-const MODEL_KEY = /model/i;
-const MODEL_KEY_EXACT = new Set(["modes"]);
-const isModelKey = (key: string): boolean => MODEL_KEY.test(key) || MODEL_KEY_EXACT.has(key);
-
-/**
- * Rewrites the model references inside a stored metadata object, leaving everything else untouched.
- *
- * Selection is by key, never by value. `normalizeStoredModelId` maps anything outside the catalog
- * onto the default, which is correct for a value already known to be a model id and destructive for
- * anything else — applied to every string in the object it would turn thread titles, branch names,
- * and ids into a model id. Arrays inherit the key that introduced them, so a list of model ids is
- * still normalised.
- */
-export function normalizeModelReferences(input: Record<string, unknown>, catalog: StoredModelCatalog): {
+export function normalizeModelReferences(input: Record<string, unknown>): {
   value: Record<string, unknown>;
   changed: boolean;
 } {
   let changed = false;
-  const visit = (value: unknown, underModelKey: boolean): unknown => {
+  const visit = (value: unknown): unknown => {
     if (typeof value === "string") {
-      if (!underModelKey) return value;
-      const normalized = normalizeStoredModelId(value, catalog);
+      const normalized = normalizeStoredModelId(value);
       if (normalized && normalized !== value) changed = true;
       return normalized ?? value;
     }
-    if (Array.isArray(value)) return value.map(entry => visit(entry, underModelKey));
+    if (Array.isArray(value)) return value.map(visit);
     if (value && typeof value === "object") {
-      return Object.fromEntries(Object.entries(value).map(
-        ([key, entry]) => [key, visit(entry, isModelKey(key))],
-      ));
+      return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, visit(entry)]));
     }
     return value;
   };
-  return { value: visit(input, false) as Record<string, unknown>, changed };
+  return { value: visit(input) as Record<string, unknown>, changed };
 }
 
 function getDomain<T>(storage: FactoryStorage, name: string): T {

--- a/test/local-provider.test.ts
+++ b/test/local-provider.test.ts
@@ -7,70 +7,30 @@ import {
   prepareLocalA1Provider,
 } from "@rlabs/factory-integration";
 
-// prepareLocalA1Provider is always handed the full declared alias list in production
-// (`defaults.gateway.models`). A narrower list here would make every declared alias except one
-// look unrecognised, and the migration would rewrite settings it should leave alone.
-const DECLARED_ALIASES = [...resolveRuntimeDefaultsV1(loadModelProfile()).gateway.models];
-
-const CATALOG = {
-  aliases: new Set(["code-frontier-high", "code-workhorse-high", "code-economic"]),
-  defaultModelId: "a1-proxy/code-frontier-high",
-};
-
 describe("local A1 provider migration", () => {
   test.each([
-    // A declared alias survives in whatever prefix form it already carries.
+    ["a1-proxy/gpt-5.6-luna", "a1-proxy/code-workhorse-high"],
+    ["mastracode/a1-proxy/gpt-5.6-luna", "a1-proxy/code-workhorse-high"],
+    ["mastracode/gpt-5.6-luna", "a1-proxy/code-workhorse-high"],
     ["a1-proxy/code-frontier-high", "a1-proxy/code-frontier-high"],
-    ["proxy/a1-proxy/code-workhorse-high", "proxy/a1-proxy/code-workhorse-high"],
-    ["mastracode/a1-proxy/code-economic", "a1-proxy/code-economic"],
-    // A raw upstream id is not a declared alias, whatever prefix it wears, so it resets to the
-    // documented default. The tier is unrecoverable: gpt-5.6-luna serves both workhorse tiers and
-    // gpt-5.6-sol serves all three frontier tiers, so there is nothing faithful to map back to.
-    ["a1-proxy/gpt-5.6-luna", "a1-proxy/code-frontier-high"],
-    ["mastracode/gpt-5.6-luna", "a1-proxy/code-frontier-high"],
-    // The one that shipped the bug: an OpenAI-prefixed upstream id used to pass through untouched,
-    // then resolved against the OpenAI provider and failed on a missing OPENAI_API_KEY.
-    ["openai/gpt-5.6-sol", "a1-proxy/code-frontier-high"],
-    ["openai/gpt-5.6-luna", "a1-proxy/code-frontier-high"],
+    ["openai/gpt-5.6-luna", "openai/gpt-5.6-luna"],
   ])("normalizes %s to %s", (input, expected) => {
-    expect(normalizeStoredModelId(input, CATALOG)).toBe(expected);
+    expect(normalizeStoredModelId(input)).toBe(expected);
   });
 
   test("migrates nested thread model references without changing unrelated metadata", () => {
     const result = normalizeModelReferences({
       currentModelId: "mastracode/a1-proxy/gpt-5.6-luna",
-      // The key shape observed live in Factory thread metadata.
-      modeModelId_build: "openai/gpt-5.6-sol",
       modes: ["a1-proxy/gpt-5.6-luna"],
       projectPath: "/workspace/a1-proxy/example",
-    }, CATALOG);
+    });
 
     expect(result).toEqual({
       changed: true,
       value: {
-        currentModelId: "a1-proxy/code-frontier-high",
-        modeModelId_build: "a1-proxy/code-frontier-high",
-        modes: ["a1-proxy/code-frontier-high"],
+        currentModelId: "a1-proxy/code-workhorse-high",
+        modes: ["a1-proxy/code-workhorse-high"],
         projectPath: "/workspace/a1-proxy/example",
-      },
-    });
-  });
-
-  test("leaves a non-model string alone even when it looks like a model id", () => {
-    // Selection is by key. Normalising by value would rewrite every unrecognised string in the
-    // object to the default model id, destroying titles, branches, and paths.
-    const result = normalizeModelReferences({
-      title: "openai/gpt-5.6-sol",
-      branch: "factory/gpt-5.6-luna",
-      resourceId: "mastracode/a1-proxy/whatever",
-    }, CATALOG);
-
-    expect(result).toEqual({
-      changed: false,
-      value: {
-        title: "openai/gpt-5.6-sol",
-        branch: "factory/gpt-5.6-luna",
-        resourceId: "mastracode/a1-proxy/whatever",
       },
     });
   });
@@ -102,7 +62,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: DECLARED_ALIASES,
+      models: ["code-frontier-high"],
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(initialized).toBe(true);
@@ -137,7 +97,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: DECLARED_ALIASES,
+      models: ["code-frontier-high"],
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(memoryPatch).toEqual({
@@ -190,7 +150,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: DECLARED_ALIASES,
+      models: ["code-frontier-high"],
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(memoryPatch).toBeUndefined();
@@ -230,7 +190,7 @@ describe("local A1 provider migration", () => {
     await prepareLocalA1Provider(storage, {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: DECLARED_ALIASES,
+      models: ["code-frontier-high"],
     }, resolveRuntimeDefaultsV1(loadModelProfile()));
 
     expect(memoryPatch).toEqual({
@@ -286,7 +246,7 @@ describe("local A1 provider migration", () => {
     const provider = {
       baseUrl: "https://proxy.invalid/v1",
       apiKey: "test-only-key",
-      models: DECLARED_ALIASES,
+      models: ["code-frontier-high"],
     };
     const defaults = resolveRuntimeDefaultsV1(loadModelProfile());
 


### PR DESCRIPTION
## Summary

Reverts PR rlabs88/mastra-toolkit#185 and restores the two affected files to their exact state at pre-merge commit `865c61592a2c4dad79271008dd6d645864739750`.

The original PR is already `MERGED` and cannot be changed to `CLOSED`; this revert preserves published history while removing its changes from `main`.

## Validation

- `npx vitest run test/local-provider.test.ts` — 11 tests passed
- `npm run typecheck` — passed
- `git diff --check origin/main...HEAD` — passed
- affected tree equals the parent of merge commit `76e4c192ffd32aae8eaea13269099de3b1c7f869`

## Follow-up

Issue rlabs88/agentics-mono#142 will be reopened after merge because its implementation is intentionally removed.

Fixes rlabs88/mastra-toolkit#194
Refs rlabs88/agentics-mono#142
