### PR TITLE
fix(factory): publish provider-compatible workflow schema

### DIFF
--- a/packages/factory-integration/src/integration.ts
+++ b/packages/factory-integration/src/integration.ts
@@ -6,14 +6,27 @@ import {
   SANDBOX_PROJECT_WORKFLOW_STREAM_PREFIX,
 } from "@rlabs/project-mounting-manager";
 
-const projectWorkflowInputSchema = z.discriminatedUnion("action", [
-  z.object({ action: z.literal("list") }).strict(),
-  z.object({
-    action: z.literal("run"),
-    workflowId: z.string().min(1).max(200),
-    input: z.record(z.string(), z.unknown()),
-  }).strict(),
-]);
+const projectWorkflowInputSchema = z.object({
+  action: z.enum(["list", "run"]),
+  workflowId: z.string().min(1).max(200).describe("Required when action is run").optional(),
+  input: z.record(z.string(), z.unknown()).describe("Required when action is run").optional(),
+}).strict().superRefine((value, context) => {
+  if (value.action === "run") {
+    if (!value.workflowId) {
+      context.addIssue({ code: "custom", path: ["workflowId"], message: "workflowId is required for run" });
+    }
+    if (!value.input) {
+      context.addIssue({ code: "custom", path: ["input"], message: "input is required for run" });
+    }
+    return;
+  }
+  if (value.workflowId !== undefined) {
+    context.addIssue({ code: "custom", path: ["workflowId"], message: "workflowId is only valid for run" });
+  }
+  if (value.input !== undefined) {
+    context.addIssue({ code: "custom", path: ["input"], message: "input is only valid for run" });
+  }
+});
 
 export function createFactoryProjectWorkflowTool() {
   return createTool({
@@ -23,6 +36,14 @@ export function createFactoryProjectWorkflowTool() {
     // Listing imports project modules, so it needs the same approval boundary as execution.
     requireApproval: true,
     execute: async (input, context) => {
+      const workflowId = input.workflowId;
+      const workflowInput = input.input;
+      if (input.action === "run" && (!workflowId || !workflowInput)) {
+        throw new Error("Project workflow run input is incomplete");
+      }
+      if (input.action === "list" && (workflowId !== undefined || workflowInput !== undefined)) {
+        throw new Error("Project workflow list input contains run-only fields");
+      }
       const workspace = context.workspace;
       if (!workspace) throw new Error("Project workflows require an active Factory session workspace");
       const [filesystem, sandbox] = await Promise.all([
@@ -38,8 +59,8 @@ export function createFactoryProjectWorkflowTool() {
         : undefined;
       if (input.action === "run") {
         args.push(
-          input.workflowId,
-          Buffer.from(JSON.stringify(input.input)).toString("base64url"),
+          workflowId!,
+          Buffer.from(JSON.stringify(workflowInput)).toString("base64url"),
           cancellationPath!,
         );
       }

--- a/packages/factory-integration/test/project-workflow.test.ts
+++ b/packages/factory-integration/test/project-workflow.test.ts
@@ -7,6 +7,7 @@ import { SandboxFilesystem } from "@mastra/code-sdk/agents/sandbox-filesystem";
 import { loadModelProfile, resolveRuntimeDefaultsV1 } from "@rlabs/runtime-config";
 import { createSandboxMachine, loadSandboxConfig } from "@rlabs/sandbox";
 import { afterEach, describe, expect, test } from "vitest";
+import { z } from "zod";
 import { createFactoryAgentBundle, ToolkitFactoryIntegration } from "../src/index.js";
 
 let projectRoot: string | undefined;
@@ -21,6 +22,37 @@ afterEach(async () => {
 });
 
 describe("Factory project workflows", () => {
+  test("publishes a provider-compatible object input schema", async () => {
+    const tools = await factoryIntegration().agentTools();
+    const projectWorkflow = tools.project_workflow as { inputSchema: z.ZodType };
+    const providerSchema = projectWorkflow.inputSchema["~standard"].jsonSchema.input({ target: "draft-07" });
+
+    expect(providerSchema).toMatchObject({
+      type: "object",
+      properties: {
+        action: { enum: ["list", "run"] },
+        workflowId: { description: "Required when action is run" },
+        input: { description: "Required when action is run" },
+      },
+      required: ["action"],
+      additionalProperties: false,
+    });
+    expect(providerSchema).not.toHaveProperty("oneOf");
+    expect(providerSchema).not.toHaveProperty("anyOf");
+    expect(projectWorkflow.inputSchema.safeParse({ action: "list" }).success).toBe(true);
+    expect(projectWorkflow.inputSchema.safeParse({ action: "list", workflowId: "demo" }).success).toBe(false);
+    expect(projectWorkflow.inputSchema.safeParse({ action: "list", input: {} }).success).toBe(false);
+    expect(projectWorkflow.inputSchema.safeParse({ action: "run", input: {} }).success).toBe(false);
+    expect(projectWorkflow.inputSchema.safeParse({ action: "run", workflowId: "demo" }).success).toBe(false);
+    expect(projectWorkflow.inputSchema.safeParse({ action: "invalid" }).success).toBe(false);
+    expect(projectWorkflow.inputSchema.safeParse({ action: "list", extra: true }).success).toBe(false);
+    expect(projectWorkflow.inputSchema.safeParse({
+      action: "run",
+      workflowId: "demo",
+      input: {},
+    }).success).toBe(true);
+  });
+
   test("lists and runs only explicitly published project workflows inside the active sandbox workspace", async () => {
     projectRoot = await mkdtemp(join(tmpdir(), "rlabs-factory-workflow-"));
     await mkdir(join(projectRoot, ".mastracode", "workflow"), { recursive: true });


### PR DESCRIPTION
## Summary
- publish `project_workflow` as a top-level object JSON Schema accepted by OpenAI-compatible providers
- preserve strict list/run validation with provider-facing run-field descriptions
- fail malformed direct executions before resolving Factory workspace resources

## Verification
- `npm run check` (48 files, 420 tests, production Studio build)
- `npm run secrets:check`
- `git diff --check`
- live Agent Factory user + ticket responses on `a1-proxy/code-economic`
- live Alpha Factory user + ticket responses on `a1-proxy/code-economic`
- live Alpha ticket agent called `project_workflow` list and completed `FACTORY-PROJECT-WORKFLOW-LIST-OK`
- Playwright hard reload/navigation with zero console and page errors

## Context
The prior discriminated union serialized as a root `oneOf` without `type: object`; the A1 OpenAI-compatible endpoint rejected the complete tool catalog before model streaming began.