### PR TITLE
fix(mcode): dispatch selected session model

### DIFF
--- a/packages/agents-roles/src/agents.ts
+++ b/packages/agents-roles/src/agents.ts
@@ -131,7 +131,11 @@ function createAgent<TId extends RoleDefinition["id"]>(
     name: role.name,
     description: role.description,
     instructions: composePrompt(role),
-    model: resolveProxyGatewayModelId(profile, profile.roles[role.id]),
+    model: ({ requestContext }) => resolveActiveSessionModel(
+      profile,
+      profile.roles[role.id],
+      requestContext.get("controller"),
+    ),
     tools: async ({ requestContext, mastra }) => {
       const resolvedAdditionalTools = typeof additionalTools === "function"
         ? await additionalTools({ requestContext, ...(mastra ? { mastra } : {}) })
@@ -151,6 +155,39 @@ function createAgent<TId extends RoleDefinition["id"]>(
     ...(agentBrowser ? { browser: agentBrowser } : {}),
     ...(agents ? { agents: { ...agents } } : {}),
   });
+}
+
+/**
+ * AgentController keeps the selected model on the session, while role agents
+ * are shared controller projections. Resolve the model at request time so an
+ * explicit session switch changes the actual provider dispatch instead of only
+ * the TUI's displayed state.
+ */
+function resolveActiveSessionModel(
+  profile: ModelProfile,
+  fallbackAlias: string,
+  controller: unknown,
+): string {
+  const selectedModelId = readSelectedModelId(controller);
+  if (!selectedModelId) return resolveProxyGatewayModelId(profile, fallbackAlias);
+
+  const prefix = "a1-proxy/";
+  if (!selectedModelId.startsWith(prefix)) {
+    throw new Error(`Selected model must use a declared A1 model alias: ${selectedModelId}`);
+  }
+  const alias = selectedModelId.slice(prefix.length);
+  if (!profile.aliases.includes(alias)) {
+    throw new Error(`Selected model must use a declared A1 model alias: ${selectedModelId}`);
+  }
+  return resolveProxyGatewayModelId(profile, alias);
+}
+
+function readSelectedModelId(controller: unknown): string | undefined {
+  if (!controller || typeof controller !== "object") return undefined;
+  const session = (controller as { session?: unknown }).session;
+  if (!session || typeof session !== "object") return undefined;
+  const modelId = (session as { modelId?: unknown }).modelId;
+  return typeof modelId === "string" && modelId.trim() ? modelId : undefined;
 }
 
 function composeToolHooks(additionalHooks?: ToolHooks): ToolHooks {

--- a/packages/mcode/src/runtime.ts
+++ b/packages/mcode/src/runtime.ts
@@ -544,6 +544,7 @@ export async function createLocalMcodeRuntime(
       tags: { projectPath: mounted.project.rootPath },
     });
     await wireSessionConcerns(mounted.code, session);
+    restrictSessionModelSelection(session, mounted.contract.runtime.profile);
   } catch (error) {
     try {
       await mounted.close();
@@ -565,6 +566,11 @@ export async function createLocalMcodeRuntime(
   });
   const observedController = new Proxy(mounted.controller, {
     get(target, property) {
+      if (property === "listAvailableModels") {
+        return async () => (await target.listAvailableModels())
+          .filter(model => isDeclaredGatewayModelId(model.id, mounted.contract.runtime.profile))
+          .map(model => ({ ...model, id: model.id.slice("mastracode/".length) }));
+      }
       if (property === "setResourceId") {
         return async (
           targetSession: Session<MastraCodeState>,
@@ -641,6 +647,31 @@ export async function createLocalMcodeRuntime(
       await closeRuntime();
     },
   };
+}
+
+function restrictSessionModelSelection(session: Session<MastraCodeState>, profile: ModelProfile): void {
+  const model = session.model as unknown as {
+    switch(input: { modelId: string; scope?: "global" | "thread"; modeId?: string }): Promise<void>;
+  };
+  const switchModel = model.switch.bind(model);
+  model.switch = async input => {
+    if (!isDeclaredA1ModelId(input.modelId, profile)) {
+      throw new Error(`Selected model must use a declared A1 model alias: ${input.modelId}`);
+    }
+    await switchModel(input);
+  };
+}
+
+function isDeclaredA1ModelId(modelId: string, profile: ModelProfile): boolean {
+  const prefix = `${A1_CODE_PROVIDER_ID}/`;
+  return modelId.startsWith(prefix) && profile.aliases.includes(modelId.slice(prefix.length));
+}
+
+function isDeclaredGatewayModelId(modelId: string, profile: ModelProfile): boolean {
+  return modelId.startsWith("mastracode/") && isDeclaredA1ModelId(
+    modelId.slice("mastracode/".length),
+    profile,
+  );
 }
 
 function localSessionId(projectRoot: string): string {

--- a/test/local-code-runtime.test.ts
+++ b/test/local-code-runtime.test.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, realpath } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -14,10 +15,65 @@ import { startDynamicWorkflowBackgroundTaskObserver } from "../packages/mcode/sr
 
 const execFileAsync = promisify(execFile);
 const openRuntimes: LocalMcodeRuntime[] = [];
+const openProxyServers: Server[] = [];
 
 afterEach(async () => {
   await Promise.all(openRuntimes.splice(0).map(runtime => runtime.close()));
+  await Promise.all(openProxyServers.splice(0).map(server => new Promise<void>((resolve, reject) =>
+    server.close(error => error ? reject(error) : resolve()),
+  )));
 });
+
+async function startOpenAiCompatibleProxy(): Promise<{
+  readonly baseUrl: string;
+  readonly requestedModels: string[];
+}> {
+  const requestedModels: string[] = [];
+  const server = createServer(async (request, response) => {
+    if (request.method !== "POST" || request.url !== "/v1/chat/completions") {
+      response.writeHead(404).end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { model?: unknown };
+    if (typeof body.model === "string") requestedModels.push(body.model);
+
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.write(`data: ${JSON.stringify({
+      id: "test-completion",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: body.model,
+      choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }],
+    })}\n\n`);
+    response.write(`data: ${JSON.stringify({
+      id: "test-completion",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: body.model,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    })}\n\n`);
+    response.end("data: [DONE]\n\n");
+  });
+  openProxyServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, "127.0.0.1");
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Expected local proxy TCP address");
+  return { baseUrl: `http://127.0.0.1:${address.port}/v1`, requestedModels };
+}
 
 describe("local Mastra Code runtime", () => {
   test("boots the canonical agents and modes at the containing Git checkout", async () => {
@@ -101,6 +157,48 @@ describe("local Mastra Code runtime", () => {
     openRuntimes.push(runtime);
 
     expect(runtime.config.runtime.proxy.model).toBe("startup-only");
+  });
+
+  test("dispatches the active selected A1 alias to the local proxy", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "mastra-code-model-project-"));
+    const dataDirectory = await mkdtemp(join(tmpdir(), "mastra-code-model-data-"));
+    const proxy = await startOpenAiCompatibleProxy();
+    await execFileAsync("git", ["init", "--quiet", projectRoot]);
+    const profile = structuredClone(loadModelProfile());
+    profile.provider.baseUrl = proxy.baseUrl;
+
+    const runtime = await createLocalMcodeRuntime({
+      cwd: projectRoot,
+      dataDirectory,
+      profile,
+      browser: false,
+      disableMcp: true,
+      watch: false,
+      memory: false,
+      environment: {
+        ...process.env,
+        PROXY_BASE_URL: proxy.baseUrl,
+        CLI_PROXY_API_KEY: "test-only-key",
+      },
+    });
+    openRuntimes.push(runtime);
+
+    await runtime.session.model.switch({ modelId: "a1-proxy/code-economic" });
+    expect(runtime.session.model.get()).toBe("a1-proxy/code-economic");
+    await runtime.session.sendMessage({ content: "Reply with ok." });
+    expect(proxy.requestedModels).toEqual(["code-economic"]);
+
+    await runtime.session.model.switch({ modelId: "a1-proxy/code-frontier-high" });
+    expect(runtime.session.model.get()).toBe("a1-proxy/code-frontier-high");
+    await runtime.session.sendMessage({ content: "Reply with ok again." });
+    expect(proxy.requestedModels).toEqual(["code-economic", "code-frontier-high"]);
+
+    const availableModelIds = (await runtime.controller.listAvailableModels()).map(model => model.id);
+    expect(availableModelIds).toContain("a1-proxy/code-economic");
+    expect(availableModelIds).toContain("a1-proxy/code-frontier-high");
+    expect(availableModelIds).not.toContain("openai/gpt-5.6-sol");
+    await expect(runtime.session.model.switch({ modelId: "openai/gpt-5.6-sol" }))
+      .rejects.toThrow(/declared A1 model alias/i);
   });
 
   test("projects manager output onto the human session bus without persisting it", async () => {


### PR DESCRIPTION
## Summary

- resolve each role agent's model from the active MCode session alias at request time
- expose only declared A1 aliases to the local picker and reject raw upstream IDs
- add a fake-proxy regression test covering two live alias switches

Fixes rlabs88/agentics-mono#139

## Validation

- `npm test -- --run test/local-code-runtime.test.ts`
- `npm test` (387 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`